### PR TITLE
External mobility surveys

### DIFF
--- a/mobility/choice_models/destination_sequence_sampler.py
+++ b/mobility/choice_models/destination_sequence_sampler.py
@@ -228,7 +228,7 @@ class DestinationSequenceSampler:
             costs_bin
             .with_columns(
                 s_ij=pl.col("effective_sink").cum_sum().over(["from", "motive"]),
-                selection_lambda=pl.col("motive").replace_strict(motives_lambda)
+                selection_lambda=pl.col("motive").cast(pl.Utf8).replace_strict(motives_lambda)
             )
             .with_columns(
                 p_a = (1 - pl.col("selection_lambda")**(1+pl.col('s_ij'))) / (1+pl.col('s_ij')) / (1-pl.col("selection_lambda"))

--- a/mobility/choice_models/state_initializer.py
+++ b/mobility/choice_models/state_initializer.py
@@ -196,7 +196,7 @@ class StateInitializer:
             
             .sort(["demand_group_id", "motive_seq_id",  "seq_step_index"])
             .with_columns(
-                is_anchor=pl.col("motive").replace_strict(anchors)
+                is_anchor=pl.col("motive").cast(pl.Utf8).replace_strict(anchors)
             )
         
         )

--- a/mobility/parsers/mobility_survey/mobility_survey.py
+++ b/mobility/parsers/mobility_survey/mobility_survey.py
@@ -25,6 +25,8 @@ class MobilitySurvey(FileAsset):
         survey_name: str | None = None,
         country: str | None = None,
         seq_prob_cutoff: float | None = None,
+        dataset_path: pathlib.Path | str | None = None,
+        patch: "MobilitySurvey | None" = None,
         parameters: "MobilitySurveyParameters" | None = None,
     ):
         """Initialize mobility survey asset inputs and cache paths.
@@ -33,6 +35,8 @@ class MobilitySurvey(FileAsset):
             survey_name: Survey dataset identifier.
             country: Country code associated with the survey.
             seq_prob_cutoff: Sequence probability cutoff used in chain filtering.
+            dataset_path: Optional raw dataset location used by survey-specific parsers.
+            patch: Optional upstream survey asset used to reuse part of another survey cache.
             parameters: Optional pre-built pydantic parameters model.
         """
         parameters = self.prepare_parameters(
@@ -42,6 +46,7 @@ class MobilitySurvey(FileAsset):
                 "survey_name": survey_name,
                 "country": country,
                 "seq_prob_cutoff": seq_prob_cutoff,
+                "dataset_path": dataset_path,
             },
             required_fields=["survey_name", "country"],
             owner_name="MobilitySurvey",
@@ -69,6 +74,8 @@ class MobilitySurvey(FileAsset):
             "version": "1",
             "parameters": parameters,
         }
+        if patch is not None:
+            inputs["patch"] = patch
         super().__init__(inputs, cache_path)
         
     def get_cached_asset(self) -> dict[str, pd.DataFrame]:
@@ -452,5 +459,14 @@ class MobilitySurveyParameters(BaseModel):
                 "Cumulative contribution cutoff used to keep the most relevant "
                 "motive/mode sequences per population group."
             ),
+        ),
+    ]
+
+    dataset_path: Annotated[
+        pathlib.Path | None,
+        Field(
+            default=None,
+            title="Dataset path",
+            description="Optional path to the raw survey dataset consumed by survey-specific parsers.",
         ),
     ]

--- a/mobility/parsers/mobility_survey/mobility_survey.py
+++ b/mobility/parsers/mobility_survey/mobility_survey.py
@@ -25,7 +25,6 @@ class MobilitySurvey(FileAsset):
         survey_name: str | None = None,
         country: str | None = None,
         seq_prob_cutoff: float | None = None,
-        dataset_path: pathlib.Path | str | None = None,
         patch: "MobilitySurvey | None" = None,
         parameters: "MobilitySurveyParameters" | None = None,
     ):
@@ -35,7 +34,6 @@ class MobilitySurvey(FileAsset):
             survey_name: Survey dataset identifier.
             country: Country code associated with the survey.
             seq_prob_cutoff: Sequence probability cutoff used in chain filtering.
-            dataset_path: Optional raw dataset location used by survey-specific parsers.
             patch: Optional upstream survey asset used to reuse part of another survey cache.
             parameters: Optional pre-built pydantic parameters model.
         """
@@ -46,7 +44,6 @@ class MobilitySurvey(FileAsset):
                 "survey_name": survey_name,
                 "country": country,
                 "seq_prob_cutoff": seq_prob_cutoff,
-                "dataset_path": dataset_path,
             },
             required_fields=["survey_name", "country"],
             owner_name="MobilitySurvey",
@@ -462,11 +459,3 @@ class MobilitySurveyParameters(BaseModel):
         ),
     ]
 
-    dataset_path: Annotated[
-        pathlib.Path | None,
-        Field(
-            default=None,
-            title="Dataset path",
-            description="Optional path to the raw survey dataset consumed by survey-specific parsers.",
-        ),
-    ]

--- a/mobility/parsers/mobility_survey/mobility_survey.py
+++ b/mobility/parsers/mobility_survey/mobility_survey.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import polars as pl
 import pandas as pd
-from typing import Annotated
+from typing import Annotated, Any
 from pydantic import BaseModel, ConfigDict, Field
 from mobility.file_asset import FileAsset
 
@@ -25,7 +25,6 @@ class MobilitySurvey(FileAsset):
         survey_name: str | None = None,
         country: str | None = None,
         seq_prob_cutoff: float | None = None,
-        patch: "MobilitySurvey | None" = None,
         parameters: "MobilitySurveyParameters" | None = None,
     ):
         """Initialize mobility survey asset inputs and cache paths.
@@ -34,7 +33,6 @@ class MobilitySurvey(FileAsset):
             survey_name: Survey dataset identifier.
             country: Country code associated with the survey.
             seq_prob_cutoff: Sequence probability cutoff used in chain filtering.
-            patch: Optional upstream survey asset used to reuse part of another survey cache.
             parameters: Optional pre-built pydantic parameters model.
         """
         parameters = self.prepare_parameters(
@@ -71,9 +69,12 @@ class MobilitySurvey(FileAsset):
             "version": "1",
             "parameters": parameters,
         }
-        if patch is not None:
-            inputs["patch"] = patch
+        inputs.update(self.get_additional_inputs())
         super().__init__(inputs, cache_path)
+
+    def get_additional_inputs(self) -> dict[str, Any]:
+        """Hook for specialized parsers to add extra hashed inputs before cache initialization."""
+        return {}
         
     def get_cached_asset(self) -> dict[str, pd.DataFrame]:
         """

--- a/mobility/parsers/mobility_survey/mobility_survey.py
+++ b/mobility/parsers/mobility_survey/mobility_survey.py
@@ -209,12 +209,12 @@ class MobilitySurvey(FileAsset):
 
             # Map detailed motives to grouped motives
             .with_columns(
-                pl.col("motive").replace_strict(motive_mapping, default="other")
+                pl.col("motive").cast(pl.Utf8).replace_strict(motive_mapping, default="other")
             )
             
             # Map detailed modes to grouped modes
             .with_columns(
-                mode=pl.col("mode_id").replace_strict(mode_mapping, default="other")
+                mode=pl.col("mode_id").cast(pl.Utf8).replace_strict(mode_mapping, default="other")
             )
                      
             # Remove motive sequences that are longer than 10 motives to speed 


### PR DESCRIPTION
**Motivation**

When we write external mobility survey parsers (we have a parser for the MRMT survey in Switzerland for example, that we can't publish because the data is not open), we need to handle some specific parameters and thus to set a clear separation between those that are generic, in MobilitySurvey, and the ones that are specific.

But we still need to hash the right inputs so the surveys are parsed only when needed.

**Changes**

- Introduced a `get_additional_inputs()` hook in MobilitySurvey so specialized parsers can inject hashed dependencies such as patch assets before cache initialization. This keeps parser-specific configuration in parser-specific pydantic models while preserving a clean generic base API.