### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "requirements-ci.txt"
+      - "requirements-min.txt"
+      - "docs/requirements.txt"


### PR DESCRIPTION
### Motivations
Make dependabot analyze pyproject.toml, not pinned requirements files.

### Changes
Added a .github/dependabot.yaml config file.