### PR TITLE
Host BPE24 on data.gouv.fr to avoid intermittent download issues

### DIFF
--- a/mobility/activities/shopping/shops_turnover_distribution.py
+++ b/mobility/activities/shopping/shops_turnover_distribution.py
@@ -124,7 +124,7 @@ class ShopsTurnoverDistribution(FileAsset):
         insee_data_folder = pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"]) / "insee"
 
         # Download shop location data
-        url = "https://www.insee.fr/fr/statistiques/fichier/8217525/BPE24.parquet"
+        url = "https://www.data.gouv.fr/api/1/datasets/r/b532ef31-edd9-4017-adda-b077aa0d39e3"
         parquet_path = insee_data_folder / "BPE24.parquet"
         download_file(url, parquet_path)
 


### PR DESCRIPTION
### Motivation
I hit an error when parsing the french "base permanente des équipements" dataset, because the download terminated before completion and produced a corrupted file. The problem is intermittent.

### Changes
This PR adds a snapshot copy of the dataset in the mobility data.gouv.fr organization dataset list, so we get a stable url and file. Url : https://www.data.gouv.fr/datasets/base-permanente-des-equipements-3

### AI-assisted contribution
- [x] No AI assistance

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
