### PR TITLE
Remove now useless error raising in LeisureMotive

### DIFF
--- a/mobility/motives/leisure.py
+++ b/mobility/motives/leisure.py
@@ -29,9 +29,6 @@ class LeisureMotive(Motive):
         parameters: "LeisureMotiveParameters" | None = None
     ):
         
-        if opportunities is None:
-            raise ValueError("No built in leisure opportunities data for now, please provide an opportunities dataframe when creating instantiating the LeisureMotive class (or don't use it at all and let the OtherMotive model handle this motive).")
-
         parameters = self.prepare_parameters(
             parameters=parameters,
             parameters_cls=LeisureMotiveParameters,

--- a/mobility/parsers/leisure_facilities_distribution.py
+++ b/mobility/parsers/leisure_facilities_distribution.py
@@ -55,7 +55,7 @@ class LeisureFacilitiesDistribution(FileAsset):
         admin_units = LocalAdminUnits().get()
         admin_units_ids = admin_units["local_admin_unit_id"].tolist()
 
-        study_area = StudyArea(admin_units_ids, radius=0)
+        study_area = StudyArea(admin_units_ids)
 
         pbf_path = OSMData(
             study_area,


### PR DESCRIPTION
### Motivation
Since https://github.com/mobility-team/mobility/pull/262 we have a way to compute opportunities for the leisure motive based on OSM data. We don't need to force users to provide them anymore.

### Changes
- Removed the error raising call in LeisureMotive.
- Removed a useless radius arg in LeisureFacilitiesDistribution (we already provide a list of local_admin_unit_ids, the radius arg is useful only if we provide one central local_admin_unit_id and then select nearby ones within a radius).