### PR TITLE
Fix last "go home" trip bug

### DIFF
--- a/mobility/surveys/survey_plan_steps.py
+++ b/mobility/surveys/survey_plan_steps.py
@@ -46,7 +46,7 @@ class MobilitySurveyPlanSteps(FileAsset):
         )
         cache_path = folder_path / "group_day_trip_plan_steps.parquet"
         inputs = {
-            "version": 2,
+            "version": 3,
             "survey": survey,
             "activities": activities,
             "modes": modes,
@@ -157,9 +157,9 @@ class MobilitySurveyPlanSteps(FileAsset):
             )
             .with_columns(activity=pl.col("motive").cast(pl.Utf8).replace_strict(activity_mapping, default="other"))
             .with_columns(mode=pl.col("mode_id").cast(pl.Utf8).replace_strict(mode_mapping, default="other"))
-            .with_columns(max_seq_step_index=pl.col("seq_step_index").max().over(["individual_id", "day_id"]))
-            .filter(pl.col("max_seq_step_index") < 11)
+            .filter(pl.col("seq_step_index") < 11)
             .filter((pl.col("departure_time") < 24.0) & (pl.col("arrival_time") < 24.0))
+            .with_columns(max_seq_step_index=pl.col("seq_step_index").max().over(["individual_id", "day_id"]))
             .with_columns(
                 activity=pl.when(
                     (pl.col("seq_step_index") == pl.col("max_seq_step_index")) & (pl.col("activity") != "home")

--- a/tests/back/unit/test_013_mobility_survey_plans.py
+++ b/tests/back/unit/test_013_mobility_survey_plans.py
@@ -105,3 +105,52 @@ def test_survey_plan_assets_return_weighted_step_level_plans():
     assert plan_steps["plan_weight_mass"].to_list() == [4.0, 4.0]
     assert plans["p_plan"].to_list() == [1.0]
     assert "plan_weight_mass" not in plans.columns
+
+
+def test_survey_plan_steps_truncate_to_ten_trips_then_force_last_trip_home():
+    survey = _StubSurvey(
+        {
+            "days_trip": pd.DataFrame(
+                {
+                    "day_id": [10, 20],
+                    "day_of_week": [1, 2],
+                    "pondki": [1.0, 1.0],
+                    "city_category": ["urban", "urban"],
+                    "csp": ["A", "A"],
+                    "n_cars": [1, 1],
+                }
+            ),
+            "short_trips": pd.DataFrame(
+                {
+                    "day_id": [10] * 12 + [20] * 2,
+                    "individual_id": [1] * 12 + [2] * 2,
+                    "daily_trip_index": list(range(1, 13)) + [1, 2],
+                    "departure_time": [i * 3600 for i in range(12)] + [8 * 3600, 17 * 3600],
+                    "arrival_time": [(i + 0.5) * 3600 for i in range(12)] + [9 * 3600, 18 * 3600],
+                    "motive": ["1"] * 12 + ["1", "1"],
+                    "mode_id": ["car"] * 14,
+                    "distance": [10.0] * 14,
+                }
+            ),
+        }
+    )
+
+    activities = [
+        _make_activity("work", ["1"]),
+        _make_activity("home", ["2"]),
+    ]
+    modes = [_make_mode("car", ["car"])]
+
+    plan_steps_asset = MobilitySurveyPlanSteps(survey=survey, activities=activities, modes=modes)
+    plan_steps = plan_steps_asset._prepare_survey_plans()
+
+    truncated_day = plan_steps.filter(pl.col("day_id") == 10).sort("seq_step_index")
+    short_day = plan_steps.filter(pl.col("day_id") == 20).sort("seq_step_index")
+
+    assert truncated_day["seq_step_index"].to_list() == list(range(1, 11))
+    assert truncated_day["activity"].to_list() == ["work"] * 9 + ["home"]
+    assert truncated_day["max_seq_step_index"].to_list() == [10] * 10
+
+    assert short_day["seq_step_index"].to_list() == [1, 2]
+    assert short_day["activity"].to_list() == ["work", "home"]
+    assert short_day["max_seq_step_index"].to_list() == [2, 2]


### PR DESCRIPTION
### Motivation

Fixes https://github.com/mobility-team/mobility/issues/309.

Survey plans are limited to 10 trips per day, but the last-trip-to-`home` correction was using the pre-truncation last trip index. For days with more than 10 trips, that could leave the truncated plan without a final return-home trip.

### Changes

This PR updates `MobilitySurveyPlanSteps._prepare_survey_plans()` so plans are first truncated to the first 10 trips, then the last kept trip is recomputed and forced to `home` if needed.

It also bumps the asset version from `2` to `3` so cached outputs are rebuilt with the corrected behavior.

A regression test was added to cover:
- a day with more than 10 trips, which should now be truncated and still end at `home`
- a shorter day that does not end at `home`, which should still be corrected

### Example (if relevant)

No API change. Truncated survey plans now consistently end at `home`.

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: added regression tests.
- What you reviewed or changed: reviewed the tests, no change needed.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest tests/back/unit/test_013_mobility_survey_plans.py --local`

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior