### PR TITLE
Améliorer la stratégie de gestion du cache

### DIFF
--- a/mobility/parsers/census_localized_individuals.py
+++ b/mobility/parsers/census_localized_individuals.py
@@ -12,7 +12,10 @@ class CensusLocalizedIndividuals(FileAsset):
     
     def __init__(self, region: str):
 
-        inputs = {"region": region}
+        inputs = {
+            "verson": "1",
+            "region": region
+        }
 
         file_name = "census_localized_individuals_" + region + ".parquet"
         cache_path = pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"]) / "insee" / "census_localized_individuals" / file_name

--- a/mobility/parsers/mobility_survey/france/emp.py
+++ b/mobility/parsers/mobility_survey/france/emp.py
@@ -27,6 +27,7 @@ class EMPMobilitySurvey(MobilitySurvey):
 
     def __init__(self, seq_prob_cutoff: float = 0.95):
         inputs = {
+            "version": "1",
             "survey_name": "fr-EMP-2019",
             "country": "fr"
         }


### PR DESCRIPTION
Issue liée : https://github.com/mobility-team/mobility/issues/177

Solution : 
- Ajout d'un champ "version" au dictionnaire d'inputs des classes FileAsset.
- Lorsque la logique d'une sous classe de FileAsset (EMPMobilitySurvey, TransportZones...) change, le développeur **doit** indiquer si les fichiers générés par les versions précédentes du code ne fonctionneront plus, en ajoutant un paramètre "version" au dictionnaire d'inputs, ou en incrémentant la version.

Cette solution demande une attention particulière pour les développeurs, mais est très légère techniquement pour un bénéfice immédiat pour les utilisateurs : plus de conflits de cache lors de l'installation d'une nouvelle version de Mobility, et mise à jour automatique des fichiers.