### PR TITLE
Align stay-home baseline utility with min_activity_time_constant

### DIFF
--- a/mobility/choice_models/population_trips.py
+++ b/mobility/choice_models/population_trips.py
@@ -352,7 +352,8 @@ class PopulationTrips(FileAsset):
         stay_home_state, current_states = self.state_initializer.get_stay_home_state(
             demand_groups,
             home_night_dur,
-            motives
+            motives,
+            parameters.min_activity_time_constant,
         )
         
         sinks = self.state_initializer.get_sinks(


### PR DESCRIPTION
### Motivation
See https://github.com/mobility-team/mobility/issues/264

### Changes
- Updated `StateInitializer.get_stay_home_state` to accept min_activity_time_constant.
- Replaced the hardcoded stay-home utility term with the same min-activity-time variable used in iterative utility computation for exterior programmes.
- Updated PopulationTrips to pass `parameters.min_activity_time_constant` when building the stay-home baseline state.