### PR TITLE
Extraire la couche multipolygons des fichiers pbf dans prepare_transport_zones.R

### DIFF
--- a/mobility/r_utils/prepare_transport_zones.R
+++ b/mobility/r_utils/prepare_transport_zones.R
@@ -108,6 +108,7 @@ clusters_to_voronoi <- function(lau_id, lau_geom, level_of_detail, buildings_are
   buildings <- st_read(
     file.path(osm_buildings_fp, lau_id, "building.pbf"),
     query = "select osm_id from multipolygons",
+    layer = "multipolygons",
     quiet = TRUE
   )
   


### PR DESCRIPTION
Issue liée : https://github.com/mobility-team/mobility/issues/181

Il semblerait que l'utilisation d'une requête SQL dans `st_read` tel qu'on le fait [ici](https://github.com/mobility-team/mobility/blob/main/mobility/r_utils/prepare_transport_zones.R#L108-L112) ne fonctionne pas systématiquement selon les versions de GDAL.

@mathilderichard2001-rgb a trouvé une solution, en ajoutant l'argument `layer = "multipolygons"`. Merci !
(en espérant que le fix soit le bon, je n'arrive pas à trouver la cause exacte)