### PR TITLE
Adding instructions to README file for set up a local development env…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,22 @@ _En cours de rédaction_
 [rtd-link]: https://mobility.readthedocs.io/en/latest/?badge=latest
 [black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
 [black-link]: https://github.com/ambv/black
+
+## Setting up a development environment with Docker
+* Make sure you have Docker installed on your machine.
+* Clone the repository to your local machine using Git. For example, you can run the following command in your terminal: 
+`git clone https://github.com/mobility-team/mobility.git`
+* Navigate to the project directory:
+`cd mobility`
+* Create a Docker container:
+`docker run -t -i --name mobility-dev -v /opt/mobility -v /C:/Users/YourUserName/mobility:/opt python:3.9 bash`
+* Navigate to the project directory in the Docker contianer:
+`cd opt`
+* Install the required dependencies:
+`pip install -r requirements.txt && pip install -e .`
+* Install the pytest package:
+`pip install pytest`
+* Run the unit tests to make sure everything is working properly:
+`pytest`
+* Starts a Docker container 
+`docker container start -i mobility-dev`

--- a/README.md
+++ b/README.md
@@ -52,15 +52,17 @@ _En cours de rédaction_
 [black-link]: https://github.com/ambv/black
 
 ## Setting up a development environment with Docker
-* Make sure you have Docker installed on your machine.
+* Make sure you have [Docker installed](https://docs.docker.com/get-docker/) on your machine.
 * Clone the repository to your local machine using Git. For example, you can run the following command in your terminal: 
 `git clone https://github.com/mobility-team/mobility.git`
 * Navigate to the project directory:
 `cd mobility`
 * Create a Docker container:
-`docker run -t -i --name mobility-dev -v /opt/mobility -v /C:/Users/YourUserName/mobility:/opt python:3.9 bash`
-* Navigate to the project directory in the Docker contianer:
-`cd opt`
+* For Windows:
+`CMD: docker run -it --name mobility-dev -w /opt -v %cd%:/opt python:3.9 bash`
+`PoweShell: docker run -it --name mobility-dev -w /opt -v ${PWD}:/opt python:3.9 bash`
+* For Linux:
+`docker run -it --name mobility-dev -w /opt -v $(PWD):/opt python:3.9 bash`
 * Install the required dependencies:
 `pip install -r requirements.txt && pip install -e .`
 * Install the pytest package:


### PR DESCRIPTION
Hi, this PR was sent as part of [OSDC](https://osdc.code-maven.com/) taught by: @szabgab. I want to contribute to your project by adding instructions on how to set up a local development environment using Docker in the project's README file. Is important for several reasons:
1. Ease of onboarding: new contributors or developers joining the project may not be familiar with the required software and libraries needed to develop and run the project. Providing clear instructions on how to set up a local development environment using Docker, it makes it easier for them to get up and running quickly.
2. Reproducibility: By using Docker to set up the local development environment, it ensures that all developers are using the same development environment with the same versions of software and libraries. This makes it easier to reproduce bugs and issues reported by other developers, as well as ensure that the project is built and tested in a consistent manner across different environments.
3. Isolation: Docker allows developers to create a containerized environment that is isolated from the host system, preventing potential conflicts with other software installed on the host. This helps ensure that the project's dependencies do not conflict with other software, potentially causing issues or breaking the development environment.
Thanks,
Ran