### PR TITLE
Replace data.cquest.org downloads with carte.gouv.fr downloads

### DIFF
--- a/mobility/parsers/admin_boundaries.py
+++ b/mobility/parsers/admin_boundaries.py
@@ -21,7 +21,7 @@ def prepare_french_admin_boundaries():
             
     # Convert to geoparquet
     path = path.parent / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03" / \
-     "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2023-05-03" / "ADECOGC_3-2_SHP_LAMB93_FXX"
+     "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2023-05-03" / "ADECOGC_3-2_SHP_LAMB93_FXX-ED2024-02-22"
     
     for shp_file in ["ARRONDISSEMENT_MUNICIPAL.shp", "COMMUNE.shp", "EPCI.shp", "REGION.shp"]:
             

--- a/mobility/parsers/admin_boundaries.py
+++ b/mobility/parsers/admin_boundaries.py
@@ -12,7 +12,7 @@ def prepare_french_admin_boundaries():
     
     logging.info("Preparing french city limits...")
     
-    url = "https://data.cquest.org/ign/adminexpress/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03.7z"
+    url = "https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22.7z"
     path = pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"]) / "ign/admin-express/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03.7z"
     download_file(url, path)
     

--- a/mobility/parsers/admin_boundaries.py
+++ b/mobility/parsers/admin_boundaries.py
@@ -20,9 +20,14 @@ def prepare_french_admin_boundaries():
         z.extractall(path.parent)
             
     # Convert to geoparquet
-    path = path.parent / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03" / \
-     "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2023-05-03" / "ADECOGC_3-2_SHP_LAMB93_FXX-ED2024-02-22"
-    
+    path = ( 
+        path.parent 
+        / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22" 
+        / "ADMIN-EXPRESS-COG-CARTO" 
+        / "1_DONNEES_LIVRAISON_2024-03-00169" 
+        / "ADECOGC_3-2_SHP_LAMB93_FXX-ED2024-02-22"
+    )
+
     for shp_file in ["ARRONDISSEMENT_MUNICIPAL.shp", "COMMUNE.shp", "EPCI.shp", "REGION.shp"]:
             
          df = gpd.read_file(path / shp_file)

--- a/mobility/parsers/local_admin_units.py
+++ b/mobility/parsers/local_admin_units.py
@@ -16,7 +16,7 @@ class LocalAdminUnits(FileAsset):
     
     Use .get() method to get its content (under Parquet format).
     
-    In France, uses adminexpress base from IGN, stored on cquest.org. For Paris, Lyon and Marseille, each 'arrondissement' is considered a distinct admin unit.
+    In France, uses adminexpress base from IGN, stored on https://cartes.gouv.fr/. For Paris, Lyon and Marseille, each 'arrondissement' is considered a distinct admin unit.
     
     In Switzerland, uses swisstopo data stored on geo.admin.ch
     
@@ -64,7 +64,7 @@ class LocalAdminUnits(FileAsset):
         
         logging.info("Preparing french city limits...")
         
-        url = "https://data.cquest.org/ign/adminexpress/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03.7z"
+        url = "https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22.7z"
         path = pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"]) / "ign/admin-express/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03.7z"
         download_file(url, path)
         

--- a/mobility/parsers/local_admin_units.py
+++ b/mobility/parsers/local_admin_units.py
@@ -73,7 +73,7 @@ class LocalAdminUnits(FileAsset):
                 
         # Convert to geoparquet
         path = path.parent / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03" / \
-         "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2023-05-03" / "ADECOGC_3-2_SHP_LAMB93_FXX"
+         "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2023-05-03" / "ADECOGC_3-2_SHP_LAMB93_FXX-ED2024-02-22"
         
         # Replace Paris / Lyon / Marseille cities with their constituting arrondissements
         arrond = gpd.read_file(path / "ARRONDISSEMENT_MUNICIPAL.shp")

--- a/mobility/spatial/local_admin_units.py
+++ b/mobility/spatial/local_admin_units.py
@@ -7,16 +7,16 @@ import shapely
 import geopandas as gpd
 import pandas as pd
 
-from mobility.file_asset import FileAsset
-from mobility.parsers.download_file import download_file
-from mobility.parsers.local_admin_units_categories import LocalAdminUnitsCategories
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.io.download_file import download_file
+from mobility.spatial.local_admin_units_categories import LocalAdminUnitsCategories
 
 class LocalAdminUnits(FileAsset):
     """FileAsset class preparing local admin units in France and Switzerland.
     
     Use .get() method to get its content (under Parquet format).
     
-    In France, uses adminexpress base from IGN, stored on https://cartes.gouv.fr/. For Paris, Lyon and Marseille, each 'arrondissement' is considered a distinct admin unit.
+    In France, uses adminexpress base from IGN, stored on cartes.gouv.fr. For Paris, Lyon and Marseille, each 'arrondissement' is considered a distinct admin unit.
     
     In Switzerland, uses swisstopo data stored on geo.admin.ch
     
@@ -72,13 +72,8 @@ class LocalAdminUnits(FileAsset):
             z.extractall(path.parent)
                 
         # Convert to geoparquet
-        path = ( 
-            path.parent 
-            / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2024-02-22" 
-            / "ADMIN-EXPRESS-COG-CARTO" 
-            / "1_DONNEES_LIVRAISON_2024-03-00169" 
-            / "ADECOGC_3-2_SHP_LAMB93_FXX-ED2024-02-22"
-        )
+        path = path.parent / "ADMIN-EXPRESS-COG-CARTO_3-2__SHP_LAMB93_FXX_2023-05-03" / \
+         "ADMIN-EXPRESS-COG-CARTO" / "1_DONNEES_LIVRAISON_2024-03-00169" / "ADECOGC_3-2_SHP_LAMB93_FXX"
         
         # Replace Paris / Lyon / Marseille cities with their constituting arrondissements
         arrond = gpd.read_file(path / "ARRONDISSEMENT_MUNICIPAL.shp")


### PR DESCRIPTION
### Motivation
data.cquest.org downloads for the ADMIN EXPRESS CARTO dataset sometimes fail (as they do today).
See https://github.com/mobility-team/mobility/issues/290 for a bug report.

### Changes
This PR replaces the url of the dataset on data.cquest.org by the url of the same dataset on cartes.gouv.fr. This server is less likely to be down because cartes.gouv.fr is an official platform backed by the french government. The url might not be stable long term so we'll may have to cache the dataset on data.gouv.fr at some point.

### AI-assisted contribution
_Select one:_
- [x] No AI assistance

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
