### PR TITLE
Add numeric_only arg to pandas sum to avoid an error

### DIFF
--- a/mobility/parsers/entd_2008.py
+++ b/mobility/parsers/entd_2008.py
@@ -548,7 +548,7 @@ def prepare_entd_2008(proxies={}):
     )
 
     # Sum on all the indivuduals grouped by csp
-    indiv_mob = indiv_mob.groupby("csp").sum()
+    indiv_mob = indiv_mob.groupby("csp").sum(numeric_only=True)
     indiv_mob["immobility_weekday"] = (
         indiv_mob["immobility_weekday"] / indiv_mob["PONDKI"] / 5
     )


### PR DESCRIPTION
Règle https://github.com/mobility-team/mobility/issues/57

La nouvelle version de pandas 2.0 renvoie maintenant une erreur lorsqu'on essaie de sommer une colonne non numérique (ici une colonne de type datetime). Il faut maintenant expliciter l'argument numeric_only=True.

Nos versions en local utilisent sûrement encore pandas 1.5, mais la procédure de test installe la dernière version de pandas (donc la 2.0), d'où la différence de comportement.
