### PR TITLE
Replace clara clustering by kmeans + knn clustering when building transport zones

### DIFF
--- a/mobility/transport_zones.py
+++ b/mobility/transport_zones.py
@@ -81,7 +81,7 @@ class TransportZones(FileAsset):
         )
 
         inputs = {
-            "version": "1",
+            "version": "2",
             "study_area": study_area,
             "level_of_detail": level_of_detail,
             "osm_buildings": osm_buildings,
@@ -136,10 +136,10 @@ class TransportZones(FileAsset):
         script = RScript(resources.files('mobility.r_utils').joinpath('prepare_transport_zones.R'))
         script.run(
             args=[
-                study_area_fp,
-                osm_buildings_fp,
+                str(study_area_fp),
+                str(osm_buildings_fp),
                 str(self.level_of_detail),
-                self.cache_path
+                str(self.cache_path)
             ]
         )
         


### PR DESCRIPTION
### Motivation
See https://github.com/mobility-team/mobility/issues/270

### Changes
- Replace clara clustering with kmeans in prepare_transport_zones.R.
- Select cluster representative points by snapping each kmeans centroid to the nearest building point FNN::get.knnx, so centers remain actual buildings.
- If the algo does not converge, retry with more iterations.
- Centralize RNG seeding to one script-level seed.
- Bump TransportZones input version and normalize R script args to str in transport_zones.py for cache invalidation and argument consistency.