### PR TITLE
Add SurveyPlanAssets

### DIFF
--- a/mobility/surveys/__init__.py
+++ b/mobility/surveys/__init__.py
@@ -1,5 +1,6 @@
 from .mobility_survey import MobilitySurvey
 from .aggregator import MobilitySurveyAggregator
+from .survey_plan_assets import SurveyPlanAssets
 from .survey_plans import MobilitySurveyPlans
 from .survey_plan_steps import MobilitySurveyPlanSteps
 from .survey_plan_summaries import MobilitySurveyPlanSummaries

--- a/mobility/surveys/survey_plan_assets.py
+++ b/mobility/surveys/survey_plan_assets.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+
+from .survey_plan_steps import MobilitySurveyPlanSteps
+from .survey_plans import MobilitySurveyPlans
+from .survey_plan_summaries import MobilitySurveyPlanSummaries
+
+
+class SurveyPlanAssets(InMemoryAsset):
+    """Merge several per-survey plan assets behind one lazy in-memory interface."""
+
+    def __init__(
+        self,
+        *,
+        surveys: list[Any],
+        activities: list[Any],
+        modes: list[Any],
+    ) -> None:
+        self._plan_steps = None
+        self._plans = None
+        self._summary_tables = None
+        self._mean_activity_durations = None
+        self._mean_home_night_durations = None
+        self._activity_demand_per_pers = None
+        per_survey_assets = []
+        for survey in surveys:
+            plan_steps = MobilitySurveyPlanSteps(
+                survey=survey,
+                activities=activities,
+                modes=modes,
+            )
+            plans = MobilitySurveyPlans(plan_steps=plan_steps)
+            summaries = MobilitySurveyPlanSummaries(
+                plans=plans,
+                plan_steps=plan_steps,
+            )
+            per_survey_assets.append(
+                {
+                    "survey": survey,
+                    "plan_steps": plan_steps,
+                    "plans": plans,
+                    "summaries": summaries,
+                }
+            )
+
+        inputs = {
+            "version": 1,
+            "surveys": surveys,
+            "activities": activities,
+            "modes": modes,
+            "per_survey_assets": per_survey_assets,
+        }
+        super().__init__(inputs)
+
+    def _get_per_survey_assets(self) -> list[dict[str, Any]]:
+        """Return the per-survey asset sets owned by this merged wrapper."""
+        return self.inputs["per_survey_assets"]
+
+    @staticmethod
+    def _concat_frames(frames: list[pl.DataFrame]) -> pl.DataFrame:
+        """Concatenate frames while tolerating an empty survey list."""
+        if not frames:
+            return pl.DataFrame()
+        return pl.concat(frames, how="vertical_relaxed")
+
+    def _get_cached_merged_table(
+        self,
+        name: str,
+        frames: list[pl.DataFrame],
+    ) -> pl.DataFrame:
+        """Cache and return one merged dataframe built from per-survey tables."""
+        cache_attr = f"_{name}"
+        value = getattr(self, cache_attr)
+        if value is None:
+            value = self._concat_frames(frames)
+            setattr(self, cache_attr, value)
+        return value
+
+    def _get_summary_tables(self) -> list[dict[str, pl.DataFrame]]:
+        """Load and cache the per-survey summary mappings once."""
+        if self._summary_tables is None:
+            self._summary_tables = [
+                assets["summaries"].get()
+                for assets in self._get_per_survey_assets()
+            ]
+        return self._summary_tables
+
+    def _get_merged_asset_table(self, name: str) -> pl.DataFrame:
+        """Merge and cache one table loaded directly from a per-survey asset."""
+        return self._get_cached_merged_table(
+            name,
+            [assets[name].get() for assets in self._get_per_survey_assets()],
+        )
+
+    def _get_merged_summary_table(self, name: str) -> pl.DataFrame:
+        """Merge and cache one table extracted from per-survey summaries."""
+        return self._get_cached_merged_table(
+            name,
+            [tables[name] for tables in self._get_summary_tables()],
+        )
+
+    def get_plan_steps(self) -> pl.DataFrame:
+        """Return merged step-level survey plans."""
+        return self._get_merged_asset_table("plan_steps")
+
+    def get_plans(self) -> pl.DataFrame:
+        """Return merged plan-level survey probabilities."""
+        return self._get_merged_asset_table("plans")
+
+    def get_mean_activity_durations(self) -> pl.DataFrame:
+        """Return merged mean activity-duration summaries."""
+        return self._get_merged_summary_table("mean_activity_durations")
+
+    def get_mean_home_night_durations(self) -> pl.DataFrame:
+        """Return merged mean home-night-duration summaries."""
+        return self._get_merged_summary_table("mean_home_night_durations")
+
+    def get_activity_demand_per_pers(self) -> pl.DataFrame:
+        """Return merged per-person activity-demand summaries."""
+        return self._get_merged_summary_table("activity_demand_per_pers")
+
+    def get(self) -> dict[str, pl.DataFrame]:
+        """SurveyPlanAssets has no single canonical value.
+
+        Callers should request the specific merged table they need through the
+        explicit getters on this class.
+        """
+        raise NotImplementedError(
+            "SurveyPlanAssets has no single canonical `get()` value. "
+            "Use one of: `get_plan_steps()`, `get_plans()`, "
+            "`get_mean_activity_durations()`, `get_mean_home_night_durations()`, "
+            "or `get_activity_demand_per_pers()`."
+        )

--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -1,3 +1,5 @@
+import warnings
+
 import polars as pl
 from typing import Dict, List
 
@@ -6,6 +8,7 @@ from mobility.transport.costs.transport_costs import TransportCosts
 from .parameters import BehaviorChangePhase, Parameters
 from .run import Run
 from mobility.activities import Activity, HomeActivity, OtherActivity
+from mobility.surveys import SurveyPlanAssets
 from mobility.surveys.mobility_survey import MobilitySurvey
 from mobility.population import Population
 from mobility.transport.modes.core.transport_mode import TransportMode
@@ -156,13 +159,20 @@ class PopulationGroupDayTrips:
         )
 
         transport_costs = TransportCosts(modes)
+        selected_surveys = self._select_surveys_for_population(population, surveys)
+        survey_plan_assets = SurveyPlanAssets(
+            surveys=selected_surveys,
+            activities=activities,
+            modes=modes,
+        )
 
         weekday_run = Run(
             population=population,
             transport_costs=transport_costs,
             activities=activities,
             modes=modes,
-            surveys=surveys,
+            surveys=selected_surveys,
+            survey_plan_assets=survey_plan_assets,
             parameters=parameters,
             is_weekday=True,
             enabled=True,
@@ -173,12 +183,14 @@ class PopulationGroupDayTrips:
             transport_costs=transport_costs,
             activities=activities,
             modes=modes,
-            surveys=surveys,
+            surveys=selected_surveys,
+            survey_plan_assets=survey_plan_assets,
             parameters=parameters,
             is_weekday=False,
             enabled=parameters.simulate_weekend,
         )
 
+        self.survey_plan_assets = survey_plan_assets
         self.weekday_run = weekday_run
         self.weekend_run = weekend_run
 
@@ -294,6 +306,54 @@ class PopulationGroupDayTrips:
                     "PopulationGroupDayTrips surveys argument should be a list of `MobilitySurvey` "
                     f"instances, but received one object of class {type(survey)}."
                 )
+
+    def _get_population_countries(self, population: Population) -> list[str]:
+        """Infer population countries from the study-area admin prefixes."""
+        study_area = population.transport_zones.study_area.get()
+        if "geometry" in study_area.columns:
+            study_area = study_area.drop("geometry", axis=1)
+        return (
+            pl.from_pandas(study_area[["local_admin_unit_id"]])
+            .with_columns(country=pl.col("local_admin_unit_id").str.slice(0, 2))
+            .get_column("country")
+            .unique()
+            .sort()
+            .to_list()
+        )
+
+    def _select_surveys_for_population(
+        self,
+        population: Population,
+        surveys: list[MobilitySurvey],
+    ) -> list[MobilitySurvey]:
+        """Validate survey coverage against the population and keep relevant surveys."""
+        population_countries = set(self._get_population_countries(population))
+        surveys_by_country: dict[str, list[MobilitySurvey]] = {}
+        for survey in surveys:
+            surveys_by_country.setdefault(survey.inputs["parameters"].country, []).append(survey)
+
+        survey_countries = set(surveys_by_country)
+        missing_countries = sorted(population_countries - survey_countries)
+        if missing_countries:
+            raise ValueError(
+                "PopulationGroupDayTrips requires at least one survey for each population country. "
+                f"Missing survey coverage for: {', '.join(missing_countries)}. "
+                f"Provided survey countries: {', '.join(sorted(survey_countries))}."
+            )
+
+        unused_countries = sorted(survey_countries - population_countries)
+        if unused_countries:
+            warnings.warn(
+                "Some provided surveys will not be used because their countries are absent from the population: "
+                + ", ".join(unused_countries)
+                + ".",
+                stacklevel=2,
+            )
+
+        selected_surveys: list[MobilitySurvey] = []
+        for country in sorted(population_countries):
+            selected_surveys.extend(surveys_by_country[country])
+        return selected_surveys
 
     def _build_cache_path(self) -> Dict[str, str]:
         """Expose child run cache paths through the wrapper keys.

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -18,6 +18,7 @@ from mobility.transport.costs.transport_costs import TransportCosts
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities import Activity
 from mobility.activities.activity import resolve_activity_parameters
+from mobility.surveys import SurveyPlanAssets
 from mobility.surveys.mobility_survey import MobilitySurvey
 from mobility.population import Population
 from mobility.transport.modes.core.transport_mode import TransportMode
@@ -34,17 +35,19 @@ class Run(FileAsset):
         activities: List[Activity],
         modes: List[TransportMode],
         surveys: List[MobilitySurvey],
+        survey_plan_assets: SurveyPlanAssets,
         parameters: Parameters,
         is_weekday: bool,
         enabled: bool = True,
     ) -> None:
         """Initialize a single weekday or weekend PopulationGroupDayTrips run."""
         inputs = {
-            "version": 7,
+            "version": 9,
             "population": population,
             "activities": activities,
             "modes": modes,
             "surveys": surveys,
+            "survey_plan_assets": survey_plan_assets,
             "parameters": parameters,
             "is_weekday": is_weekday,
             "enabled": enabled,
@@ -161,15 +164,11 @@ class Run(FileAsset):
         """Build the initial mutable state and restore it when resuming."""
         survey_plans, survey_plan_steps, demand_groups = self.initializer.get_survey_plan_data(
             self.population,
-            self.surveys,
-            self.activities,
-            self.modes,
+            self.survey_plan_assets,
             self.is_weekday,
         )
         activity_dur, home_night_dur, activity_demand_per_pers = self.initializer.get_survey_duration_summaries(
-            self.surveys,
-            self.activities,
-            self.modes,
+            self.survey_plan_assets,
             self.is_weekday,
             demand_groups,
             survey_plan_steps,
@@ -542,9 +541,7 @@ class Run(FileAsset):
 
         population_weighted_plan_steps = PopulationWeightedPlanSteps(
             population=self.population,
-            surveys=self.surveys,
-            activities=self.activities,
-            modes=self.modes,
+            survey_plan_assets=self.survey_plan_assets,
             is_weekday=self.is_weekday,
         ).get()
 

--- a/mobility/trips/group_day_trips/evaluation/population_weighted_plan_steps.py
+++ b/mobility/trips/group_day_trips/evaluation/population_weighted_plan_steps.py
@@ -7,8 +7,7 @@ from typing import Any
 import polars as pl
 
 from mobility.runtime.assets.file_asset import FileAsset
-from mobility.surveys.survey_plan_steps import MobilitySurveyPlanSteps
-from mobility.surveys.survey_plans import MobilitySurveyPlans
+from mobility.surveys import SurveyPlanAssets
 
 
 class PopulationWeightedPlanSteps(FileAsset):
@@ -18,15 +17,11 @@ class PopulationWeightedPlanSteps(FileAsset):
         self,
         *,
         population: Any,
-        surveys: list[Any],
-        activities: list[Any],
-        modes: list[Any],
+        survey_plan_assets: SurveyPlanAssets,
         is_weekday: bool,
     ) -> None:
         self.population = population
-        self.surveys = surveys
-        self.activities = activities
-        self.modes = modes
+        self.survey_plan_assets = survey_plan_assets
         self.is_weekday = is_weekday
         project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
         cache_path = (
@@ -35,11 +30,9 @@ class PopulationWeightedPlanSteps(FileAsset):
             / f"population_weighted_plan_steps_{'weekday' if is_weekday else 'weekend'}.parquet"
         )
         inputs = {
-            "version": 3,
+            "version": 4,
             "population": population,
-            "surveys": surveys,
-            "activities": activities,
-            "modes": modes,
+            "survey_plan_assets": survey_plan_assets,
             "is_weekday": is_weekday,
         }
         super().__init__(inputs, cache_path)
@@ -58,7 +51,6 @@ class PopulationWeightedPlanSteps(FileAsset):
             ).with_columns(country=pl.col("local_admin_unit_id").str.slice(0, 2))
         )
 
-        countries = lau_to_city_cat["country"].unique().to_list()
         demand_groups = (
             pl.scan_parquet(self.population.get()["population_groups"])
             .rename(
@@ -75,24 +67,8 @@ class PopulationWeightedPlanSteps(FileAsset):
             .collect(engine="streaming")
         )
 
-        surveys = [s for s in self.surveys if s.inputs["parameters"].country in countries]
-        survey_plan_step_assets = [
-            MobilitySurveyPlanSteps(
-                survey=survey,
-                activities=self.activities,
-                modes=self.modes,
-            )
-            for survey in surveys
-        ]
-        survey_plan_assets = [
-            MobilitySurveyPlans(plan_steps=plan_steps_asset)
-            for plan_steps_asset in survey_plan_step_assets
-        ]
-
-        survey_plan_steps = pl.concat(
-            [plan_steps_asset.get() for plan_steps_asset in survey_plan_step_assets],
-            how="vertical_relaxed",
-        ).select(
+        countries = demand_groups["country"].unique().sort().to_list()
+        survey_plan_steps = self.survey_plan_assets.get_plan_steps().select(
             [
                 "activity_seq_id",
                 "time_seq_id",
@@ -103,10 +79,7 @@ class PopulationWeightedPlanSteps(FileAsset):
                 "distance",
             ]
         )
-        survey_plans = pl.concat(
-            [plan_asset.get() for plan_asset in survey_plan_assets],
-            how="vertical_relaxed",
-        ).select(
+        survey_plans = self.survey_plan_assets.get_plans().select(
             [
                 "country",
                 "activity_seq_id",

--- a/mobility/trips/group_day_trips/plans/plan_initializer.py
+++ b/mobility/trips/group_day_trips/plans/plan_initializer.py
@@ -3,9 +3,7 @@ import math
 import polars as pl
 
 from mobility.activities.activity import ActivityParameters
-from mobility.surveys.survey_plan_steps import MobilitySurveyPlanSteps
-from mobility.surveys.survey_plans import MobilitySurveyPlans
-from mobility.surveys.survey_plan_summaries import MobilitySurveyPlanSummaries
+from mobility.surveys import SurveyPlanAssets
 from mobility.transport.modes.core.mode_values import get_mode_values
 from .plan_ids import add_plan_id
 
@@ -19,7 +17,7 @@ class PlanInitializer:
     and (5) fetch current OD costs.
     """
 
-    def get_survey_plan_data(self, population, surveys, activities, modes, is_weekday):
+    def get_survey_plan_data(self, population, survey_plan_assets: SurveyPlanAssets, is_weekday):
         """Build runtime survey plan inputs from survey assets and demand groups."""
 
         lau_to_city_cat = (
@@ -29,8 +27,6 @@ class PlanInitializer:
                 .rename({"urban_unit_category": "city_category"}, axis=1)
             ).with_columns(country=pl.col("local_admin_unit_id").str.slice(0, 2))
         )
-
-        countries = lau_to_city_cat["country"].unique().to_list()
 
         demand_groups = (
             pl.scan_parquet(population.get()["population_groups"])
@@ -48,24 +44,8 @@ class PlanInitializer:
             .collect(engine="streaming")
         )
 
-        surveys = [s for s in surveys if s.inputs["parameters"].country in countries]
-
-        survey_plan_step_assets = [
-            MobilitySurveyPlanSteps(
-                survey=survey,
-                activities=activities,
-                modes=modes,
-            )
-            for survey in surveys
-        ]
-        survey_plan_assets = [
-            MobilitySurveyPlans(plan_steps=plan_steps_asset)
-            for plan_steps_asset in survey_plan_step_assets
-        ]
-        survey_plan_steps = pl.concat(
-            [plan_steps_asset.get() for plan_steps_asset in survey_plan_step_assets],
-            how="vertical_relaxed",
-        ).select(
+        countries = demand_groups["country"].unique().sort().to_list()
+        survey_plan_steps = survey_plan_assets.get_plan_steps().select(
             [
                 "activity_seq_id",
                 "time_seq_id",
@@ -78,10 +58,7 @@ class PlanInitializer:
                 "duration_per_pers",
             ]
         )
-        survey_plans = pl.concat(
-            [plan_asset.get() for plan_asset in survey_plan_assets],
-            how="vertical_relaxed",
-        ).select(
+        survey_plans = survey_plan_assets.get_plans().select(
             [
                 "country",
                 "activity_seq_id",
@@ -93,6 +70,7 @@ class PlanInitializer:
                 "p_plan",
             ]
         )
+
         def get_col_values(df1, df2, col):
             s = pl.concat([df1.select(col), df2.select(col)]).to_series()
             return s.unique().sort().to_list()
@@ -188,57 +166,27 @@ class PlanInitializer:
 
     def get_survey_duration_summaries(
         self,
-        surveys,
-        activities,
-        modes,
+        survey_plan_assets: SurveyPlanAssets,
         is_weekday,
         demand_groups: pl.DataFrame,
         survey_plan_steps: pl.DataFrame,
     ):
         """Load precomputed survey-weighted summaries for one day type."""
 
-        summary_assets = [
-            MobilitySurveyPlanSummaries(
-                plans=MobilitySurveyPlans(
-                    plan_steps=MobilitySurveyPlanSteps(
-                        survey=survey,
-                        activities=activities,
-                        modes=modes,
-                    )
-                ),
-                plan_steps=MobilitySurveyPlanSteps(
-                    survey=survey,
-                    activities=activities,
-                    modes=modes,
-                ),
-            )
-            for survey in surveys
-        ]
-        summary_tables = [summary_asset.get() for summary_asset in summary_assets]
-
         mean_activity_durations = (
-            pl.concat(
-                [tables["mean_activity_durations"] for tables in summary_tables],
-                how="vertical_relaxed",
-            )
+            survey_plan_assets.get_mean_activity_durations()
             .filter(pl.col("is_weekday") == is_weekday)
             .drop("is_weekday")
         )
 
         mean_home_night_durations = (
-            pl.concat(
-                [tables["mean_home_night_durations"] for tables in summary_tables],
-                how="vertical_relaxed",
-            )
+            survey_plan_assets.get_mean_home_night_durations()
             .filter(pl.col("is_weekday") == is_weekday)
             .drop("is_weekday")
         )
 
         activity_demand_per_pers = (
-            pl.concat(
-                [tables["activity_demand_per_pers"] for tables in summary_tables],
-                how="vertical_relaxed",
-            )
+            survey_plan_assets.get_activity_demand_per_pers()
             .filter(pl.col("is_weekday") == is_weekday)
             .drop("is_weekday")
         )

--- a/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
+++ b/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
@@ -1,15 +1,20 @@
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
+
+import pandas as pd
+import pytest
 
 from mobility.trips.group_day_trips import BehaviorChangePhase, BehaviorChangeScope, PopulationGroupDayTrips
 from mobility.trips.group_day_trips.core import group_day_trips as group_day_trips_module
 
 
 class _FakeRun:
-    def __init__(self, *, parameters, is_weekday, enabled, **kwargs):
+    def __init__(self, *, parameters, is_weekday, enabled, survey_plan_assets, **kwargs):
         self.parameters = parameters
         self.is_weekday = is_weekday
         self.enabled = enabled
+        self.survey_plan_assets = survey_plan_assets
         base = Path("cache") / ("weekday" if is_weekday else "weekend")
         self.cache_path = {
             "plan_steps": base / "plan_steps.parquet",
@@ -21,18 +26,38 @@ class _FakeRun:
         }
 
 
+class _FakeSurveyPlanAssets:
+    def __init__(self, *, surveys, activities, modes):
+        self.surveys = surveys
+        self.activities = activities
+        self.modes = modes
+
+
+class _FakeSurvey:
+    def __init__(self, country: str):
+        self.inputs = {"parameters": SimpleNamespace(country=country)}
+
+
+def _make_population(*countries: str):
+    rows = [{"local_admin_unit_id": f"{country}001"} for country in countries]
+    study_area = SimpleNamespace(get=lambda: pd.DataFrame(rows))
+    transport_zones = SimpleNamespace(study_area=study_area)
+    return SimpleNamespace(transport_zones=transport_zones)
+
+
 def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
     monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
     monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
 
     wrapper = PopulationGroupDayTrips(
-        population=object(),
+        population=_make_population("fr"),
         modes=[object()],
         activities=[object()],
-        surveys=[object()],
+        surveys=[_FakeSurvey("fr")],
         n_iterations=4,
         k_activity_sequences=5,
         k_destination_sequences=6,
@@ -66,4 +91,46 @@ def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
     assert parameters.behavior_change_phases == [
         BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING)
     ]
+    assert wrapper.weekday_run.survey_plan_assets is wrapper.weekend_run.survey_plan_assets
+    assert wrapper.survey_plan_assets is wrapper.weekday_run.survey_plan_assets
+    assert wrapper.survey_plan_assets.surveys == wrapper.weekday_run.survey_plan_assets.surveys
     assert wrapper.weekend_run.enabled is False
+
+
+def test_group_day_trips_wrapper_raises_when_population_country_has_no_matching_survey(monkeypatch):
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
+    monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
+    monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
+
+    with pytest.raises(ValueError, match="Missing survey coverage for: be"):
+        PopulationGroupDayTrips(
+            population=_make_population("fr", "be"),
+            modes=[object()],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr")],
+        )
+
+
+def test_group_day_trips_wrapper_warns_when_some_surveys_will_not_be_used(monkeypatch):
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
+    monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
+    monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        wrapper = PopulationGroupDayTrips(
+            population=_make_population("fr"),
+            modes=[object()],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr"), _FakeSurvey("be")],
+        )
+
+    assert len(caught) == 1
+    assert "will not be used" in str(caught[0].message)
+    assert [survey.inputs["parameters"].country for survey in wrapper.survey_plan_assets.surveys] == ["fr"]


### PR DESCRIPTION
### Motivation
This PR cleans up how grouped day trips accesses survey-derived plan data, to address https://github.com/mobility-team/mobility/issues/311.

`MobilitySurveyPlanSteps`, `MobilitySurveyPlans`, and `MobilitySurveyPlanSummaries` had become reusable assets, but the grouped day-trips stack was still reconstructing and concatenating them in several downstream places. That made inspection harder, duplicated merge logic, and let survey/population mismatches surface too late.

### Changes
- Added `SurveyPlanAssets` as a merged `InMemoryAsset` over the per-survey plan assets.
- Moved survey-plan asset ownership up to `PopulationGroupDayTrips`, so weekday and weekend runs share the same upstream survey asset object.
- Added early survey/population reconciliation in `PopulationGroupDayTrips`:
  - fail if a population country has no matching survey
  - warn if a provided survey will not be used
- Simplified downstream grouped day-trips consumers:
  - `Run` now receives one `SurveyPlanAssets`
  - `PlanInitializer` reads merged survey tables from that asset
  - `PopulationWeightedPlanSteps` reads merged survey tables from that asset
- Updated focused unit coverage for:
  - missing survey coverage error
  - unused survey warning
  - survey plan asset behavior

### Example
To load the survey plans steps used by a model run, we can now use : 
```
pop_group_day_trips.weekday_run.survey_plan_assets.get_plan_steps()
```
The list of getters is : 
- `get_plan_steps()`
- `get_plans()`
- `get_mean_activity_durations()`
- `get_mean_home_night_durations()`
- `get_activity_demand_per_pers()`

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
  Refactoring grouped day-trips survey asset ownership, introducing `SurveyPlanAssets`, simplifying downstream consumers, and drafting/update of focused tests.
- What you reviewed or changed:
  I reviewed the resulting architecture, simplified the API further, tightened documentation, removed unnecessary generic paths, and refined the warning/error behavior for survey coverage.
- How you validated it (tests, checks, manual verification):
  ran focused unit tests with  `mamba run -n mobility python -m pytest --local tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py tests/back/unit/test_013_mobility_survey_plans.py`

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior