### PR TITLE
Correct choice probability

### DIFF
--- a/mobility/transport_modes/compute_subtour_mode_probs_parallel_utilities.py
+++ b/mobility/transport_modes/compute_subtour_mode_probs_parallel_utilities.py
@@ -182,6 +182,7 @@ def run_top_k_search(
         is_return_mode,
         return_mode,
         k=10,
+        divider=10,
         debug=False
     ):
     
@@ -302,7 +303,7 @@ def run_top_k_search(
         utilities -= np.max(utilities)
         
         # Compute probabilities
-        prob = np.exp(utilities)
+        prob = np.exp(utilities/divider)
         prob = prob/prob.sum()
         
         # Keep only the first 98 % of the cumulative distribution


### PR DESCRIPTION
Adds a divider before using log logic, otherwise the slightly better option will be too heavily chosen

Simple example with the possible divider values :
<img width="737" height="138" alt="image" src="https://github.com/user-attachments/assets/b93b1482-52b4-43e0-a367-23ef3371920c" />

1 is the current, and we see that the option with utility 14 (vs 18 and 20) is chosen by 98 % of persons, which is not realistic. Given the utilities we use, 10 looks a better option !