### PR TITLE
Montée de version de R de 4.1.3 à 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Pour l'instant, la solution est centrée sur les territoires et les données fra
 
 Plus d'infos sur [le site web](https://mobility-team.github.io/) !
 
+# Installation
+- Installer mamba avec [miniforge](https://github.com/conda-forge/miniforge).
+- Aller dans le dossier qui contient le code du repo : `cd path/to/mobility-repo`.
+- Créer un environnement pour mobility à partir du fichier environment.yml : `mamba env create -n mobility -f environment.yml`.
+- Activer l'environnement mobility : `mamba activate mobility`.
+- Installer mobility avec pip : `pip install -e .`.
+- Importer mobility dans votre code avec `import mobility` (script d'exemple [ici](https://github.com/mobility-team/mobility/blob/main/examples/trip_localizer_detailed_steps/trip_localizer_detailed_steps.py)).
+- Il faut appeler `mobility.setup` avant de pouvoir utiliser mobility : la fonction va fixer plusieurs variables d'environnement qui peuvent être nécessaires (où stocker les fichiers temporaires, info sur le proxy pour les requêtes http...) et installer si besoin les packages R.
+
 # Contributeur·ices
 | Entreprise/école  | Participant·es |
 | :------------- | :------------- |

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - r-base=4.1.3
+  - r-base=4.4.1
   - geopandas
   - osmium-tool
   # - pip:

--- a/examples/trip_localizer_detailed_steps/trip_localizer_detailed_steps.py
+++ b/examples/trip_localizer_detailed_steps/trip_localizer_detailed_steps.py
@@ -7,7 +7,7 @@ dotenv.load_dotenv()
 
 mobility.set_params(
     package_data_folder_path=os.environ["MOBILITY_PACKAGE_DATA_FOLDER"],
-    project_data_folder_path="D:/data/mobility/projects/lyon"
+    project_data_folder_path=os.environ["MOBILITY_PROJECT_DATA_FOLDER"]
 )
 
 transport_zones = mobility.TransportZones("69387", method="radius", radius=30.0)

--- a/mobility/gtfs.py
+++ b/mobility/gtfs.py
@@ -81,7 +81,7 @@ class GTFS(Asset):
             stops = gpd.read_file(path, bbox=bbox)
             
             
-        stops = gpd.sjoin(stops, transport_zones, how="inner", op='within')
+        stops = gpd.sjoin(stops, transport_zones, how="inner", predicate='within')
         
         return stops
     


### PR DESCRIPTION
Nous étions bloqués à la version 4.1.3 de R parce que conda-forge ne distribuait pas de version au delà de celle-ci pour Windows. Cela vient de changer, les versions 4.3 et 4.4 sont disponibles. Je teste la montée de version et je mets à jour dès que ça fonctionne.