### PR TITLE
Ajout de pyarrow dans les packages nécessaires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setuptools.setup(
     url="https://github.com/mobility-team/mobility",
     packages=setuptools.find_packages(),
     python_requires=">=3.9",
-    install_requires=["numpy", "pandas", "requests"],
+    install_requires=["numpy", "pandas", "requests", "pyarrow"],
 )


### PR DESCRIPTION
get_insee_data ne fonctionne pas sans possibilité d'écrire des fichiers parquet, et il faut pyarrow pour cela. J'ai donc ajouté pyarrow à la liste de packages à installer dans setup.py.