### PR TITLE
Fix congestion artifacts clean up

### DIFF
--- a/mobility/transport/costs/path/path_travel_costs.py
+++ b/mobility/transport/costs/path/path_travel_costs.py
@@ -9,7 +9,7 @@ import geopandas as gpd
 
 from importlib import resources
 from mobility.transport.graphs.core.path_graph import PathGraph
-from mobility.runtime.assets.file_asset import FileAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
 from mobility.transport.costs.parameters.path_routing_parameters import PathRoutingParameters
@@ -21,7 +21,7 @@ from mobility.transport.costs.congestion_state import CongestionState
 
 from typing import List
 
-class PathTravelCosts(FileAsset):
+class PathTravelCosts(TravelCostsAsset):
     """
     A class for managing travel cost calculations for certain modes using OpenStreetMap (OSM) data, inheriting from the Asset class.
 
@@ -255,4 +255,19 @@ class PathTravelCosts(FileAsset):
             contracted_graph=contracted_graph,
         )
         return variant
+
+    def remove_congestion_artifacts(self, congestion_state: CongestionState) -> None:
+        """Remove one congestion-specific travel-cost variant and owned graph caches."""
+        variant = self.asset_for_congestion_state(congestion_state)
+        if variant is None or variant is self:
+            return
+
+        variant.remove()
+
+        contracted_graph = variant.inputs.get("contracted_path_graph")
+        if contracted_graph is not None:
+            contracted_graph.remove()
+            congested_graph = getattr(contracted_graph, "inputs", {}).get("congested_graph")
+            if congested_graph is not None:
+                congested_graph.remove()
         

--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+from collections.abc import Iterator
 
 import polars as pl
 
 from mobility.transport.costs.congestion_state_manager import CongestionStateManager
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.transport.costs.congestion_state import CongestionState
+from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
 
 
 class TransportCosts(FileAsset):
@@ -389,6 +392,64 @@ class TransportCosts(FileAsset):
             `True` when the iteration triggers a congestion refresh.
         """
         return update_interval > 0 and (iteration - 1) % update_interval == 0
+
+    def remove_congestion_artifacts(
+        self,
+        congestion_state: CongestionState,
+    ) -> None:
+        """Remove congestion-derived artifacts owned by this transport-cost state."""
+        variant = self.asset_for_congestion_state(congestion_state)
+        if variant is not self:
+            variant.remove()
+
+        for mode in self.modes:
+            travel_costs = mode.inputs.get("travel_costs")
+            if travel_costs is None or isinstance(travel_costs, TravelCostsAsset) is False:
+                continue
+            travel_costs.remove_congestion_artifacts(congestion_state)
+
+    def iter_run_congestion_artifacts(
+        self,
+        run,
+    ) -> Iterator[tuple["TransportCosts", CongestionState, dict[str, VehicleODFlowsAsset]]]:
+        """Yield persisted congestion states and flow assets for one run."""
+        if self.has_enabled_congestion() is False:
+            return
+
+        update_interval = run.parameters.n_iter_per_cost_update
+        if update_interval == 0:
+            return
+
+        for completed_iteration in range(1, int(run.parameters.n_iterations) + 1):
+            if self.should_recompute_congested_costs(completed_iteration, update_interval) is False:
+                continue
+
+            next_transport_costs = self.for_iteration(completed_iteration + 1)
+            flow_assets_by_mode = {}
+            for mode in next_transport_costs.congestion_states._iter_congestion_enabled_modes():
+                mode_name = mode.inputs["parameters"].name
+                flow_asset = VehicleODFlowsAsset.from_inputs(
+                    run_key=run.inputs_hash,
+                    is_weekday=run.is_weekday,
+                    iteration=completed_iteration,
+                    mode_name=mode_name,
+                )
+                if flow_asset.cache_path.exists():
+                    flow_assets_by_mode[mode_name] = flow_asset
+
+            if not flow_assets_by_mode:
+                continue
+
+            yield (
+                next_transport_costs,
+                CongestionState(
+                    run_key=str(run.inputs_hash),
+                    is_weekday=bool(run.is_weekday),
+                    iteration=int(completed_iteration),
+                    flow_assets_by_mode=flow_assets_by_mode,
+                ),
+                flow_assets_by_mode,
+            )
 
     def get_costs_for_next_iteration(
         self,

--- a/mobility/transport/costs/travel_costs_asset.py
+++ b/mobility/transport/costs/travel_costs_asset.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from mobility.runtime.assets.file_asset import FileAsset
+
+
+class TravelCostsAsset(FileAsset):
+    """Base class for per-mode travel-cost assets with congestion helpers."""
+
+    def asset_for_congestion_state(self, congestion_state):
+        """Return the effective asset for one congestion state."""
+        return self
+
+    def remove_congestion_artifacts(self, congestion_state) -> None:
+        """Remove congestion-derived artifacts owned by this asset."""
+        variant = self.asset_for_congestion_state(congestion_state)
+        if variant is not None and variant is not self:
+            variant.remove()

--- a/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
+++ b/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
@@ -11,14 +11,14 @@ from typing import Annotated
 from importlib import resources
 from pydantic import BaseModel, ConfigDict, Field
 
-from mobility.runtime.assets.file_asset import FileAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.transport.costs.congestion_state import CongestionState
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.modes.core.modal_transfer import IntermodalTransfer
 from mobility.transport.costs.path.path_travel_costs import PathTravelCosts
 
-class DetailedCarpoolTravelCosts(FileAsset):
+class DetailedCarpoolTravelCosts(TravelCostsAsset):
 
     def __init__(
             self,

--- a/mobility/transport/modes/public_transport/intermodal_transport_graph.py
+++ b/mobility/transport/modes/public_transport/intermodal_transport_graph.py
@@ -9,7 +9,6 @@ from importlib import resources
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
-from mobility.transport.modes.core.transport_mode import TransportMode
 from mobility.transport.modes.core.modal_transfer import IntermodalTransfer
 from mobility.transport.modes.public_transport.public_transport_graph import PublicTransportGraph, PublicTransportRoutingParameters
 from mobility.transport.graphs.contracted.contracted_path_graph import ContractedPathGraph
@@ -32,12 +31,15 @@ class IntermodalTransportGraph(FileAsset):
             self,
             transport_zones: TransportZones,
             parameters: PublicTransportRoutingParameters,
-            first_leg_mode: TransportMode,
-            last_leg_mode: TransportMode,
+            first_leg_travel_costs,
+            last_leg_travel_costs,
+            first_leg_mode_name: str,
+            last_leg_mode_name: str,
             first_modal_transfer: IntermodalTransfer = None,
             last_modal_transfer: IntermodalTransfer = None,
             parkings_geofabrik_extract_date: str = "250101"
     ):
+        """Build the intermodal PT graph from leg graphs and PT routing inputs."""
         """
         Retrieves public transport travel costs if they already exist for these transport zones and parameters,
         otherwise calculates them.
@@ -64,14 +66,17 @@ class IntermodalTransportGraph(FileAsset):
         inputs = {
             "transport_zones": transport_zones,
             "public_transport_graph": public_transport_graph,
-            "first_leg_graph": first_leg_mode.inputs["travel_costs"].contracted_path_graph,
-            "last_leg_graph": last_leg_mode.inputs["travel_costs"].contracted_path_graph,
+            # PT only needs the contracted leg graphs here, not the full leg
+            # mode objects that were previously threaded through this constructor.
+            "first_leg_graph": first_leg_travel_costs.contracted_path_graph,
+            "last_leg_graph": last_leg_travel_costs.contracted_path_graph,
             "first_modal_transfer": first_modal_transfer,
             "last_modal_transfer": last_modal_transfer,
             "parameters": parameters
         }
 
-        if first_leg_mode.inputs["parameters"].name == "car":
+        # Parking supply is only relevant when access to PT starts by car.
+        if first_leg_mode_name == "car":
             inputs["osm_parkings"] = OSMData(
                 transport_zones.study_area,
                 object_type="a",
@@ -81,9 +86,9 @@ class IntermodalTransportGraph(FileAsset):
             )
         
         file_name = (
-            first_leg_mode.inputs["parameters"].name
+            first_leg_mode_name
             + "_public_transport_"
-            + last_leg_mode.inputs["parameters"].name
+            + last_leg_mode_name
             + "_intermodal_transport_graph/simplified/done"
         )
         cache_path = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / file_name
@@ -91,10 +96,12 @@ class IntermodalTransportGraph(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pd.DataFrame:
+        """Return the persisted intermodal graph marker path."""
         logging.info("Intermodal graph already created. Reusing the file : " + str(self.cache_path))
         return self.cache_path
 
     def create_and_get_asset(self) -> pd.DataFrame:
+        """Build and persist the intermodal graph marker path."""
         self.prepare_intermodal_graph(**self.inputs)
         return self.cache_path
 
@@ -110,23 +117,7 @@ class IntermodalTransportGraph(FileAsset):
             parameters: PublicTransportRoutingParameters,
             osm_parkings: OSMData = None
         ) -> pd.DataFrame:
-        """
-        Calculates intermodal travel costs between transport zones. Uses the R script called prepare_intermodal_public_transport_graph.R
-
-        Args:
-            transport_zones (gpd.GeoDataFrame): GeoDataFrame containing transport zone geometries.
-            public_transport_graph (PublicTransportGraph): public transport part of the intermodal graph
-            first_leg_graph: graph for the first leg mode
-            last_leg_graph: graph for the last leg mode
-            first_modal_transfer: transfer parameters between the first mode and public transport
-            last_modal_transfer: transfer parameters between public transport and the last mode
-            osm_parkings: 
-            parameters: PublicTransportRoutingParameters
-
-
-        Returns:
-            None, but a file is prepared
-        """
+        """Build the routable intermodal PT graph on disk."""
 
         logging.info("Computing public transport travel costs...")
         
@@ -150,8 +141,10 @@ class IntermodalTransportGraph(FileAsset):
     
 
     def update(self):
+        """Refresh the persisted intermodal graph."""
         
         self.create_and_get_asset()
 
     def audit_gtfs(self):
+        """Expose GTFS audit information from the PT subgraph."""
         return self.inputs["public_transport_graph"].audit_gtfs()

--- a/mobility/transport/modes/public_transport/public_transport.py
+++ b/mobility/transport/modes/public_transport/public_transport.py
@@ -56,6 +56,7 @@ class PublicTransportMode(TransportMode):
         ghg_intensity: float | None = None,
         parameters: "PublicTransportParameters | None" = None,
     ):
+        """Build one PT mode from explicit or registry-resolved leg modes."""
         first_leg_mode = self._resolve_leg_mode(
             leg_mode=first_leg_mode,
             mode_registry=mode_registry,
@@ -83,13 +84,21 @@ class PublicTransportMode(TransportMode):
             routing_parameters = PublicTransportRoutingParameters()
 
         travel_costs = PublicTransportTravelCosts(
-            transport_zones,
-            routing_parameters,
-            first_leg_mode,
-            last_leg_mode,
-            first_intermodal_transfer,
-            last_intermodal_transfer,
+            transport_zones=transport_zones,
+            parameters=routing_parameters,
+            first_leg_travel_costs=first_leg_mode.inputs["travel_costs"],
+            last_leg_travel_costs=last_leg_mode.inputs["travel_costs"],
+            first_leg_mode_name=first_leg_mode.inputs["parameters"].name,
+            last_leg_mode_name=last_leg_mode.inputs["parameters"].name,
+            first_modal_transfer=first_intermodal_transfer,
+            last_modal_transfer=last_intermodal_transfer,
         )
+
+        # Keep the original leg modes on the mode instance so `for_iteration`
+        # can rebuild a PT mode with the same leg definitions but different
+        # routing parameters.
+        self.first_leg_mode = first_leg_mode
+        self.last_leg_mode = last_leg_mode
 
         congestion = (
             first_leg_mode.inputs["parameters"].congestion
@@ -143,6 +152,7 @@ class PublicTransportMode(TransportMode):
         )
 
     def audit_gtfs(self):
+        """Audit GTFS inputs through the PT travel-cost asset."""
         logging.info("Auditing GTFS for this mode")
         travel_costs = self.inputs["travel_costs"].audit_gtfs()
         return travel_costs
@@ -161,8 +171,8 @@ class PublicTransportMode(TransportMode):
 
         return PublicTransportMode(
             transport_zones=travel_costs.inputs["transport_zones"],
-            first_leg_mode=travel_costs.first_leg_mode,
-            last_leg_mode=travel_costs.last_leg_mode,
+            first_leg_mode=self.first_leg_mode,
+            last_leg_mode=self.last_leg_mode,
             first_intermodal_transfer=travel_costs.inputs["first_modal_transfer"],
             last_intermodal_transfer=travel_costs.inputs["last_modal_transfer"],
             routing_parameters=resolved_routing_parameters,
@@ -176,6 +186,7 @@ class PublicTransportMode(TransportMode):
         mode_registry: ModeRegistry | None,
         leg_label: str,
     ) -> TransportMode:
+        """Return an explicit leg mode or resolve the default from the registry."""
         if leg_mode is not None:
             return leg_mode
 

--- a/mobility/transport/modes/public_transport/public_transport_travel_costs.py
+++ b/mobility/transport/modes/public_transport/public_transport_travel_costs.py
@@ -2,20 +2,20 @@ import os
 import pathlib
 import logging
 import json
+from typing import Any
+
 import pandas as pd
 
 from importlib import resources
 
-from mobility.runtime.assets.file_asset import FileAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
-from mobility.transport.modes.public_transport.public_transport_graph import PublicTransportGraph, PublicTransportRoutingParameters
+from mobility.transport.modes.public_transport.public_transport_graph import PublicTransportRoutingParameters
 from mobility.transport.modes.public_transport.intermodal_transport_graph import IntermodalTransportGraph
-from mobility.transport.modes.core.transport_mode import TransportMode
 from mobility.transport.modes.core.modal_transfer import IntermodalTransfer
-from mobility.transport.graphs import SimplifiedPathGraph, ContractedPathGraph
 
-class PublicTransportTravelCosts(FileAsset):
+class PublicTransportTravelCosts(TravelCostsAsset):
     """
     A class for managing public transport travel costs calculations using GTFS files, inheriting from the FileAsset class.
 
@@ -30,11 +30,14 @@ class PublicTransportTravelCosts(FileAsset):
             self,
             transport_zones: TransportZones,
             parameters: PublicTransportRoutingParameters,
-            first_leg_mode: TransportMode,
-            last_leg_mode: TransportMode,
+            first_leg_travel_costs,
+            last_leg_travel_costs,
+            first_leg_mode_name: str,
+            last_leg_mode_name: str,
             first_modal_transfer: IntermodalTransfer = None,
             last_modal_transfer: IntermodalTransfer = None
     ):
+        """Build the PT travel-cost asset for one pair of access and egress legs."""
         """
         Retrieves public transport travel costs if they already exist for these transport zones and parameters,
         otherwise calculates them.
@@ -55,14 +58,20 @@ class PublicTransportTravelCosts(FileAsset):
                 "PublicTransportTravelCosts requires both `first_modal_transfer` and `last_modal_transfer`."
             )
 
-        self.first_leg_mode = first_leg_mode
-        self.last_leg_mode = last_leg_mode
+        # Store the leg dependencies directly so PT variants can rebind them
+        # without rebuilding whole leg-mode objects.
+        self.first_leg_travel_costs = first_leg_travel_costs
+        self.last_leg_travel_costs = last_leg_travel_costs
+        self.first_leg_mode_name = first_leg_mode_name
+        self.last_leg_mode_name = last_leg_mode_name
 
         intermodal_graph = IntermodalTransportGraph(
             transport_zones,
             parameters,
-            first_leg_mode,
-            last_leg_mode,
+            first_leg_travel_costs,
+            last_leg_travel_costs,
+            first_leg_mode_name,
+            last_leg_mode_name,
             first_modal_transfer,
             last_modal_transfer
         )
@@ -76,9 +85,9 @@ class PublicTransportTravelCosts(FileAsset):
         }
 
         file_name = (
-            first_leg_mode.inputs["parameters"].name
+            first_leg_mode_name
             + "_public_transport_"
-            + last_leg_mode.inputs["parameters"].name
+            + last_leg_mode_name
             + "_travel_costs.parquet"
         )
         cache_path = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / file_name
@@ -86,6 +95,7 @@ class PublicTransportTravelCosts(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self, congestion: bool = False) -> pd.DataFrame:
+        """Load the persisted PT OD costs."""
         
         logging.info("Travel costs already prepared. Reusing the file : " + str(self.cache_path))
         costs = pd.read_parquet(self.cache_path)
@@ -93,6 +103,7 @@ class PublicTransportTravelCosts(FileAsset):
         return costs
 
     def create_and_get_asset(self, congestion: bool = False) -> pd.DataFrame:
+        """Compute and persist the PT OD costs."""
         
         costs = self.compute_travel_costs(
             self.inputs["transport_zones"],
@@ -115,19 +126,7 @@ class PublicTransportTravelCosts(FileAsset):
             last_modal_transfer: IntermodalTransfer,
             parameters: PublicTransportRoutingParameters
         ) -> pd.DataFrame:
-        """
-        Calculates travel costs for public transport between transport zones.
-
-        Args:
-            transport_zones (gpd.GeoDataFrame): GeoDataFrame containing transport zone geometries.
-            gtfs_router : GTFSRouter object containing data about public transport routes and schedules.
-            start_time_min : float containing the start hour to consider for cost determination
-            start_time_max : float containing the end hour to consider for cost determination, should be superior to start_time_min
-            max_traveltime : float with the maximum travel time to consider for public transport, in hours
-
-        Returns:
-            pd.DataFrame: A DataFrame containing calculated public transport travel costs.
-        """
+        """Run the PT routing pipeline and return the resulting OD costs."""
 
         logging.info("Computing public transport travel costs...")
         
@@ -150,9 +149,59 @@ class PublicTransportTravelCosts(FileAsset):
     
     
     def update(self, od_flows):
+        """Refresh the PT asset after one of its dependencies changed."""
         
         self.inputs["intermodal_graph"].update()
         self.create_and_get_asset()
+
+    def asset_for_congestion_state(self, congestion_state):
+        """Return a PT variant rebound to congestion-aware leg travel costs."""
+        first_leg_variant = self._travel_costs_for_congestion_state(
+            self.first_leg_travel_costs,
+            congestion_state,
+        )
+        last_leg_variant = self._travel_costs_for_congestion_state(
+            self.last_leg_travel_costs,
+            congestion_state,
+        )
+
+        if (
+            first_leg_variant is self.first_leg_travel_costs
+            and last_leg_variant is self.last_leg_travel_costs
+        ):
+            return self
+
+        # PT owns its own parquet/intermodal graph cache, but not the caches of
+        # the leg travel-cost assets it depends on.
+        return PublicTransportTravelCosts(
+            transport_zones=self.inputs["transport_zones"],
+            parameters=self.inputs["parameters"],
+            first_leg_travel_costs=first_leg_variant,
+            last_leg_travel_costs=last_leg_variant,
+            first_leg_mode_name=self.first_leg_mode_name,
+            last_leg_mode_name=self.last_leg_mode_name,
+            first_modal_transfer=self.inputs["first_modal_transfer"],
+            last_modal_transfer=self.inputs["last_modal_transfer"],
+        )
+
+    def remove_congestion_artifacts(self, congestion_state) -> None:
+        """Remove PT-owned congestion-specific variants without touching leg-owned caches."""
+        variant = self.asset_for_congestion_state(congestion_state)
+        if variant is self:
+            return
+
+        variant.remove()
+        variant.inputs["intermodal_graph"].remove()
         
     def audit_gtfs(self):
+        """Expose GTFS audit information from the intermodal graph."""
         return self.inputs["intermodal_graph"].audit_gtfs()
+
+    @staticmethod
+    def _travel_costs_for_congestion_state(travel_costs: Any, congestion_state):
+        """Resolve one leg travel-cost asset for the requested congestion state."""
+        if isinstance(travel_costs, TravelCostsAsset) is False:
+            return travel_costs
+
+        variant = travel_costs.asset_for_congestion_state(congestion_state)
+        return travel_costs if variant is None else variant

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -12,8 +12,6 @@ from .parameters import Parameters
 from .results import RunResults
 from .run_state import RunState
 from mobility.transport.costs.transport_costs import TransportCosts
-from mobility.transport.costs.congestion_state import CongestionState
-from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities import Activity
 from mobility.activities.activity import resolve_activity_parameters
@@ -491,100 +489,27 @@ class Run(FileAsset):
     def remove(self) -> None:
         """Remove cached outputs and saved iteration artifacts for this run."""
         super().remove()
+        self._remove_run_iteration_artifacts()
+
+    def _remove_run_iteration_artifacts(self) -> None:
+        """Remove all iteration-derived artifacts for this run."""
+        self._remove_run_iteration_state_artifacts()
+        self._remove_run_iteration_congestion_artifacts()
+
+    def _remove_run_iteration_state_artifacts(self) -> None:
+        """Remove saved run iteration state folders."""
         Iterations(
             run_inputs_hash=self.inputs_hash,
             is_weekday=self.is_weekday,
             base_folder=self.cache_path["plan_steps"].parent,
         ).remove_all()
-        self._remove_run_owned_congestion_artifacts()
 
-    def _remove_run_owned_congestion_artifacts(self) -> None:
-        """Remove congestion snapshots and congestion-derived cost caches for this run."""
-        if self.transport_costs.has_enabled_congestion() is False:
-            return
-
-        update_interval = self.parameters.n_iter_per_cost_update
-        if update_interval == 0:
-            return
-
-        for completed_iteration in range(1, int(self.parameters.n_iterations) + 1):
-            if self.transport_costs.should_recompute_congested_costs(completed_iteration, update_interval) is False:
-                continue
-
-            next_transport_costs = self.transport_costs.for_iteration(completed_iteration + 1)
-            flow_assets_by_mode = {}
-            for mode in next_transport_costs.congestion_states._iter_congestion_enabled_modes():
-                mode_name = mode.inputs["parameters"].name
-                flow_asset = VehicleODFlowsAsset.from_inputs(
-                    run_key=self.inputs_hash,
-                    is_weekday=self.is_weekday,
-                    iteration=completed_iteration,
-                    mode_name=mode_name,
-                )
-                if flow_asset.cache_path.exists():
-                    flow_assets_by_mode[mode_name] = flow_asset
-
-            if not flow_assets_by_mode:
-                continue
-
-            congestion_state = CongestionState(
-                run_key=str(self.inputs_hash),
-                is_weekday=bool(self.is_weekday),
-                iteration=int(completed_iteration),
-                flow_assets_by_mode=flow_assets_by_mode,
-            )
-
-            self._remove_asset_if_possible(
-                next_transport_costs.asset_for_congestion_state(congestion_state)
-            )
-            for mode in next_transport_costs.modes:
-                self._remove_mode_congestion_variant_caches(
-                    mode.inputs.get("travel_costs"),
-                    congestion_state,
-                )
+    def _remove_run_iteration_congestion_artifacts(self) -> None:
+        """Remove congestion snapshots and congestion-derived caches for this run."""
+        for next_transport_costs, congestion_state, flow_assets_by_mode in (
+            self.transport_costs.iter_run_congestion_artifacts(self)
+        ):
+            next_transport_costs.remove_congestion_artifacts(congestion_state)
 
             for flow_asset in flow_assets_by_mode.values():
                 flow_asset.remove()
-
-    def _remove_mode_congestion_variant_caches(
-        self,
-        travel_costs,
-        congestion_state: CongestionState,
-    ) -> None:
-        """Remove one mode's congestion-derived travel-cost and graph caches."""
-        if travel_costs is None:
-            return
-
-        variant = travel_costs.asset_for_congestion_state(congestion_state)
-        self._remove_congestion_variant_artifact_tree(variant)
-
-    def _remove_congestion_variant_artifact_tree(self, variant) -> None:
-        """Remove a congestion-specific asset variant and its derived graph caches."""
-        if variant is None:
-            return
-
-        self._remove_asset_if_possible(variant)
-
-        inputs = getattr(variant, "inputs", {})
-
-        contracted_graph = inputs.get("contracted_path_graph")
-        if contracted_graph is not None:
-            self._remove_asset_if_possible(contracted_graph)
-            congested_graph = getattr(contracted_graph, "inputs", {}).get("congested_graph")
-            self._remove_asset_if_possible(congested_graph)
-
-        nested_travel_costs = inputs.get("car_travel_costs")
-        nested_flow_asset = inputs.get("road_flow_asset")
-        if (
-            nested_travel_costs is not None
-            and nested_flow_asset is not None
-            and hasattr(nested_travel_costs, "asset_for_flow_asset")
-        ):
-            nested_variant = nested_travel_costs.asset_for_flow_asset(nested_flow_asset)
-            self._remove_congestion_variant_artifact_tree(nested_variant)
-
-    @staticmethod
-    def _remove_asset_if_possible(asset) -> None:
-        """Remove one cache-bearing asset when the object supports it."""
-        if asset is not None and hasattr(asset, "remove"):
-            asset.remove()

--- a/tests/back/unit/domain/group_day_trips/test_004_remove_clears_congestion_variants.py
+++ b/tests/back/unit/domain/group_day_trips/test_004_remove_clears_congestion_variants.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
-from uuid import uuid4
 
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
 from mobility.trips.group_day_trips.core.run import Run
 
 
@@ -25,31 +25,69 @@ class _FlowAsset:
         self.cache_path.unlink(missing_ok=True)
 
 
-class _TravelCostsWithCongestionVariant:
+class _TravelCostsWithCongestionVariant(TravelCostsAsset):
     def __init__(self, variant):
         self.variant = variant
+        self.inputs = {}
 
     def asset_for_congestion_state(self, congestion_state):
         return self.variant
+
+    def remove_congestion_artifacts(self, congestion_state):
+        self.variant.remove()
+        contracted_graph = self.variant.inputs.get("contracted_path_graph")
+        if contracted_graph is not None:
+            contracted_graph.remove()
+            congested_graph = contracted_graph.inputs.get("congested_graph")
+            if congested_graph is not None:
+                congested_graph.remove()
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+    def get(self):
+        return None
+
+
+class _TravelCostsWithoutCongestionVariant(TravelCostsAsset):
+    def __init__(self):
+        self.inputs = {}
+        self.remove_calls = 0
+
+    def remove_congestion_artifacts(self, congestion_state):
+        self.remove_calls += 1
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+    def get(self):
+        return None
 
 
 class _TransportCostsWithCongestionVariants:
     def __init__(self, next_transport_costs):
         self.next_transport_costs = next_transport_costs
 
-    def has_enabled_congestion(self) -> bool:
-        return True
+    def iter_run_congestion_artifacts(self, run):
+        flow_asset = VehicleODFlowsAsset.from_inputs(
+            run_key=run.inputs_hash,
+            is_weekday=run.is_weekday,
+            iteration=1,
+            mode_name="car",
+        )
+        yield self.next_transport_costs, SimpleNamespace(iteration=1), {"car": flow_asset}
 
-    def should_recompute_congested_costs(self, iteration: int, update_interval: int) -> bool:
-        return True
 
-    def for_iteration(self, iteration: int):
-        return self.next_transport_costs
-
-
-def test_remove_run_owned_congestion_artifacts_clears_mode_variant_graph_chain(monkeypatch):
-    tmp_path = Path(".pytest-local-tmp") / "group-day-trips" / f"mobility-tests-{uuid4().hex}"
-    tmp_path.mkdir(parents=True, exist_ok=False)
+def test_remove_run_iteration_congestion_artifacts_clears_mode_variant_graph_chain(
+    monkeypatch,
+    tmp_path,
+):
     flow_path = tmp_path / "vehicle_od_flows_car.parquet"
     flow_path.write_text("stub", encoding="utf-8")
     flow_asset = _FlowAsset(flow_path)
@@ -70,11 +108,10 @@ def test_remove_run_owned_congestion_artifacts_clears_mode_variant_graph_chain(m
         }
     )
     next_transport_costs = SimpleNamespace(
-        modes=[car_mode],
         congestion_states=SimpleNamespace(
             _iter_congestion_enabled_modes=lambda: iter([car_mode])
         ),
-        asset_for_congestion_state=lambda congestion_state: combined_transport_costs_variant,
+        remove_congestion_artifacts=lambda congestion_state: combined_transport_costs_variant.remove(),
     )
 
     run = object.__new__(Run)
@@ -89,11 +126,66 @@ def test_remove_run_owned_congestion_artifacts_clears_mode_variant_graph_chain(m
         staticmethod(lambda **kwargs: flow_asset),
     )
 
-    run._remove_run_owned_congestion_artifacts()
+    original_remove = next_transport_costs.remove_congestion_artifacts
+
+    def remove_congestion_artifacts(congestion_state):
+        original_remove(congestion_state)
+        car_mode.inputs["travel_costs"].remove_congestion_artifacts(congestion_state)
+
+    next_transport_costs.remove_congestion_artifacts = remove_congestion_artifacts
+
+    run._remove_run_iteration_congestion_artifacts()
 
     assert combined_transport_costs_variant.remove_calls == 1
     assert travel_cost_variant.remove_calls == 1
     assert contracted_graph_variant.remove_calls == 1
     assert congested_graph_variant.remove_calls == 1
+    assert flow_asset.remove_calls == 1
+    assert flow_path.exists() is False
+
+
+def test_remove_run_iteration_congestion_artifacts_keeps_non_variant_mode_cleanup_shallow(
+    monkeypatch,
+    tmp_path,
+):
+    flow_path = tmp_path / "vehicle_od_flows_car.parquet"
+    flow_path.write_text("stub", encoding="utf-8")
+    flow_asset = _FlowAsset(flow_path)
+
+    combined_transport_costs_variant = _RemovableAsset()
+    travel_costs = _TravelCostsWithoutCongestionVariant()
+
+    car_mode = SimpleNamespace(
+        inputs={
+            "parameters": SimpleNamespace(name="car"),
+            "travel_costs": travel_costs,
+        }
+    )
+    next_transport_costs = SimpleNamespace(
+        congestion_states=SimpleNamespace(
+            _iter_congestion_enabled_modes=lambda: iter([car_mode])
+        ),
+        remove_congestion_artifacts=lambda congestion_state: (
+            combined_transport_costs_variant.remove(),
+            travel_costs.remove_congestion_artifacts(congestion_state),
+        ),
+    )
+
+    run = object.__new__(Run)
+    run.inputs_hash = "run-key"
+    run.is_weekday = True
+    run.parameters = SimpleNamespace(n_iter_per_cost_update=1, n_iterations=1)
+    run.transport_costs = _TransportCostsWithCongestionVariants(next_transport_costs)
+
+    monkeypatch.setattr(
+        VehicleODFlowsAsset,
+        "from_inputs",
+        staticmethod(lambda **kwargs: flow_asset),
+    )
+
+    run._remove_run_iteration_congestion_artifacts()
+
+    assert combined_transport_costs_variant.remove_calls == 1
+    assert travel_costs.remove_calls == 1
     assert flow_asset.remove_calls == 1
     assert flow_path.exists() is False


### PR DESCRIPTION
### Motivation
Fix a failure during `PopulationGroupDayTrips.remove()` when congestion cleanup reaches `PublicTransportTravelCosts`, and simplify the ownership of congestion-derived cleanup.

### Changes
- Fix run removal so PT travel costs no longer trigger `AttributeError` during congestion cleanup
- Move congestion-variant cleanup ownership out of `Run` and into transport-cost assets
- Add a shared transport-domain base for per-mode travel-cost congestion cleanup
- Make `PublicTransportTravelCosts` congestion-aware and keep its cleanup limited to PT-owned artifacts
- Simplify run iteration cleanup structure and delegate congestion artifact discovery to `TransportCosts`
- Narrow PT/intermodal constructor inputs to leg travel-cost assets and leg mode names
- Add targeted regression coverage for the cleanup path

### Example (if relevant)
Before:
`PopulationGroupDayTrips.remove()` could fail with:
`AttributeError: 'PublicTransportTravelCosts' object has no attribute 'asset_for_congestion_state'`

After:
run removal cleans up congestion-derived artifacts without assuming all mode travel-cost assets share the same implementation details.

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
  Refactoring congestion cleanup ownership, updating PT/intermodal boundaries, and drafting regression-oriented tests/comments.
- What you reviewed or changed:
  Reviewed the generated refactor, adjusted the class boundaries, removed the PT proxy approach that was proposed, and simplified run cleanup structure.
- How you validated it (tests, checks, manual verification): ran unit tests, tested on an actual case study.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior