### PR TITLE
Use saturation-weighted effective sink in destination sampling

### DIFF
--- a/mobility/choice_models/state_initializer.py
+++ b/mobility/choice_models/state_initializer.py
@@ -336,8 +336,7 @@ class StateInitializer:
             transport_zones: Zone container passed to motives.
         
         Returns:
-            pl.DataFrame: ["to","motive","sink_capacity","sink_available",
-                           "k_saturation_utility"] with initial availability=capacity.
+            pl.DataFrame: ["to","motive","sink_capacity","k_saturation_utility"].
         """
 
         demand = ( 
@@ -380,10 +379,7 @@ class StateInitializer:
                 ),
                 k_saturation_utility=pl.lit(1.0, dtype=pl.Float64())
             )
-            .with_columns(
-                sink_available=pl.col("sink_capacity")
-            )
-            .select(["to", "motive", "sink_capacity", "sink_available", "k_saturation_utility"])
+            .select(["to", "motive", "sink_capacity", "k_saturation_utility"])
         )
 
         return sinks


### PR DESCRIPTION
This PR aligns destination sampling with saturation dynamics already used in programme utility evaluation, and removes redundant remaning sink computations. See https://github.com/mobility-team/mobility/issues/266.

### Changes

- state_initializer.py
  - Removed sink_available creation.
  - Sink schema now: ["to", "motive", "sink_capacity", "k_saturation_utility"].

- state_updater.py
  - Removed sink_available recomputation/output in get_new_sinks.
  - Kept saturation update via k_saturation_utility.

- destination_sequence_sampler.py

  - Replaced hard-availability logic with soft saturation-weighted mass:
 effective_sink = sink_capacity * k_saturation_utility * prob
  - Replaced all sampling opportunity uses:
    - p_to normalization now uses effective_sink
    - bin aggregation now sums effective_sink
    - radiation cumulative s_ij now uses effective_sink

- Updated related docstrings.

### Notes
This keeps saturation active in both destination proposal and programme utility scoring.
No behavior change to external interfaces; this is an internal consistency cleanup.