### PR TITLE
Update activities duration when travel times change because of congestion

### DIFF
--- a/mobility/activities/activity.py
+++ b/mobility/activities/activity.py
@@ -201,6 +201,19 @@ class ActivityParameters(BaseModel):
         ),
     ]
 
+    arrival_time_rigidity: Annotated[
+        UnitIntervalFloat | ScalarParameterProfile | None,
+        Field(
+            default=None,
+            title="Arrival time rigidity",
+            description=(
+                "Share of a travel-time change absorbed on the departure side "
+                "for trips ending at this activity. `0` keeps departure fixed, "
+                "`1` keeps arrival fixed, intermediate values split the shift."
+            ),
+        ),
+    ]
+
 
 def resolve_activity_parameters(
     activities: list[Activity],
@@ -212,3 +225,20 @@ def resolve_activity_parameters(
         activity.name: activity.get_parameters_for_iteration(iteration)
         for activity in activities
     }
+
+
+def resolve_activity_arrival_time_rigidity(
+    activities: list[Activity],
+    iteration: int,
+) -> dict[str, float]:
+    """Resolve per-activity arrival-time rigidity with anchor-based defaults."""
+
+    rigidity_by_activity: dict[str, float] = {}
+    for activity in activities:
+        parameters = activity.get_parameters_for_iteration(iteration)
+        rigidity = parameters.arrival_time_rigidity
+        if rigidity is None:
+            rigidity = 1.0 if activity.is_anchor else 0.0
+        rigidity_by_activity[activity.name] = float(rigidity)
+
+    return rigidity_by_activity

--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -40,6 +40,7 @@ class PopulationGroupDayTrips:
         save_transition_events: bool = None,
         persist_iteration_artifacts: bool = None,
         min_activity_time_constant: float = None,
+        update_plan_timings_from_modeled_travel_times: bool = None,
         transition_distance_threshold: float = None,
         enable_transition_distance_model: bool = None,
         transition_revision_probability: float = None,
@@ -100,6 +101,8 @@ class PopulationGroupDayTrips:
                 `Parameters.persist_iteration_artifacts`.
             min_activity_time_constant: Optional override for
                 `Parameters.min_activity_time_constant`.
+            update_plan_timings_from_modeled_travel_times: Optional override for
+                `Parameters.update_plan_timings_from_modeled_travel_times`.
             transition_distance_threshold: Optional override for
                 `Parameters.transition_distance_threshold`.
             enable_transition_distance_model: Optional override for
@@ -149,6 +152,7 @@ class PopulationGroupDayTrips:
                 "save_transition_events": save_transition_events,
                 "persist_iteration_artifacts": persist_iteration_artifacts,
                 "min_activity_time_constant": min_activity_time_constant,
+                "update_plan_timings_from_modeled_travel_times": update_plan_timings_from_modeled_travel_times,
                 "transition_distance_threshold": transition_distance_threshold,
                 "enable_transition_distance_model": enable_transition_distance_model,
                 "transition_revision_probability": transition_revision_probability,

--- a/mobility/trips/group_day_trips/core/parameters.py
+++ b/mobility/trips/group_day_trips/core/parameters.py
@@ -296,6 +296,19 @@ class Parameters(BaseModel):
         ),
     ]
 
+    update_plan_timings_from_modeled_travel_times: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Update plan timings from modeled travel times",
+            description=(
+                "Whether to adjust candidate-plan departure, arrival, and activity "
+                "times from survey reference schedules using the modeled travel "
+                "times at each iteration before recomputing utilities."
+            ),
+        ),
+    ]
+
     transition_distance_threshold: Annotated[
         float,
         Field(

--- a/mobility/trips/group_day_trips/core/results.py
+++ b/mobility/trips/group_day_trips/core/results.py
@@ -55,6 +55,7 @@ class RunResults:
         self.metrics_methods = {
             "global_metrics": self.global_metrics,
             "metrics_by_variable": self.metrics_by_variable,
+            "activity_time_series": self.activity_time_series,
             "opportunity_occupation": self.opportunity_occupation,
             "sink_occupation": self.opportunity_occupation,
             "state_waterfall": self.state_waterfall,
@@ -320,6 +321,150 @@ class RunResults:
             fig.show("browser")
 
         return immobility
+
+    def activity_time_series(self, interval_minutes: int = 15, plot: bool = False) -> pl.DataFrame:
+        """Aggregate average occupancy by activity and in-transit mode over time bins."""
+        time_series = self._activity_time_series_raw(interval_minutes=interval_minutes)
+        total_population = (
+            self.demand_groups
+            .select(pl.col("n_persons").sum().alias("total_population"))
+            .collect(engine="streaming")
+            .item()
+        )
+        bin_duration_hours = interval_minutes / 60.0
+        bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
+        bins = pl.DataFrame(
+            {
+                "time_bin_start": bin_starts,
+                "time_label": [
+                    f"{int(hour):02d}:{int(round((hour * 60.0) % 60.0)):02d}"
+                    for hour in bin_starts
+                ],
+            }
+        )
+
+        residual_home = (
+            bins.lazy()
+            .join(
+                time_series.lazy()
+                .group_by(["time_bin_start", "time_label"])
+                .agg(stacked_total=pl.col("n_persons").sum()),
+                on=["time_bin_start", "time_label"],
+                how="left",
+            )
+            .with_columns(
+                stacked_total=pl.col("stacked_total").fill_null(0.0),
+                label=pl.lit("home"),
+                n_persons=pl.lit(float(total_population)) - pl.col("stacked_total"),
+            )
+            .filter(pl.col("n_persons") != 0.0)
+            .select(["time_bin_start", "time_label", "label", "n_persons"])
+            .collect(engine="streaming")
+        )
+
+        time_series = (
+            pl.concat([time_series, residual_home], how="vertical_relaxed")
+            .group_by(["time_bin_start", "time_label", "label"])
+            .agg(n_persons=pl.col("n_persons").sum())
+            .sort(["time_bin_start", "label"])
+        )
+
+        if plot:
+            self._plot_activity_time_series(time_series)
+
+        return time_series
+
+    def _activity_time_series_raw(self, interval_minutes: int = 15) -> pl.DataFrame:
+        """Aggregate only the explicit states stored in plan_steps, before residual home completion."""
+        if interval_minutes <= 0 or 1440 % interval_minutes != 0:
+            raise ValueError("interval_minutes must be a positive divisor of 1440.")
+
+        bin_duration_hours = interval_minutes / 60.0
+        bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
+        bins = pl.DataFrame(
+            {
+                "time_bin_start": bin_starts,
+                "time_bin_end": bin_starts + bin_duration_hours,
+            }
+        )
+
+        plan_steps = (
+            self.plan_steps
+            .select(
+                [
+                    "activity",
+                    "mode",
+                    "n_persons",
+                    "departure_time",
+                    "arrival_time",
+                    "next_departure_time",
+                ]
+            )
+            .with_columns(
+                activity=pl.col("activity").cast(pl.String),
+                mode=pl.col("mode").cast(pl.String),
+            )
+        )
+
+        activity_intervals = plan_steps.select(
+            label=pl.col("activity"),
+            interval_start=pl.col("arrival_time"),
+            interval_end=pl.col("next_departure_time"),
+            n_persons=pl.col("n_persons"),
+        )
+        transit_intervals = plan_steps.select(
+            label=pl.format("in_transit:{}", pl.col("mode")),
+            interval_start=pl.col("departure_time"),
+            interval_end=pl.col("arrival_time"),
+            n_persons=pl.col("n_persons"),
+        )
+
+        intervals = pl.concat([activity_intervals, transit_intervals], how="vertical_relaxed")
+
+        return (
+            intervals.lazy()
+            .join(bins.lazy(), how="cross")
+            .with_columns(
+                overlap_start=pl.max_horizontal("interval_start", "time_bin_start"),
+                overlap_end=pl.min_horizontal("interval_end", "time_bin_end"),
+            )
+            .with_columns(
+                overlap_hours=(pl.col("overlap_end") - pl.col("overlap_start")).clip(0.0, bin_duration_hours),
+            )
+            .filter(pl.col("overlap_hours") > 0.0)
+            .with_columns(
+                n_persons=(pl.col("n_persons") * pl.col("overlap_hours") / pl.lit(bin_duration_hours)),
+                time_label=(
+                    pl.col("time_bin_start").floor().cast(pl.Int64).cast(pl.String).str.zfill(2)
+                    + ":"
+                    + ((pl.col("time_bin_start") * 60.0) % 60.0).round(0).cast(pl.Int64).cast(pl.String).str.zfill(2)
+                ),
+            )
+            .group_by(["time_bin_start", "time_label", "label"])
+            .agg(n_persons=pl.col("n_persons").sum())
+            .sort(["time_bin_start", "label"])
+            .collect(engine="streaming")
+        )
+
+    def plot_activity_time_series(self, interval_minutes: int = 15):
+        """Plot a stacked bar chart of average occupancy by activity and transit mode."""
+        time_series = self.activity_time_series(interval_minutes=interval_minutes)
+        return self._plot_activity_time_series(time_series)
+
+    def _plot_activity_time_series(self, time_series: pl.DataFrame):
+        """Render a stacked bar chart from a precomputed activity time series."""
+        fig = px.bar(
+            time_series.to_pandas(),
+            x="time_label",
+            y="n_persons",
+            color="label",
+            barmode="stack",
+            category_orders={"time_label": time_series["time_label"].to_list()},
+            title=f"Average occupancy by activity on {self.period}",
+        )
+        fig.update_layout(xaxis_title="Time of day", yaxis_title="Average persons in bin")
+        fig.show("browser")
+        return fig
 
     def opportunity_occupation(self, plot_activity: str = None, mask_outliers: bool = False):
         """Compute opportunity occupation per zone and activity for this run."""

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -17,7 +17,10 @@ from .run_state import RunState
 from mobility.transport.costs.transport_costs import TransportCosts
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities import Activity
-from mobility.activities.activity import resolve_activity_parameters
+from mobility.activities.activity import (
+    resolve_activity_arrival_time_rigidity,
+    resolve_activity_parameters,
+)
 from mobility.surveys import SurveyPlanAssets
 from mobility.surveys.mobility_survey import MobilitySurvey
 from mobility.population import Population
@@ -128,7 +131,6 @@ class Run(FileAsset):
             f"Run for {day_type} is disabled. "
             "Enable this day type or avoid accessing its outputs."
         )
-
 
     def _prepare_iterations(
         self,
@@ -391,6 +393,10 @@ class Run(FileAsset):
     ) -> pl.LazyFrame | None:
         """Advance the simulation state by one iteration and return transition events."""
         resolved_activity_parameters = resolve_activity_parameters(self.activities, iteration.iteration)
+        arrival_time_rigidity_by_activity = resolve_activity_arrival_time_rigidity(
+            self.activities,
+            iteration.iteration,
+        )
         state.current_plans, state.current_plan_steps, state.candidate_plan_steps, transition_events = self.updater.get_new_plans(
             state.current_plans,
             state.current_plan_steps,
@@ -402,6 +408,7 @@ class Run(FileAsset):
             state.activity_dur,
             iteration.iteration,
             resolved_activity_parameters,
+            arrival_time_rigidity_by_activity,
             destination_sequences,
             mode_sequences,
             state.home_night_dur,
@@ -451,6 +458,10 @@ class Run(FileAsset):
     def _build_final_plan_steps(self, state: RunState, costs: pl.DataFrame) -> pl.DataFrame:
         """Join final per-step states with demand-group attributes and costs."""
         plan_steps = state.current_plan_steps
+        duplicate_cost_columns = {"cost", "distance", "time", "ghg_emissions_per_trip"}
+        existing_duplicate_columns = [col for col in plan_steps.columns if col in duplicate_cost_columns]
+        if existing_duplicate_columns:
+            plan_steps = plan_steps.drop(existing_duplicate_columns)
         if "mode" in plan_steps.columns:
             plan_steps = plan_steps.with_columns(mode=pl.col("mode").cast(pl.String))
 

--- a/mobility/trips/group_day_trips/plans/plan_schedule_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_schedule_updater.py
@@ -1,0 +1,80 @@
+import polars as pl
+
+from .plan_ids import PLAN_KEY_COLS
+
+
+class PlanScheduleUpdater:
+    """Adjust candidate-plan schedules from survey timings and modeled travel times."""
+
+    MIN_ACTIVITY_DURATION_HOURS = 1e-3
+
+    def update_plan_timings(
+        self,
+        possible_plan_steps: pl.LazyFrame,
+        *,
+        arrival_time_rigidity_by_activity: dict[str, float],
+        enabled: bool,
+    ) -> pl.LazyFrame:
+        """Return iteration-local plan timings updated from modeled travel times."""
+        if enabled is False:
+            return possible_plan_steps
+
+        activity_dtype = possible_plan_steps.collect_schema()["activity"]
+        duration_dtype = possible_plan_steps.collect_schema()["duration_per_pers"]
+        time_dtype = possible_plan_steps.collect_schema()["departure_time"]
+
+        rigidity_lookup = (
+            pl.DataFrame(
+                {
+                    "activity": list(arrival_time_rigidity_by_activity.keys()),
+                    "arrival_time_rigidity": list(arrival_time_rigidity_by_activity.values()),
+                }
+            )
+            .with_columns(
+                activity=pl.col("activity").cast(activity_dtype),
+                arrival_time_rigidity=pl.col("arrival_time_rigidity").cast(pl.Float64),
+            )
+            .lazy()
+        )
+
+        raw_duration = pl.col("next_departure_time") - pl.col("arrival_time")
+
+        return (
+            possible_plan_steps
+            .join(rigidity_lookup, on="activity", how="left")
+            .with_columns(
+                reference_travel_time=(pl.col("arrival_time") - pl.col("departure_time")).clip(0.0, 24.0),
+            )
+            .with_columns(
+                travel_time_delta=pl.col("time") - pl.col("reference_travel_time"),
+            )
+            .with_columns(
+                departure_time=(
+                    pl.col("departure_time")
+                    - pl.col("arrival_time_rigidity") * pl.col("travel_time_delta")
+                ).cast(time_dtype),
+                arrival_time=(
+                    pl.col("arrival_time")
+                    + (1.0 - pl.col("arrival_time_rigidity")) * pl.col("travel_time_delta")
+                ).cast(time_dtype),
+            )
+            .sort(PLAN_KEY_COLS + ["seq_step_index"])
+            .with_columns(
+                next_departure_time=(
+                    pl.col("departure_time")
+                    .shift(-1)
+                    .over(PLAN_KEY_COLS)
+                    .fill_null(pl.col("next_departure_time"))
+                    .cast(time_dtype)
+                )
+            )
+            .with_columns(
+                duration_per_pers=(
+                    pl.when(raw_duration < self.MIN_ACTIVITY_DURATION_HOURS)
+                    .then(pl.lit(self.MIN_ACTIVITY_DURATION_HOURS))
+                    .otherwise(raw_duration)
+                    .cast(duration_dtype)
+                )
+            )
+            .drop(["arrival_time_rigidity", "reference_travel_time", "travel_time_delta"])
+        )

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -15,12 +15,16 @@ from ..transitions.transition_events import (
 from .candidate_plan_steps import CandidatePlanStepsAsset
 from .plan_distance import PlanDistance
 from .plan_ids import PLAN_KEY_COLS, add_plan_id
+from .plan_schedule_updater import PlanScheduleUpdater
 from .destination_sequences import DestinationSequences
 from .mode_sequence_search import ModeSequences
 
 
 class PlanUpdater:
     """Updates population plan distributions over activity/destination/mode sequences."""
+
+    def __init__(self) -> None:
+        self.schedule_updater = PlanScheduleUpdater()
 
     def get_new_plans(
         self,
@@ -34,6 +38,7 @@ class PlanUpdater:
         activity_dur: pl.DataFrame,
         iteration: int,
         resolved_activity_parameters: dict[str, Any],
+        arrival_time_rigidity_by_activity: dict[str, float],
         destination_sequences: DestinationSequences,
         mode_sequences: ModeSequences,
         home_night_dur: pl.DataFrame,
@@ -70,15 +75,6 @@ class PlanUpdater:
             possible_plan_steps,
             iteration,
         )
-
-        possible_plan_utility = self.get_possible_plan_utility(
-            possible_plan_steps,
-            home_night_dur,
-            resolved_activity_parameters["home"].value_of_time_stay_home,
-            stay_home_plan,
-            parameters.min_activity_time_constant,
-            sequence_index_folder=sequence_index_folder,
-        )
         candidate_plan_steps = possible_plan_steps.select(
             CandidatePlanStepsAsset.STRUCTURAL_COLUMNS
             + CandidatePlanStepsAsset.RETENTION_COLUMNS
@@ -86,6 +82,19 @@ class PlanUpdater:
         log_memory_checkpoint(
             f"plan_updater:iteration:{iteration}:candidate_plan_steps",
             candidate_plan_steps=candidate_plan_steps,
+        )
+        possible_plan_steps = self.schedule_updater.update_plan_timings(
+            possible_plan_steps,
+            arrival_time_rigidity_by_activity=arrival_time_rigidity_by_activity,
+            enabled=parameters.update_plan_timings_from_modeled_travel_times,
+        )
+        possible_plan_utility = self.get_possible_plan_utility(
+            possible_plan_steps,
+            home_night_dur,
+            resolved_activity_parameters["home"].value_of_time_stay_home,
+            stay_home_plan,
+            parameters.min_activity_time_constant,
+            sequence_index_folder=sequence_index_folder,
         )
         possible_plan_steps = self.add_stay_home_plan_steps(
             possible_plan_steps,

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -1,6 +1,5 @@
 import math
-import pathlib
-import shutil
+from pathlib import Path
 
 import polars as pl
 
@@ -90,25 +89,19 @@ def _make_possible_plan_utility(rows: dict[str, list]) -> pl.LazyFrame:
     ).lazy()
 
 
-def _make_local_tmp_path(name: str) -> pathlib.Path:
-    path = pathlib.Path(".pytest-local-tmp") / "group_day_trips" / name
-    shutil.rmtree(path, ignore_errors=True)
+def _make_local_tmp_path(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / "group_day_trips" / name
     path.mkdir(parents=True, exist_ok=True)
     return path
 
 def _with_plan_id(
     frame: pl.DataFrame | pl.LazyFrame,
     *,
+    tmp_path: Path,
     name: str,
 ) -> pl.DataFrame | pl.LazyFrame:
-    return add_plan_id(frame, index_folder=_make_local_tmp_path(name))
-def test_parameters_returns_default_behavior_change_scope():
-    parameters = Parameters()
-
-    assert parameters.get_behavior_change_scope(1) == BehaviorChangeScope.FULL_REPLANNING
-
-
-def test_parameters_resolves_active_behavior_change_scope():
+    return add_plan_id(frame, index_folder=_make_local_tmp_path(tmp_path, name))
+def test_parameters_resolve_behavior_change_scope_from_active_phases():
     parameters = Parameters(
         behavior_change_phases=[
             BehaviorChangePhase(start_iteration=3, scope=BehaviorChangeScope.MODE_REPLANNING),
@@ -116,12 +109,12 @@ def test_parameters_resolves_active_behavior_change_scope():
         ]
     )
 
-    assert parameters.get_behavior_change_scope(1) == BehaviorChangeScope.FULL_REPLANNING
+    assert Parameters().get_behavior_change_scope(1) == BehaviorChangeScope.FULL_REPLANNING
     assert parameters.get_behavior_change_scope(3) == BehaviorChangeScope.MODE_REPLANNING
     assert parameters.get_behavior_change_scope(6) == BehaviorChangeScope.DESTINATION_REPLANNING
 
 
-def test_sample_active_destination_sequences_keeps_only_active_activity_sequences():
+def test_sample_active_destination_sequences_keeps_only_active_activity_sequences(tmp_path):
     class _StubAsset:
         def __init__(self, df):
             self._df = df
@@ -133,7 +126,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
         run_key="run",
         is_weekday=True,
         iteration=3,
-        base_folder=_make_local_tmp_path("active_destination_sequences"),
+        base_folder=_make_local_tmp_path(tmp_path, "active_destination_sequences"),
         current_plans=pl.DataFrame(
             {
                 "demand_group_id": [1],
@@ -214,12 +207,12 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
     assert seen["chains"].select("activity_seq_id").to_series().to_list() == [10]
 
 
-def test_reuse_current_destination_sequences_reuses_current_plan_steps():
+def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path):
     destination_sequences = DestinationSequences(
         run_key="run",
         is_weekday=True,
         iteration=4,
-        base_folder=_make_local_tmp_path("reuse_current_destination_sequences"),
+        base_folder=_make_local_tmp_path(tmp_path, "reuse_current_destination_sequences"),
         current_plans=pl.DataFrame(
             {
                 "demand_group_id": [1],
@@ -272,7 +265,7 @@ def test_reuse_current_destination_sequences_reuses_current_plan_steps():
     assert result["seq_step_index"].sort().to_list() == [0, 1]
 
 
-def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning():
+def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning(tmp_path):
     updater = PlanUpdater()
     current_plans = _make_current_plans(
         {
@@ -326,10 +319,12 @@ def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning():
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_mode_replanning_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_mode_replanning_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.MODE_REPLANNING,
@@ -343,8 +338,8 @@ def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning():
     assert result.filter(pl.col("activity_seq_id_trans") == 0).height == 0
 
 
-def test_add_plan_id_keeps_stay_home_and_non_stay_home_states_distinct():
-    index_folder = _make_local_tmp_path("add_plan_id")
+def test_add_plan_id_keeps_stay_home_and_non_stay_home_states_distinct(tmp_path):
+    index_folder = _make_local_tmp_path(tmp_path, "add_plan_id")
     plans = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
@@ -644,130 +639,7 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
 
     assert result.select("activity_seq_id").sort("activity_seq_id").to_series().to_list() == [10]
 
-def test_candidate_memory_is_already_compact_before_persistence():
-    class _StubAsset:
-        def __init__(self, df):
-            self._df = df
-
-        def get_cached_asset(self):
-            return self._df
-
-    destination_sequences = _StubAsset(
-        pl.DataFrame(
-            {
-                "demand_group_id": [1],
-                "activity_seq_id": [10],
-                "time_seq_id": [0],
-                "dest_seq_id": [100],
-                "seq_step_index": [1],
-                "from": [11],
-                "to": [22],
-                "departure_time": [8.0],
-                "arrival_time": [8.5],
-                "next_departure_time": [17.0],
-                "iteration": [1],
-            },
-            schema={
-                "demand_group_id": pl.UInt32,
-                "activity_seq_id": pl.UInt32,
-                "time_seq_id": pl.UInt32,
-                "dest_seq_id": pl.UInt32,
-                "seq_step_index": pl.UInt8,
-                "from": pl.UInt16,
-                "to": pl.UInt16,
-                "departure_time": pl.Float32,
-                "arrival_time": pl.Float32,
-                "next_departure_time": pl.Float32,
-                "iteration": pl.UInt16,
-            },
-        )
-    )
-    mode_sequences = _StubAsset(
-        pl.DataFrame(
-            {
-                "demand_group_id": [1],
-                "activity_seq_id": [10],
-                "time_seq_id": [0],
-                "dest_seq_id": [100],
-                "mode_seq_id": [1000],
-                "seq_step_index": [1],
-                "mode": ["car"],
-                "iteration": [1],
-            },
-            schema={
-                "demand_group_id": pl.UInt32,
-                "activity_seq_id": pl.UInt32,
-                "time_seq_id": pl.UInt32,
-                "dest_seq_id": pl.UInt32,
-                "mode_seq_id": pl.UInt32,
-                "seq_step_index": pl.UInt8,
-                "mode": pl.Enum(["car", "walk", "stay_home"]),
-                "iteration": pl.UInt16,
-            },
-        )
-    )
-    survey_plan_steps = pl.DataFrame(
-        {
-            "activity_seq_id": [10],
-            "time_seq_id": [0],
-            "seq_step_index": [1],
-            "activity": ["work"],
-            "duration_per_pers": [8.0],
-            "departure_time": [8.0],
-            "arrival_time": [8.5],
-            "next_departure_time": [17.0],
-        },
-        schema={
-            "activity_seq_id": pl.UInt32,
-            "time_seq_id": pl.UInt32,
-            "seq_step_index": pl.UInt8,
-            "activity": pl.Utf8,
-            "duration_per_pers": pl.Float32,
-            "departure_time": pl.Float32,
-            "arrival_time": pl.Float32,
-            "next_departure_time": pl.Float32,
-        },
-    )
-    demand_groups = pl.DataFrame(
-        {
-            "demand_group_id": [1],
-            "country": ["fr"],
-            "csp": ["x"],
-        }
-    )
-
-    result = CandidatePlanStepsAsset.build_candidate_memory(
-        destination_sequences=destination_sequences,
-        mode_sequences=mode_sequences,
-        survey_plan_steps=survey_plan_steps,
-        demand_groups=demand_groups,
-        current_plans=pl.DataFrame(
-            schema={
-                "demand_group_id": pl.UInt32,
-                "activity_seq_id": pl.UInt32,
-                "time_seq_id": pl.UInt32,
-                "dest_seq_id": pl.UInt32,
-                "mode_seq_id": pl.UInt32,
-            }
-        ),
-        previous_candidate_plan_steps=None,
-        current_iteration=1,
-        n_warmup_iterations=1,
-        max_inactive_age=2,
-    ).collect()
-
-    assert result.schema["seq_step_index"] == pl.UInt8
-    assert result.schema["from"] == pl.UInt16
-    assert result.schema["to"] == pl.UInt16
-    assert result.schema["duration_per_pers"] == pl.Float32
-    assert result.schema["departure_time"] == pl.Float32
-    assert result.schema["arrival_time"] == pl.Float32
-    assert result.schema["next_departure_time"] == pl.Float32
-    assert result.schema["iteration"] == pl.UInt16
-    assert result.schema["first_seen_iteration"] == pl.UInt16
-    assert result.schema["last_active_iteration"] == pl.UInt16
-    assert isinstance(result.schema["mode"], pl.Enum)
-def test_get_transition_probabilities_limits_destination_replanning_to_same_timing_profile():
+def test_get_transition_probabilities_limits_destination_replanning_to_same_timing_profile(tmp_path):
     updater = PlanUpdater()
     current_plans = _make_current_plans(
         {
@@ -821,10 +693,12 @@ def test_get_transition_probabilities_limits_destination_replanning_to_same_timi
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_destination_replanning_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_destination_replanning_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.DESTINATION_REPLANNING,
@@ -834,7 +708,7 @@ def test_get_transition_probabilities_limits_destination_replanning_to_same_timi
     assert result.select("time_seq_id_trans").unique().to_series().to_list() == [0]
 
 
-def test_get_transition_probabilities_filters_candidates_by_distance_threshold():
+def test_get_transition_probabilities_filters_candidates_by_distance_threshold(tmp_path):
     updater = PlanUpdater()
     updater.attach_transition_distances = lambda allowed_transitions, **kwargs: allowed_transitions.with_columns(
         distance=pl.when(pl.col("dest_seq_id_trans") == pl.col("dest_seq_id"))
@@ -889,10 +763,12 @@ def test_get_transition_probabilities_filters_candidates_by_distance_threshold()
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_distance_threshold_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_distance_threshold_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
@@ -905,7 +781,7 @@ def test_get_transition_probabilities_filters_candidates_by_distance_threshold()
     assert abs(float(result["p_transition"].sum()) - 1.0) < 1e-9
 
 
-def test_get_transition_probabilities_uses_revision_probability_for_redistribution():
+def test_get_transition_probabilities_uses_revision_probability_for_redistribution(tmp_path):
     updater = PlanUpdater()
     updater.attach_transition_distances = lambda allowed_transitions, **kwargs: allowed_transitions.with_columns(
         distance=pl.when(pl.col("dest_seq_id_trans") == pl.col("dest_seq_id"))
@@ -964,10 +840,12 @@ def test_get_transition_probabilities_uses_revision_probability_for_redistributi
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_revision_probability_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_revision_probability_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
@@ -988,92 +866,7 @@ def test_get_transition_probabilities_uses_revision_probability_for_redistributi
     assert abs(float(p_self + p_switch) - 1.0) < 1e-9
 
 
-def test_get_transition_probabilities_transition_logit_scale_softens_choice_probabilities():
-    updater = PlanUpdater()
-    current_plans = _make_current_plans(
-        {
-            "demand_group_id": [1],
-            "activity_seq_id": [10],
-            "dest_seq_id": [100],
-            "mode_seq_id": [1000],
-            "utility": [1.0],
-            "n_persons": [5.0],
-        }
-    )
-    possible_plan_utility = _make_possible_plan_utility(
-        {
-            "demand_group_id": [1, 1],
-            "activity_seq_id": [10, 10],
-            "dest_seq_id": [100, 101],
-            "mode_seq_id": [1000, 1001],
-            "utility": [1.0, 2.0],
-        }
-    )
-
-    possible_plan_steps = _make_possible_plan_steps(
-        {
-            "demand_group_id": [1, 1],
-            "activity_seq_id": [10, 10],
-            "dest_seq_id": [100, 101],
-            "mode_seq_id": [1000, 1001],
-            "seq_step_index": [0, 0],
-            "activity": ["work", "work"],
-            "from": [1, 1],
-            "to": [2, 3],
-            "mode": ["car", "bike"],
-            "duration_per_pers": [8.0, 8.0],
-            "departure_time": [8.0, 8.0],
-            "arrival_time": [9.0, 9.0],
-            "next_departure_time": [17.0, 17.0],
-            "iteration": [1, 1],
-            "csp": ["x", "x"],
-            "cost": [1.0, 1.0],
-            "distance": [10.0, 12.0],
-            "time": [1.0, 1.0],
-            "mean_duration_per_pers": [8.0, 8.0],
-            "value_of_time": [1.0, 1.0],
-            "k_saturation_utility": [1.0, 1.0],
-            "min_activity_time": [1.0, 1.0],
-            "utility": [1.0, 2.0],
-        }
-    )
-
-    result_default = updater.get_transition_probabilities(
-        current_plans=current_plans,
-        possible_plan_utility=_with_plan_id(
-            possible_plan_utility,
-            name="transition_probabilities_logit_scale_default_utility",
-        ),
-        possible_plan_steps=_with_plan_id(
-            possible_plan_steps,
-            name="transition_probabilities_logit_scale_default_steps",
-        ),
-        behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
-        transport_zones=None,
-    )
-    result_scaled = updater.get_transition_probabilities(
-        current_plans=current_plans,
-        possible_plan_utility=_with_plan_id(
-            possible_plan_utility,
-            name="transition_probabilities_logit_scale_scaled_utility",
-        ),
-        possible_plan_steps=_with_plan_id(
-            possible_plan_steps,
-            name="transition_probabilities_logit_scale_scaled_steps",
-        ),
-        behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
-        transport_zones=None,
-        transition_logit_scale=0.25,
-    )
-
-    q_switch_default = result_default.filter(pl.col("mode_seq_id_trans") == 1001)["q_transition"][0]
-    q_switch_scaled = result_scaled.filter(pl.col("mode_seq_id_trans") == 1001)["q_transition"][0]
-
-    assert float(q_switch_scaled) < float(q_switch_default)
-    assert abs(float(q_switch_scaled) - float(0.5621765008857981)) < 1e-9
-
-
-def test_get_transition_probabilities_scales_pruning_window_with_transition_logit_scale():
+def test_get_transition_probabilities_scales_pruning_window_with_transition_logit_scale(tmp_path):
     updater = PlanUpdater()
     current_plans = _make_current_plans(
         {
@@ -1127,10 +920,12 @@ def test_get_transition_probabilities_scales_pruning_window_with_transition_logi
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_pruning_default_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_pruning_default_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
@@ -1140,10 +935,12 @@ def test_get_transition_probabilities_scales_pruning_window_with_transition_logi
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_pruning_scaled_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_pruning_scaled_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
@@ -1155,7 +952,7 @@ def test_get_transition_probabilities_scales_pruning_window_with_transition_logi
     assert result_scaled["mode_seq_id_trans"].sort().to_list() == [1000, 1001]
 
 
-def test_get_transition_probabilities_transition_distance_friction_penalizes_far_states():
+def test_get_transition_probabilities_transition_distance_friction_penalizes_far_states(tmp_path):
     updater = PlanUpdater()
     updater.attach_transition_distances = lambda allowed_transitions, **kwargs: allowed_transitions.with_columns(
         distance=pl.when(pl.col("dest_seq_id_trans") == pl.col("dest_seq_id"))
@@ -1216,10 +1013,12 @@ def test_get_transition_probabilities_transition_distance_friction_penalizes_far
         current_plans=current_plans,
         possible_plan_utility=_with_plan_id(
             possible_plan_utility,
+            tmp_path=tmp_path,
             name="transition_probabilities_distance_friction_utility",
         ),
         possible_plan_steps=_with_plan_id(
             possible_plan_steps,
+            tmp_path=tmp_path,
             name="transition_probabilities_distance_friction_steps",
         ),
         behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,

--- a/tests/back/unit/domain/group_day_trips/test_007_plan_schedule_updater.py
+++ b/tests/back/unit/domain/group_day_trips/test_007_plan_schedule_updater.py
@@ -1,0 +1,165 @@
+import pytest
+import polars as pl
+
+from mobility.activities.activity import resolve_activity_arrival_time_rigidity
+from mobility.activities.home import HomeActivity
+from mobility.activities.other import OtherActivity
+from mobility.activities.work.work import WorkActivity, WorkParameters
+from mobility.trips.group_day_trips.plans.plan_schedule_updater import PlanScheduleUpdater
+
+
+def _make_plan_steps(rows: dict[str, list]) -> pl.LazyFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "demand_group_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt8,
+            "activity": pl.Utf8,
+            "departure_time": pl.Float32,
+            "arrival_time": pl.Float32,
+            "next_departure_time": pl.Float32,
+            "duration_per_pers": pl.Float32,
+            "time": pl.Float64,
+        },
+    ).lazy()
+
+
+def test_plan_schedule_updater_keeps_reference_schedule_when_disabled():
+    """Check that turning the feature off leaves the survey schedule untouched.
+
+    Even if the modeled travel time is different from the
+    survey travel time, we should keep the original departure, arrival, and
+    activity duration when the global timing-update switch is disabled.
+    """
+    possible_plan_steps = _make_plan_steps(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_seq_id": [1000],
+            "mode_seq_id": [10000],
+            "seq_step_index": [0],
+            "activity": ["work"],
+            "departure_time": [8.0],
+            "arrival_time": [9.0],
+            "next_departure_time": [17.0],
+            "duration_per_pers": [8.0],
+            "time": [2.0],
+        }
+    )
+
+    result = PlanScheduleUpdater().update_plan_timings(
+        possible_plan_steps,
+        arrival_time_rigidity_by_activity={"work": 1.0},
+        enabled=False,
+    ).collect()
+
+    assert result["departure_time"].to_list() == [8.0]
+    assert result["arrival_time"].to_list() == [9.0]
+    assert result["next_departure_time"].to_list() == [17.0]
+    assert result["duration_per_pers"].to_list() == [8.0]
+
+
+def test_plan_schedule_updater_reconciles_timings_from_modeled_travel_times():
+    """Check that modeled travel times shift trips and activity time as intended.
+
+    If the trip to an anchor activity like work becomes
+    longer, we move departure earlier and keep arrival fixed. If a later trip to
+    a flexible activity becomes longer, we keep departure fixed and arrive
+    later. After that, the remaining activity time is recomputed from the new
+    schedule, and tiny infeasible durations are clipped to a very small value
+    instead of dropping the plan.
+    """
+    possible_plan_steps = _make_plan_steps(
+        {
+            "demand_group_id": [1, 1],
+            "activity_seq_id": [10, 10],
+            "time_seq_id": [100, 100],
+            "dest_seq_id": [1000, 1000],
+            "mode_seq_id": [10000, 10000],
+            "seq_step_index": [0, 1],
+            "activity": ["work", "other"],
+            "departure_time": [8.0, 17.0],
+            "arrival_time": [9.0, 17.5],
+            "next_departure_time": [17.0, 17.5],
+            "duration_per_pers": [8.0, 0.0],
+            "time": [2.0, 1.0],
+        }
+    )
+
+    result = PlanScheduleUpdater().update_plan_timings(
+        possible_plan_steps,
+        arrival_time_rigidity_by_activity={"work": 1.0, "other": 0.0},
+        enabled=True,
+    ).collect()
+
+    assert result["departure_time"].to_list() == [7.0, 17.0]
+    assert result["arrival_time"].to_list() == [9.0, 18.0]
+    assert result["next_departure_time"].to_list() == [17.0, 17.5]
+    durations = result["duration_per_pers"].to_list()
+    assert durations[0] == 8.0
+    assert durations[1] == pytest.approx(PlanScheduleUpdater.MIN_ACTIVITY_DURATION_HOURS)
+
+
+def test_plan_schedule_updater_keeps_last_activity_boundary_when_no_next_trip_exists():
+    """Check that the last explicit activity keeps its own end boundary.
+
+    In plain language: the final activity in a plan should not collapse to zero
+    duration just because there is no following trip row. It should keep the
+    original survey boundary stored on that last step, and only then apply the
+    timing adjustment.
+    """
+    possible_plan_steps = _make_plan_steps(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_seq_id": [1000],
+            "mode_seq_id": [10000],
+            "seq_step_index": [0],
+            "activity": ["other"],
+            "departure_time": [17.0],
+            "arrival_time": [17.5],
+            "next_departure_time": [19.0],
+            "duration_per_pers": [1.5],
+            "time": [1.0],
+        }
+    )
+
+    result = PlanScheduleUpdater().update_plan_timings(
+        possible_plan_steps,
+        arrival_time_rigidity_by_activity={"other": 0.0},
+        enabled=True,
+    ).collect()
+
+    assert result["departure_time"].to_list() == [17.0]
+    assert result["arrival_time"].to_list() == [18.0]
+    assert result["next_departure_time"].to_list() == [19.0]
+    assert result["duration_per_pers"].to_list() == [1.0]
+
+
+def test_activity_arrival_time_rigidity_defaults_from_anchor_flag_and_allows_override():
+    """Check the default and override rules for timing rigidity by activity.
+
+    Anchor activities should, by default, behave like
+    fixed-arrival activities, while non-anchor activities should default to more
+    flexible timing. The test also checks that a user can override the default
+    value for a specific activity.
+    """
+    activities = [
+        HomeActivity(),
+        OtherActivity(
+            opportunities=pl.DataFrame({"to": [1], "n_opp": [1.0]}).to_pandas(),
+        ),
+        WorkActivity(parameters=WorkParameters(arrival_time_rigidity=0.25)),
+    ]
+
+    rigidity_by_activity = resolve_activity_arrival_time_rigidity(activities, iteration=1)
+
+    assert rigidity_by_activity["home"] == 1.0
+    assert rigidity_by_activity["other"] == 0.0
+    assert rigidity_by_activity["work"] == 0.25

--- a/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
+++ b/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+import pytest
+import polars as pl
+
+from mobility.trips.group_day_trips.core.results import RunResults
+
+
+def _make_results(plan_steps: pl.DataFrame, demand_groups: pl.DataFrame | None = None) -> RunResults:
+    if demand_groups is None:
+        demand_groups = pl.DataFrame({"n_persons": [float(plan_steps["n_persons"].sum())]})
+    return RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=SimpleNamespace(get=lambda: None, study_area=SimpleNamespace(get=lambda: None)),
+        demand_groups=demand_groups.lazy(),
+        plan_steps=plan_steps.lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=SimpleNamespace(),
+    )
+
+
+def test_activity_time_series_uses_average_bin_occupancy_and_splits_transit_by_mode():
+    """Check that 15-minute bins average occupancy and keep in-transit states by mode.
+
+    In plain language: if one person spends half of a 15-minute bin travelling by
+    car and the whole bin at work, the output should count 0.5 person in
+    `in_transit:car` and 0.5 person in `work` for that bin. Any remaining
+    people with no explicit out-of-home state in that bin should be counted at
+    `home`, so the total always matches the modeled population. Different travel
+    modes should appear as separate in-transit labels.
+    """
+    plan_steps = pl.DataFrame(
+        {
+            "activity": ["work", "shop"],
+            "mode": ["car", "walk"],
+            "n_persons": [1.0, 2.0],
+            "departure_time": [8.0, 8.25],
+            "arrival_time": [8.125, 8.5],
+            "next_departure_time": [8.5, 9.0],
+        }
+    )
+    results = _make_results(plan_steps)
+
+    series = results.activity_time_series(interval_minutes=15)
+
+    at_0800 = series.filter(pl.col("time_label") == "08:00").sort("label")
+    assert at_0800["label"].to_list() == ["home", "in_transit:car", "work"]
+    occupancy = dict(zip(at_0800["label"].to_list(), at_0800["n_persons"].to_list(), strict=True))
+    assert occupancy["home"] == pytest.approx(2.0)
+    assert occupancy["in_transit:car"] == pytest.approx(0.5)
+    assert occupancy["work"] == pytest.approx(0.5)
+
+    at_0815 = series.filter(pl.col("time_label") == "08:15").sort("label")
+    assert at_0815["label"].to_list() == ["in_transit:walk", "work"]
+    occupancy = dict(zip(at_0815["label"].to_list(), at_0815["n_persons"].to_list(), strict=True))
+    assert occupancy["in_transit:walk"] == pytest.approx(2.0)
+    assert occupancy["work"] == pytest.approx(1.0)
+
+    at_0830 = series.filter(pl.col("time_label") == "08:30").sort("label")
+    assert at_0830["label"].to_list() == ["home", "shop"]
+    occupancy = dict(zip(at_0830["label"].to_list(), at_0830["n_persons"].to_list(), strict=True))
+    assert occupancy["home"] == pytest.approx(1.0)
+    assert occupancy["shop"] == pytest.approx(2.0)
+
+
+def test_activity_time_series_completes_missing_home_time_so_totals_stay_constant():
+    """Check that the plotted occupancy series adds implicit home time back in.
+
+    In plain language: the plan-step table often stores explicit trips and
+    out-of-home activities, but not every home period. The public time-series
+    output should fill that residual as `home` so each 15-minute bin still sums
+    to the full modeled population.
+    """
+    plan_steps = pl.DataFrame(
+        {
+            "activity": ["work", "shop"],
+            "mode": ["car", "walk"],
+            "n_persons": [1.0, 2.0],
+            "departure_time": [8.0, 8.25],
+            "arrival_time": [8.125, 8.5],
+            "next_departure_time": [8.5, 9.0],
+        }
+    )
+    results = _make_results(plan_steps, demand_groups=pl.DataFrame({"n_persons": [3.0]}))
+
+    totals = (
+        results.activity_time_series(interval_minutes=15)
+        .group_by("time_label")
+        .agg(total=pl.col("n_persons").sum())
+    )
+
+    assert totals["total"].to_list() == pytest.approx([3.0] * totals.height)
+
+
+def test_activity_time_series_can_trigger_plotting_from_same_entrypoint(monkeypatch):
+    """Check that callers can request the plot from the activity_time_series entrypoint.
+
+    In plain language: the same method should still return the table, but when
+    `plot=True` it should also call the plotting path so `Run.evaluate(...)`
+    can be used directly for both data and charts.
+    """
+    results = _make_results(
+        pl.DataFrame(
+            {
+                "activity": ["home"],
+                "mode": ["stay_home"],
+                "n_persons": [1.0],
+                "departure_time": [0.0],
+                "arrival_time": [0.0],
+                "next_departure_time": [24.0],
+            }
+        )
+    )
+
+    seen = {}
+
+    def fake_plot(df):
+        seen["rows"] = df.height
+        return "figure"
+
+    monkeypatch.setattr(results, "_plot_activity_time_series", fake_plot)
+
+    series = results.activity_time_series(interval_minutes=15, plot=True)
+
+    assert seen["rows"] == series.height


### PR DESCRIPTION
### Motivation
This PR adds two pieces needed to make grouped day-trip timing and analysis more behaviorally meaningful :
- Plan timings can now be updated from modeled travel times instead of always keeping the survey schedule fixed. This lets congestion or other travel-time changes feed back into activity durations before plan utilities are recomputed.
- Run results now include a time-of-day occupancy analysis, so we can inspect how many people are at each activity, or in transit by mode, over the day.

### Changes
This PR changes the grouped day-trips model in the following ways:

- Added `arrival_time_rigidity` to activity parameters.
  This controls how a travel-time change is absorbed for trips ending at that activity:
  - `0`: keep departure fixed, shift arrival
  - `1`: keep arrival fixed, shift departure
  - intermediate values split the adjustment
- Added anchor-based default resolution for `arrival_time_rigidity`.
  Anchor activities default to `1.0`, non-anchor activities default to `0.0`, and explicit activity parameter values still override the default.
- Added `PlanScheduleUpdater` in `mobility/trips/group_day_trips/plans/plan_schedule_updater.py`.
  It rebuilds candidate-plan timings each iteration from:
  - survey reference departure/arrival times
  - modeled travel times
  - activity-specific arrival-time rigidity
- Added a global grouped day-trips parameter `update_plan_timings_from_modeled_travel_times`. The feature is disabled by default so current behavior is preserved unless explicitly enabled (@Mind-the-Cap 😉).
- Added `RunResults.activity_time_series()` and `RunResults.plot_activity_time_series()`. These build 15-minute average occupancy profiles by:
  - activity (`home`, `work`, `shopping`, etc.)
  - transit state by mode (`in_transit:car`, `in_transit:walk`, etc.)

### Example (if relevant)
Enable timing updates:

```python
population_trips = PopulationGroupDayTrips(
    ...,
    update_plan_timings_from_modeled_travel_times=True,
)
```

Set a custom arrival-time rigidity for an activity:

```python
from mobility.activities.work.work import WorkActivity, WorkParameters

work = WorkActivity(
    parameters=WorkParameters(
        arrival_time_rigidity=1.0,
    )
)
```

Interpretation:
- `arrival_time_rigidity=0.0`: keep departure fixed, shift arrival
- `arrival_time_rigidity=1.0`: keep arrival fixed, shift departure
- `arrival_time_rigidity=0.5`: split the adjustment equally

Plot the occupancy profile for a run:

```python
population_trips.weekday_run.evaluate(
    "activity_time_series",
    interval_minutes=15,
    plot=True,
)
```

Which gives (on a two iteration model so a lot of people still staying home):
<img width="1870" height="978" alt="image" src="https://github.com/user-attachments/assets/a07b10db-aee5-4f3b-a2a2-80399ead7402" />
<br>
Or get the underlying table:

```python
ts = population_trips.weekday_run.results().activity_time_series(interval_minutes=15)
```

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Schedule-reconciliation feature design and implementation, activity time-series analysis, and nearby test refactoring/documentation.
- What you reviewed or changed: Reviewed the resulting code paths, corrected the last-activity timing behavior, simplified the test slice, and checked that the final behavior matched the intended grouped day-trips model logic.
- How you validated it (tests, checks, manual verification): ran unit tests, ran several manual tests on a large case study.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior