### PR TITLE
Suppression du parallélisme dans prepare_transport_zones.R

### DIFF
--- a/mobility/r_utils/prepare_transport_zones.R
+++ b/mobility/r_utils/prepare_transport_zones.R
@@ -226,8 +226,8 @@ study_area_dt[, geometry_wkb := geos_write_wkb(geometry)]
 
 set.seed(0)
 
-plan(multisession, workers = max(parallel::detectCores()-3, 1))
-# plan(sequential)
+# plan(multisession, workers = max(parallel::detectCores(logical = FALSE)-3, 1))
+plan(sequential)
 
 transport_zones_buildings <- future_lapply(
   


### PR DESCRIPTION
Issue liée : https://github.com/mobility-team/mobility/issues/185

Les appels à future_lapply ne fonctionnent plus sur les derniers PC AREP (Windows 11). En attendant de trouver une solution de contournement ou correction, je propose de supprimer le parallélisme pour débloquer la situation pour les utilisateurs concernés par ce bug, quitte à ralentir un peu les simulations des autres (sachant que la construction des zones de transport n'est à faire normalement qu'une seule fois par projet).