### PR TITLE
Améliorer la documentation de PopulationTrips et la validation de ses arguments

### DIFF
--- a/mobility/choice_models/population_trips.py
+++ b/mobility/choice_models/population_trips.py
@@ -20,7 +20,7 @@ from mobility.choice_models.top_k_mode_sequence_search import TopKModeSequenceSe
 from mobility.choice_models.state_initializer import StateInitializer
 from mobility.choice_models.state_updater import StateUpdater
 from mobility.choice_models.results import Results
-from mobility.motives import Motive
+from mobility.motives import Motive, HomeMotive, OtherMotive
 from mobility.transport_modes.transport_mode import TransportMode
 from mobility.parsers.mobility_survey import MobilitySurvey
 
@@ -68,14 +68,59 @@ class PopulationTrips(FileAsset):
             mode_sequence_search_parallel: bool = None
             
         ):
-        
-        if not modes:
-            raise ValueError("PopulationTrips needs at least one mode in `modes`.")
-        if not motives:
-            raise ValueError("PopulationTrips needs at least one motive in `motives`.")
-        if not surveys:
-            raise ValueError("PopulationTrips needs at least one survey in `surveys`.")
-        
+        """
+        Initialize a PopulationTrips model and its caching backend.
+
+        This constructor validates core inputs (modes, motives, surveys),
+        resolves model parameters (preferably from a PopulationTripsParameters
+        instance, otherwise from legacy keyword arguments), and sets up internal
+        components used during simulation (state initialization, destination
+        sampling, mode sequence search, and state updates). A TravelCostsAggregator
+        is built from the provided modes. Cache file paths are derived from the
+        MOBILITY_PROJECT_DATA_FOLDER environment variable and passed to FileAsset.
+
+        Parameters
+        ----------
+        population : Population
+            Population object containing demand groups and transport zones.
+        modes : list[TransportMode]
+            Available transport modes. Must contain at least one TransportMode.
+        motives : list[Motive]
+            Activity motives used to build and spatialize schedules. Must contain
+            at least one Motive and include HomeMotive and OtherMotive.
+        surveys : list[MobilitySurvey]
+            Mobility surveys providing empirical activity chains. Must contain at
+            least one MobilitySurvey.
+        parameters : PopulationTripsParameters, optional
+            Preferred way to configure the model. If provided, legacy keyword
+            arguments must be None.
+
+        Legacy Parameters (deprecated)
+        ------------------------------
+        n_iterations, alpha, k_mode_sequences, dest_prob_cutoff,
+        n_iter_per_cost_update, cost_uncertainty_sd, mode_sequence_search_parallel :
+            Deprecated shortcuts for PopulationTripsParameters fields. If any are
+            provided, a PopulationTripsParameters is built from them and a
+            FutureWarning is emitted.
+
+        Raises
+        ------
+        ValueError
+            If modes, motives, or surveys are empty, or if required motives are missing.
+        TypeError
+            If any element of modes, motives, or surveys has an incorrect type, or if
+            both `parameters` and legacy arguments are provided.
+
+        Notes
+        -----
+        Randomness is controlled by parameters.seed. If seed is None, a non-deterministic
+        RNG is used. The model itself is executed lazily via FileAsset.get()/create().
+        """
+
+        self.validate_modes(modes)
+        self.validate_motives(motives)
+        self.validate_surveys(surveys)
+
         parameters = self.resolve_parameters(
             parameters,
             n_iterations,
@@ -202,7 +247,42 @@ class PopulationTrips(FileAsset):
         parameters.validate()
             
         return parameters
-        
+
+
+    def validate_motives(self, motives: List[Motive]) -> None:
+
+        if not motives:
+            raise ValueError("PopulationTrips needs at least one motive in `motives`.")
+
+        for motive in motives:
+            if not isinstance(motive, Motive):
+                raise TypeError(f"PopulationTrips motives argument should be a list of `Motive` instances, but received one object of class {type(motive)}.")
+
+        if not any(isinstance(m, OtherMotive) for m in motives):
+            raise ValueError("PopulationTrips `motives` argument should contain a `OtherMotive`.")
+
+        if not any(isinstance(m, HomeMotive) for m in motives):
+            raise ValueError("PopulationTrips `motives` argument should contain a `HomeMotive`.")
+
+
+    def validate_modes(self, modes: List[TransportMode]) -> None:
+
+        if not modes:
+            raise ValueError("PopulationTrips needs at least one mode in `modes`.")
+
+        for mode in modes:
+            if not isinstance(mode, TransportMode):
+                raise TypeError(f"PopulationTrips modes argument should be a list of `TransportMode` instances, but received one object of class  {type(mode)}.")
+
+    def validate_surveys(self, surveys: List[MobilitySurvey]) -> None:
+
+        if not surveys:
+            raise ValueError("PopulationTrips needs at least one survey in `surveys`.")
+
+        for survey in surveys:
+            if not isinstance(survey, MobilitySurvey):
+                raise TypeError(f"PopulationTrips surveys argument should be a list of `MobilitySurvey` instances, but received one object of class  {type(survey)}.")
+
         
     def get_cached_asset(self):
         return {k: pl.scan_parquet(v) for k, v in self.cache_path.items()}


### PR DESCRIPTION
Issue liée : https://github.com/mobility-team/mobility/issues/226

Cette PR renforce la validation des entrées de `PopulationTrips` et améliore la documentation du constructeur.

- Ajout des imports `HomeMotive` et `OtherMotive`, et clarification qu’ils sont des motifs requis pour que la logique du modèle fonctionne correctement.
- Remplacement des simples vérifications « liste non vide » dans `__init__` par trois méthodes de validation dédiées :
  - `validate_modes` vérifie que `modes` est non vide et que tous les éléments sont des instances de `TransportMode`.
  - `validate_motives` vérifie que `motives` est non vide, que tous les éléments sont des instances de `Motive`, et impose la présence de `HomeMotive` et `OtherMotive` (invariant du modèle).
  - `validate_surveys` vérifie que `surveys` est non vide et que tous les éléments sont des instances de `MobilitySurvey`.
  Ces contrôles font échouer tôt avec des messages explicites plutôt que de laisser le modèle casser plus loin dans la pipeline.
- Ajout d’une docstring complète à `__init__`, détaillant les entrées attendues, l’usage recommandé via `PopulationTripsParameters` vs. les arguments legacy, le comportement du RNG, ainsi que les erreurs possibles.

Pour le moment pas de OtherMotive ou HomeMotive par défaut, car je crains que les utilisateurs ne voient pas qu'il est important qu'ils règlent les paramètres de ces motifs pour calibrer leur modèle ? C'est à dire qu'ils se limitent à calibrer avec WorkMotive par exemple, OtherMotive et HomeMotive étant "invisibilisés" car ajoutés par défaut.
