### PR TITLE
Group day trips

### DIFF
--- a/mobility/activities/activity.py
+++ b/mobility/activities/activity.py
@@ -29,7 +29,7 @@ class Activity(InMemoryAsset):
             is_anchor: bool = False,
             opportunities: pd.DataFrame = None,
             utilities: pd.DataFrame = None,
-            country_utilities: Dict = None,
+            country_value_coefficients: Dict = None,
             sink_saturation_coeff: float = None,
             extra_inputs: dict | None = None,
             parameters: "ActivityParameters" | None = None,
@@ -45,7 +45,7 @@ class Activity(InMemoryAsset):
                 "value_of_time_v2": value_of_time_v2,
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
-                "country_utilities": country_utilities,
+                "country_value_coefficients": country_value_coefficients,
                 "sink_saturation_coeff": sink_saturation_coeff,
             },
             required_fields=["value_of_time", "saturation_fun_ref_level", "saturation_fun_beta"],
@@ -79,33 +79,6 @@ class Activity(InMemoryAsset):
                 resolved to scalar values for ``iteration``.
         """
         return resolve_model_for_iteration(self.inputs["parameters"], iteration)
-
-
-    def get_utilities(self, transport_zones, parameters: "ActivityParameters" | None = None):
-
-        parameters = parameters or self.inputs["parameters"]
-
-        if self.utilities is not None:
-
-            utilities = self.utilities
-
-        elif parameters.country_utilities is not None:
-            
-            transport_zones = transport_zones.get().drop("geometry", axis=1)
-            transport_zones["country"] = transport_zones["local_admin_unit_id"].str[0:2]
-            transport_zones["utility"] = transport_zones["country"].map(parameters.country_utilities)
-
-            utilities = pl.from_pandas( 
-                transport_zones[["transport_zone_id", "utility"]]
-                .rename({"transport_zone_id": "to"}, axis=1)
-            )
-
-        else:
-
-            utilities = None
-
-        return utilities
-
 
     def enforce_opportunities_schema(self, opportunities):
         
@@ -183,12 +156,16 @@ class ActivityParameters(BaseModel):
         ),
     ]
 
-    country_utilities: Annotated[
+    country_value_coefficients: Annotated[
         dict[str, float] | None,
         Field(
             default=None,
-            title="Country utility offsets",
-            description="Optional country-level utility offsets used for this activity.",
+            title="Country value coefficients",
+            description=(
+                "Optional destination-country coefficients applied to the "
+                "positive activity-value term for this activity. Coefficients "
+                "default to `1.0` when a country is not listed."
+            ),
         ),
     ]
 

--- a/mobility/activities/work/work.py
+++ b/mobility/activities/work/work.py
@@ -24,7 +24,7 @@ class WorkActivity(Activity):
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
         utilities: pd.DataFrame = None,
-        country_utilities: Dict = None,
+        country_value_coefficients: Dict = None,
         parameters: "WorkParameters" | None = None
     ):
 
@@ -37,7 +37,7 @@ class WorkActivity(Activity):
                 "saturation_fun_beta": saturation_fun_beta,
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
-                "country_utilities": country_utilities,
+                "country_value_coefficients": country_value_coefficients,
             },
             owner_name="WorkActivity",
         )
@@ -113,7 +113,7 @@ class WorkParameters(ActivityParameters):
         Field(default=0.99986),
     ]
 
-    country_utilities: Annotated[
+    country_value_coefficients: Annotated[
         dict[str, float],
-        Field(default_factory=lambda: {"fr": 0.0, "ch": 5.0}),
+        Field(default_factory=lambda: {"fr": 1.0, "ch": 1.0}),
     ]

--- a/mobility/trips/group_day_trips/core/metrics.py
+++ b/mobility/trips/group_day_trips/core/metrics.py
@@ -8,7 +8,9 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.express as px
+import plotly.graph_objects as go
 import polars as pl
+from plotly.subplots import make_subplots
 
 from ..evaluation.car_traffic_evaluation import CarTrafficEvaluation
 from ..evaluation.public_transport_network_evaluation import (
@@ -273,74 +275,124 @@ class RunMetrics:
 
         return immobility
 
-    def activity_time_series(self, interval_minutes: int = 15, plot: bool = False) -> pl.DataFrame:
+    def activity_time_series(
+        self,
+        interval_minutes: int = 15,
+        plot: bool = False,
+        inner_zone_residents_only: bool = False,
+    ) -> pl.DataFrame:
         """Aggregate average occupancy by activity and in-transit mode over time bins."""
-        time_series = self._activity_time_series_raw(interval_minutes=interval_minutes)
-        total_population = (
-            self.results.demand_groups
-            .select(pl.col("n_persons").sum().alias("total_population"))
-            .collect(engine="streaming")
-            .item()
+        observed_time_series = self._add_residual_home_time(
+            self._activity_time_series_raw(
+                interval_minutes=interval_minutes,
+                inner_zone_residents_only=inner_zone_residents_only,
+            ),
+            bins=self._time_bins(interval_minutes=interval_minutes),
+            total_population=self._modeled_total_population(inner_zone_residents_only=inner_zone_residents_only),
+        ).with_columns(source=pl.lit("observed"))
+        survey_time_series = self._survey_activity_time_series(
+            interval_minutes=interval_minutes,
+            inner_zone_residents_only=inner_zone_residents_only,
         )
-        bin_duration_hours = interval_minutes / 60.0
-        bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
-        bins = pl.DataFrame(
-            {
-                "time_bin_start": bin_starts,
-                "time_label": [
-                    f"{int(hour):02d}:{int(round((hour * 60.0) % 60.0)):02d}"
-                    for hour in bin_starts
-                ],
-            }
+        time_series = pl.concat(
+            [
+                observed_time_series,
+                survey_time_series.with_columns(source=pl.lit("survey")),
+            ],
+            how="vertical_relaxed",
+        ).select(
+            ["source", "time_bin_start", "time_label", "label", "n_persons"]
         )
-
-        residual_home = (
-            bins.lazy()
-            .join(
-                time_series.lazy()
-                .group_by(["time_bin_start", "time_label"])
-                .agg(stacked_total=pl.col("n_persons").sum()),
-                on=["time_bin_start", "time_label"],
-                how="left",
-            )
-            .with_columns(
-                stacked_total=pl.col("stacked_total").fill_null(0.0),
-                label=pl.lit("home"),
-                n_persons=pl.lit(float(total_population)) - pl.col("stacked_total"),
-            )
-            .filter(pl.col("n_persons") != 0.0)
-            .select(["time_bin_start", "time_label", "label", "n_persons"])
-            .collect(engine="streaming")
-        )
-
-        time_series = (
-            pl.concat([time_series, residual_home], how="vertical_relaxed")
-            .group_by(["time_bin_start", "time_label", "label"])
-            .agg(n_persons=pl.col("n_persons").sum())
-            .sort(["time_bin_start", "label"])
-        )
-
         if plot:
             self._plot_activity_time_series(time_series)
 
         return time_series
 
-    def _activity_time_series_raw(self, interval_minutes: int = 15) -> pl.DataFrame:
-        """Aggregate only the explicit states stored in plan_steps, before residual home completion."""
+    def _activity_time_series_raw(
+        self,
+        interval_minutes: int = 15,
+        inner_zone_residents_only: bool = False,
+    ) -> pl.DataFrame:
+        """Aggregate average occupancy by activity and in-transit mode over time bins."""
+        plan_steps = self.results.plan_steps
+        if inner_zone_residents_only:
+            plan_steps = self._filter_plan_steps_to_inner_zone_residents(plan_steps)
+        return self._time_series_from_plan_steps(plan_steps, interval_minutes=interval_minutes)
+
+    def _survey_activity_time_series(
+        self,
+        interval_minutes: int = 15,
+        inner_zone_residents_only: bool = False,
+    ) -> pl.DataFrame:
+        """Build the same occupancy time series from the canonical survey reference asset."""
+        weighted_survey_plan_steps = self.results.population_weighted_plan_steps
+        if inner_zone_residents_only:
+            weighted_survey_plan_steps = self._filter_plan_steps_to_inner_zone_residents(weighted_survey_plan_steps)
+
+        total_population = self._modeled_total_population(inner_zone_residents_only=inner_zone_residents_only)
+        explicit_time_series = self._time_series_from_plan_steps(
+            weighted_survey_plan_steps,
+            interval_minutes=interval_minutes,
+        )
+        return self._add_residual_home_time(
+            explicit_time_series,
+            bins=self._time_bins(interval_minutes=interval_minutes),
+            total_population=total_population,
+        )
+
+    def _modeled_total_population(self, inner_zone_residents_only: bool = False) -> float:
+        """Return the total modeled population represented in the demand groups."""
+        demand_groups = self.results.demand_groups
+        if inner_zone_residents_only:
+            demand_groups = self._filter_demand_groups_to_inner_zone_residents(demand_groups)
+        total_population = demand_groups.select(pl.col("n_persons").sum().alias("total_population")).collect(engine="streaming").item()
+        return float(total_population)
+
+    def _inner_zone_transport_zone_ids(self) -> pl.DataFrame:
+        """Return the transport-zone ids marked as inner zones."""
+        return (
+            pl.DataFrame(self.results.transport_zones.get().drop("geometry", axis=1, errors="ignore"))
+            .filter(pl.col("is_inner_zone"))
+            .select(pl.col("transport_zone_id").cast(pl.Int32))
+            .unique()
+        )
+
+    def _filter_demand_groups_to_inner_zone_residents(self, demand_groups: pl.LazyFrame) -> pl.LazyFrame:
+        """Keep only demand groups whose home zone is an inner zone."""
+        inner_zone_ids = self._inner_zone_transport_zone_ids()
+        return demand_groups.join(
+            inner_zone_ids.lazy(),
+            left_on=pl.col("home_zone_id").cast(pl.Int32),
+            right_on="transport_zone_id",
+            how="inner",
+        ).drop("transport_zone_id")
+
+    def _filter_plan_steps_to_inner_zone_residents(self, plan_steps: pl.LazyFrame) -> pl.LazyFrame:
+        """Keep only plan steps belonging to residents of inner zones."""
+        inner_zone_ids = self._inner_zone_transport_zone_ids()
+        return plan_steps.join(
+            inner_zone_ids.lazy(),
+            left_on=pl.col("home_zone_id").cast(pl.Int32),
+            right_on="transport_zone_id",
+            how="inner",
+        ).drop("transport_zone_id")
+
+    def _time_series_from_plan_steps(
+        self,
+        plan_steps: pl.LazyFrame,
+        *,
+        interval_minutes: int = 15,
+    ) -> pl.DataFrame:
+        """Aggregate only the explicit states stored in plan steps over time bins."""
         if interval_minutes <= 0 or 1440 % interval_minutes != 0:
             raise ValueError("interval_minutes must be a positive divisor of 1440.")
 
+        bins = self._time_bins(interval_minutes=interval_minutes)
         bin_duration_hours = interval_minutes / 60.0
-        bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
-        bins = pl.DataFrame(
-            {
-                "time_bin_start": bin_starts,
-                "time_bin_end": bin_starts + bin_duration_hours,
-            }
-        )
+        n_bins = bins.height
 
         plan_steps = (
-            self.results.plan_steps
+            plan_steps
             .select(
                 [
                     "activity",
@@ -374,7 +426,35 @@ class RunMetrics:
 
         return (
             intervals.lazy()
-            .join(bins.lazy(), how="cross")
+            .filter(pl.col("interval_end") > pl.col("interval_start"))
+            .with_columns(
+                start_bin_index=(
+                    (pl.col("interval_start") / pl.lit(bin_duration_hours))
+                    .floor()
+                    .clip(0, n_bins - 1)
+                    .cast(pl.UInt32)
+                ),
+                end_bin_index=(
+                    (pl.col("interval_end") / pl.lit(bin_duration_hours))
+                    .ceil()
+                    .clip(0, n_bins)
+                    .cast(pl.UInt32)
+                ),
+            )
+            .with_columns(
+                bin_index=pl.int_ranges(
+                    "start_bin_index",
+                    "end_bin_index",
+                    step=1,
+                    dtype=pl.UInt32,
+                )
+            )
+            .explode("bin_index")
+            .join(
+                bins.with_row_index("bin_index").lazy(),
+                on="bin_index",
+                how="inner",
+            )
             .with_columns(
                 overlap_start=pl.max_horizontal("interval_start", "time_bin_start"),
                 overlap_end=pl.min_horizontal("interval_end", "time_bin_end"),
@@ -385,11 +465,6 @@ class RunMetrics:
             .filter(pl.col("overlap_hours") > 0.0)
             .with_columns(
                 n_persons=(pl.col("n_persons") * pl.col("overlap_hours") / pl.lit(bin_duration_hours)),
-                time_label=(
-                    pl.col("time_bin_start").floor().cast(pl.Int64).cast(pl.String).str.zfill(2)
-                    + ":"
-                    + ((pl.col("time_bin_start") * 60.0) % 60.0).round(0).cast(pl.Int64).cast(pl.String).str.zfill(2)
-                ),
             )
             .group_by(["time_bin_start", "time_label", "label"])
             .agg(n_persons=pl.col("n_persons").sum())
@@ -397,57 +472,234 @@ class RunMetrics:
             .collect(engine="streaming")
         )
 
-    def plot_activity_time_series(self, interval_minutes: int = 15):
+    def _time_bins(self, *, interval_minutes: int) -> pl.DataFrame:
+        """Return one full-day time-bin table shared by modeled and survey series."""
+        bin_duration_hours = interval_minutes / 60.0
+        bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
+        return pl.DataFrame(
+            {
+                "time_bin_start": bin_starts,
+                "time_bin_end": bin_starts + bin_duration_hours,
+                "time_label": [
+                    f"{int(hour):02d}:{int(round((hour * 60.0) % 60.0)):02d}"
+                    for hour in bin_starts
+                ],
+            }
+        )
+
+    def plot_activity_time_series(
+        self,
+        interval_minutes: int = 15,
+        inner_zone_residents_only: bool = False,
+    ):
         """Plot a stacked bar chart of average occupancy by activity and transit mode."""
-        time_series = self.activity_time_series(interval_minutes=interval_minutes)
+        time_series = self.activity_time_series(
+            interval_minutes=interval_minutes,
+            inner_zone_residents_only=inner_zone_residents_only,
+        )
         return self._plot_activity_time_series(time_series)
 
-    def _plot_activity_time_series(self, time_series: pl.DataFrame):
-        """Render a stacked bar chart from a precomputed activity time series."""
-        fig = px.bar(
-            time_series.to_pandas(),
-            x="time_label",
-            y="n_persons",
-            color="label",
-            barmode="stack",
-            category_orders={"time_label": time_series["time_label"].to_list()},
-            title=f"Average occupancy by activity on {self.results.period}",
+    def _add_residual_home_time(
+        self,
+        time_series: pl.DataFrame,
+        *,
+        bins: pl.DataFrame,
+        total_population: float,
+    ) -> pl.DataFrame:
+        """Fill missing occupancy in each bin as home time so totals stay constant."""
+        residual_home = (
+            bins.lazy()
+            .join(
+                time_series.lazy()
+                .group_by(["time_bin_start", "time_label"])
+                .agg(stacked_total=pl.col("n_persons").sum()),
+                on=["time_bin_start", "time_label"],
+                how="left",
+            )
+            .with_columns(
+                stacked_total=pl.col("stacked_total").fill_null(0.0),
+                label=pl.lit("home"),
+                n_persons=pl.lit(total_population) - pl.col("stacked_total"),
+            )
+            .filter(pl.col("n_persons") != 0.0)
+            .select(["time_bin_start", "time_label", "label", "n_persons"])
+            .collect(engine="streaming")
         )
-        fig.update_layout(xaxis_title="Time of day", yaxis_title="Average persons in bin")
+
+        return (
+            pl.concat([time_series, residual_home], how="vertical_relaxed")
+            .group_by(["time_bin_start", "time_label", "label"])
+            .agg(n_persons=pl.col("n_persons").sum())
+            .sort(["time_bin_start", "label"])
+        )
+
+    def _plot_activity_time_series(
+        self,
+        time_series: pl.DataFrame,
+    ):
+        """Render stacked occupancy charts, with survey on the left when available."""
+        source_titles = {"survey": "Survey", "observed": "Model"}
+        available_sources = [source for source in ["survey", "observed"] if source in time_series["source"].unique().to_list()]
+        panel_series = [
+            (source_titles[source], time_series.filter(pl.col("source") == source).drop("source"))
+            for source in available_sources
+        ]
+        category_orders = {
+            "time_label": (
+                time_series
+                .select(["time_bin_start", "time_label"])
+                .unique()
+                .sort("time_bin_start")
+                .get_column("time_label")
+                .to_list()
+            )
+        }
+        labels = sorted({label for _, series in panel_series for label in series["label"].to_list()})
+        color_map = self._activity_time_series_color_map(labels)
+
+        fig = make_subplots(
+            rows=1,
+            cols=len(panel_series),
+            subplot_titles=[title for title, _ in panel_series],
+            shared_yaxes=True,
+        )
+
+        for col_index, (_, series) in enumerate(panel_series, start=1):
+            pivoted = (
+                series
+                .pivot(index="time_label", on="label", values="n_persons", aggregate_function="sum")
+                .sort("time_label")
+                .fill_null(0.0)
+            )
+            time_labels = pivoted["time_label"].to_list()
+            for label in labels:
+                values = pivoted.get_column(label).to_list() if label in pivoted.columns else [0.0] * len(time_labels)
+                fig.add_trace(
+                    go.Bar(
+                        x=time_labels,
+                        y=values,
+                        name=label,
+                        marker_color=color_map[label],
+                        showlegend=(col_index == 1),
+                    ),
+                    row=1,
+                    col=col_index,
+                )
+
+        fig.update_layout(
+            barmode="stack",
+            title=f"Average occupancy by activity on {self.results.period}",
+            xaxis_title="Time of day",
+            yaxis_title="Average persons in bin",
+        )
+        for axis_name in [f"xaxis{suffix}" for suffix in ([""] + [str(index) for index in range(2, len(panel_series) + 1)])]:
+            fig.layout[axis_name].update(categoryorder="array", categoryarray=category_orders["time_label"])
         fig.show("browser")
         return fig
 
-    def opportunity_occupation(self, plot_activity: str = None, mask_outliers: bool = False):
-        """Compute opportunity occupation per zone and activity for this run."""
-        transport_zones_df = (
-            pl.DataFrame(self.results.transport_zones.get().drop("geometry", axis=1))
-            .filter(pl.col("is_inner_zone"))
+    @staticmethod
+    def _activity_time_series_color_map(labels: list[str]) -> dict[str, str]:
+        """Return stable, distinct colors for activity time-series labels."""
+        fixed_colors = {
+            "home": "#7f8c8d",
+            "work": "#355CDE",
+            "studies": "#FFBE3D",
+            "shopping": "#E88AF2",
+            "other": "#B8E986",
+            "leisure": "#FF5C8A",
+            "in_transit:car": "#00C389",
+            "in_transit:walk": "#FFA15A",
+            "in_transit:bicycle": "#EF553B",
+            "in_transit:other": "#AB63FA",
+            "in_transit:walk/public_transport/walk": "#19D3F3",
+        }
+        fallback_palette = (
+            px.colors.qualitative.Safe
+            + px.colors.qualitative.Bold
+            + px.colors.qualitative.Set3
+        )
+
+        color_map: dict[str, str] = {}
+        fallback_index = 0
+        for label in labels:
+            if label in fixed_colors:
+                color_map[label] = fixed_colors[label]
+                continue
+
+            while fallback_index < len(fallback_palette) and fallback_palette[fallback_index] in color_map.values():
+                fallback_index += 1
+            if fallback_index >= len(fallback_palette):
+                fallback_index = 0
+            color_map[label] = fallback_palette[fallback_index]
+            fallback_index += 1
+
+        return color_map
+
+    def opportunity_occupation(
+        self,
+        plot_activity: str = None,
+        mask_outliers: bool = False,
+        inner_zone_residents_only: bool = True,
+    ):
+        """Compute opportunity occupation per destination and activity for this run.
+
+        The returned table always includes the full modeled opportunity stock.
+        Destinations with capacity but no realized occupation are kept with
+        ``duration = 0`` and ``opportunity_occupation = 0``.
+        """
+        transport_zones_df = pl.DataFrame(
+            self.results.transport_zones.get().drop("geometry", axis=1, errors="ignore")
+        )
+        resident_zone_scope = (
+            transport_zones_df.filter(pl.col("is_inner_zone")).lazy()
+            if inner_zone_residents_only
+            else transport_zones_df.lazy()
+        )
+        destination_zone_flags = (
+            transport_zones_df
+            .select(
+                pl.col("transport_zone_id").alias("to"),
+                pl.col("is_inner_zone").alias("destination_is_inner_zone"),
+            )
             .lazy()
         )
 
         opportunity_occupation = (
-            self.results.plan_steps.filter(pl.col("activity_seq_id") != 0)
-            .rename({"home_zone_id": "transport_zone_id"})
-            .join(transport_zones_df.select(["transport_zone_id", "local_admin_unit_id"]), on=["transport_zone_id"])
+            self.results.opportunities
+            .select(["to", "activity", "opportunity_capacity"])
             .with_columns(pl.col("activity").cast(pl.String()))
-            .group_by(["to", "activity"])
-            .agg(pl.col("duration").sum())
+            .join(destination_zone_flags, on="to", how="left")
             .join(
-                self.results.opportunities.select(["to", "activity", "opportunity_capacity"]).with_columns(
-                    pl.col("activity").cast(pl.String())
-                ),
+                self.results.plan_steps.filter(pl.col("activity_seq_id") != 0)
+                .rename({"home_zone_id": "transport_zone_id"})
+                .join(
+                    resident_zone_scope.select("transport_zone_id"),
+                    on=["transport_zone_id"],
+                    how="inner",
+                )
+                .with_columns(pl.col("activity").cast(pl.String()))
+                .group_by(["to", "activity"])
+                .agg(pl.col("duration").sum()),
                 on=["to", "activity"],
+                how="left",
             )
-            .with_columns(opportunity_occupation=pl.col("duration") / pl.col("opportunity_capacity"))
+            .with_columns(
+                duration=pl.col("duration").fill_null(0.0),
+                opportunity_occupation=(
+                    pl.col("duration").fill_null(0.0) / pl.col("opportunity_capacity")
+                ),
+            )
             .rename({"to": "transport_zone_id"})
             .collect(engine="streaming")
         )
 
         if plot_activity:
             tz = self.results.transport_zones.get().to_crs(4326)
-            tz = tz.merge(transport_zones_df.collect().to_pandas(), on="transport_zone_id")
+            tz = tz.merge(transport_zones_df.to_pandas(), on="transport_zone_id")
             tz = tz.merge(
-                opportunity_occupation.filter(pl.col("activity") == plot_activity).to_pandas(),
+                opportunity_occupation
+                .filter(pl.col("activity") == plot_activity)
+                .to_pandas(),
                 on="transport_zone_id",
                 how="left",
             )

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -66,7 +66,7 @@ class Run(FileAsset):
     ) -> None:
         """Initialize a single weekday or weekend PopulationGroupDayTrips run."""
         inputs = {
-            "version": 9,
+            "version": 10,
             "population": population,
             "activities": activities,
             "modes": modes,
@@ -239,11 +239,10 @@ class Run(FileAsset):
             self.survey_plan_assets,
             self.is_weekday,
         )
+        expected_inputs = self._get_expected_diagnostics_inputs()
         activity_dur, home_night_dur, activity_demand_per_pers = self.initializer.get_survey_duration_summaries(
-            self.survey_plan_assets,
-            self.is_weekday,
+            expected_inputs.population_weighted_plan_steps.get(),
             demand_groups,
-            survey_plan_steps,
         )
         resolved_activity_parameters = resolve_activity_parameters(self.activities, 1)
         stay_home_plan, current_plans = self.initializer.get_stay_home_state(

--- a/mobility/trips/group_day_trips/evaluation/population_weighted_plan_steps.py
+++ b/mobility/trips/group_day_trips/evaluation/population_weighted_plan_steps.py
@@ -30,7 +30,7 @@ class PopulationWeightedPlanSteps(FileAsset):
             / f"population_weighted_plan_steps_{'weekday' if is_weekday else 'weekend'}.parquet"
         )
         inputs = {
-            "version": 6,
+            "version": 7,
             "population": population,
             "survey_plan_assets": survey_plan_assets,
             "is_weekday": is_weekday,
@@ -72,9 +72,18 @@ class PopulationWeightedPlanSteps(FileAsset):
             [
                 "activity_seq_id",
                 "time_seq_id",
+                "is_weekday",
+                "city_category",
+                "csp",
+                "n_cars",
                 "seq_step_index",
                 "activity",
                 "mode",
+                "is_anchor",
+                "departure_time",
+                "arrival_time",
+                "next_departure_time",
+                "duration_per_pers",
                 "travel_time",
                 "distance",
             ]
@@ -115,28 +124,17 @@ class PopulationWeightedPlanSteps(FileAsset):
             n_cars=pl.col("n_cars").cast(pl.Enum(n_cars_values)),
         )
         survey_plan_steps = survey_plan_steps.with_columns(
+            city_category=pl.col("city_category").cast(pl.Enum(city_category_values)),
+            csp=pl.col("csp").cast(pl.Enum(csp_values)),
+            n_cars=pl.col("n_cars").cast(pl.Enum(n_cars_values)),
             activity=pl.col("activity").cast(pl.Enum(activity_values)),
             mode=pl.col("mode").cast(pl.Enum(mode_values)),
         )
-        survey_plan_steps = survey_plan_steps.unique(
-            subset=["activity_seq_id", "time_seq_id", "seq_step_index"],
-            keep="first",
-        )
+        survey_plan_steps = survey_plan_steps.filter(pl.col("is_weekday") == self.is_weekday).drop("is_weekday")
         survey_plans = (
             survey_plans
             .filter(pl.col("is_weekday") == self.is_weekday)
             .drop("is_weekday")
-            .group_by(
-                [
-                    "country",
-                    "city_category",
-                    "csp",
-                    "n_cars",
-                    "activity_seq_id",
-                    "time_seq_id",
-                ]
-            )
-            .agg(p_plan=pl.col("p_plan").sum())
         )
 
         population_weighted_plan_steps = (
@@ -144,19 +142,26 @@ class PopulationWeightedPlanSteps(FileAsset):
             .with_columns(n_persons=pl.col("n_persons") * pl.col("p_plan"))
             .join(
                 survey_plan_steps,
-                on=["activity_seq_id", "time_seq_id"],
+                on=["activity_seq_id", "time_seq_id", "city_category", "csp", "n_cars"],
                 how="inner",
             )
             .select(
                 [
                     "country",
                     "home_zone_id",
+                    "city_category",
                     "csp",
+                    "n_cars",
                     "activity_seq_id",
                     "time_seq_id",
                     "seq_step_index",
                     "activity",
                     "mode",
+                    "is_anchor",
+                    "departure_time",
+                    "arrival_time",
+                    "next_departure_time",
+                    "duration_per_pers",
                     "travel_time",
                     "distance",
                     "n_persons",

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -101,16 +101,13 @@ class DestinationSequences(FileAsset):
         seed: int,
     ) -> pl.DataFrame:
         """Compute destination sequences for one iteration."""
-        utilities = self._get_utilities(
-            activities,
-            self.resolved_activity_parameters,
-            transport_zones,
+        utility_inputs = self._get_destination_probability_inputs(
             destination_saturation,
             costs,
             parameters.cost_uncertainty_sd,
         )
         destination_probability = self._get_destination_probability(
-            utilities,
+            utility_inputs,
             activities,
             self.resolved_activity_parameters,
             parameters.dest_prob_cutoff,
@@ -310,37 +307,13 @@ class DestinationSequences(FileAsset):
             }
         )
 
-    def _get_utilities(
+    def _get_destination_probability_inputs(
         self,
-        activities: list[Any],
-        resolved_activity_parameters: dict[str, Any] | None,
-        transport_zones: Any,
         opportunities: pl.DataFrame,
         costs: pl.DataFrame,
         cost_uncertainty_sd: float,
     ) -> tuple[pl.LazyFrame, pl.LazyFrame]:
-        """Assemble destination utilities with cost uncertainty."""
-        if resolved_activity_parameters is None:
-            raise ValueError("Cannot build destination utilities without resolved activity parameters.")
-        utilities = [
-            (
-                activity.name,
-                activity.get_utilities(
-                    transport_zones,
-                    parameters=resolved_activity_parameters[activity.name],
-                ),
-            )
-            for activity in activities
-        ]
-        utilities = [utility for utility in utilities if utility[1] is not None]
-        utilities = [utility[1].with_columns(activity=pl.lit(utility[0])) for utility in utilities]
-
-        activity_values = opportunities.schema["activity"].categories
-        utilities = (
-            pl.concat(utilities)
-            .with_columns(activity=pl.col("activity").cast(pl.Enum(activity_values)))
-        )
-
+        """Assemble radiation-model inputs from travel costs and destination sinks."""
         x = [-2.0, -1.0, 0.0, 1.0, 2.0]
         probabilities = norm.pdf(x, loc=0.0, scale=cost_uncertainty_sd)
         probabilities /= probabilities.sum()
@@ -361,9 +334,7 @@ class DestinationSequences(FileAsset):
             .with_columns(cost=pl.col("cost") + pl.col("cost_delta"))
             .drop("cost_delta")
             .join(opportunities.lazy(), on="to")
-            .join(utilities.lazy(), on=["activity", "to"], how="left")
             .with_columns(
-                utility=pl.col("utility").fill_null(0.0),
                 effective_sink=(
                     pl.col("opportunity_capacity")
                     * pl.col("k_saturation_utility").fill_null(1.0)
@@ -372,7 +343,7 @@ class DestinationSequences(FileAsset):
             )
             .drop("prob")
             .filter(pl.col("effective_sink") > 0.0)
-            .with_columns(cost_bin=(pl.col("cost") - pl.col("utility")).floor())
+            .with_columns(cost_bin=pl.col("cost").floor())
         )
         cost_bin_to_destination = (
             costs
@@ -392,7 +363,7 @@ class DestinationSequences(FileAsset):
 
     def _get_destination_probability(
         self,
-        utilities: tuple[pl.LazyFrame, pl.LazyFrame],
+        destination_probability_inputs: tuple[pl.LazyFrame, pl.LazyFrame],
         activities: list[Any],
         resolved_activity_parameters: dict[str, Any] | None,
         destination_probability_cutoff: float,
@@ -401,8 +372,8 @@ class DestinationSequences(FileAsset):
         logging.info(
             "Computing the probability of choosing a destination based on current location, potential destinations, and activity (with radiation models)..."
         )
-        costs_by_bin = utilities[0]
-        cost_bin_to_destination = utilities[1]
+        costs_by_bin = destination_probability_inputs[0]
+        cost_bin_to_destination = destination_probability_inputs[1]
         if resolved_activity_parameters is None:
             raise ValueError("Cannot compute destination probabilities without resolved activity parameters.")
         activities_lambda = {

--- a/mobility/trips/group_day_trips/plans/plan_initializer.py
+++ b/mobility/trips/group_day_trips/plans/plan_initializer.py
@@ -140,13 +140,12 @@ class PlanInitializer:
         mean_home_night_durations: pl.DataFrame,
         activity_demand_per_pers: pl.DataFrame,
         demand_groups: pl.DataFrame,
-        survey_plan_steps: pl.DataFrame,
+        activity_dtype,
     ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
         """Align summary-key enums with the runtime demand and activity domains."""
 
         country_dtype = demand_groups.schema["country"]
         csp_dtype = demand_groups.schema["csp"]
-        activity_dtype = survey_plan_steps.schema["activity"]
 
         return (
             mean_activity_durations.with_columns(
@@ -166,29 +165,93 @@ class PlanInitializer:
 
     def get_survey_duration_summaries(
         self,
-        survey_plan_assets: SurveyPlanAssets,
-        is_weekday,
+        population_weighted_plan_steps: pl.LazyFrame,
         demand_groups: pl.DataFrame,
-        survey_plan_steps: pl.DataFrame,
     ):
-        """Load precomputed survey-weighted summaries for one day type."""
+        """Build survey-derived summaries from the canonical weighted step asset.
+
+        The grouped day-trips model uses three different survey summaries:
+
+        - ``mean_activity_durations`` for step-level activity utility
+        - ``mean_home_night_durations`` for the stay-home utility term
+        - ``activity_demand_per_pers`` for destination opportunity capacity
+
+        They now all come from the same population-weighted survey reference
+        table so diagnostics and runtime opportunity totals use one source of
+        truth. The aggregations intentionally differ:
+
+        - mean activity duration is weighted per activity occurrence
+        - activity demand per person is weighted by total represented persons
+        """
+        two_minutes = 120.0 / 3600.0
+        plan_segment_keys = [
+            "country",
+            "home_zone_id",
+            "city_category",
+            "csp",
+            "n_cars",
+            "activity_seq_id",
+            "time_seq_id",
+        ]
+        plan_keys_without_home_zone = [key for key in plan_segment_keys if key != "home_zone_id"]
+
+        weighted_plan_steps = population_weighted_plan_steps.with_columns(
+            country=pl.col("country").cast(pl.String()),
+            csp=pl.col("csp").cast(pl.String()),
+            activity=pl.col("activity").cast(pl.String()),
+        )
+        weighted_plan_step_schema = population_weighted_plan_steps.collect_schema()
 
         mean_activity_durations = (
-            survey_plan_assets.get_mean_activity_durations()
-            .filter(pl.col("is_weekday") == is_weekday)
-            .drop("is_weekday")
+            weighted_plan_steps
+            .filter(pl.col("seq_step_index") != pl.col("seq_step_index").max().over(plan_keys_without_home_zone))
+            .group_by(["country", "csp", "activity"])
+            .agg(
+                mean_duration_per_pers=pl.max_horizontal(
+                    [
+                        (pl.col("duration_per_pers") * pl.col("n_persons")).sum()
+                        / pl.col("n_persons").sum().clip(1e-18),
+                        pl.lit(two_minutes),
+                    ]
+                )
+            )
+            .collect(engine="streaming")
         )
 
         mean_home_night_durations = (
-            survey_plan_assets.get_mean_home_night_durations()
-            .filter(pl.col("is_weekday") == is_weekday)
-            .drop("is_weekday")
+            weighted_plan_steps
+            .group_by(plan_segment_keys)
+            .agg(
+                n_persons=pl.col("n_persons").first(),
+                home_night_per_pers=24.0 - pl.col("duration_per_pers").sum(),
+            )
+            .group_by(["country", "csp"])
+            .agg(
+                mean_home_night_per_pers=pl.max_horizontal(
+                    [
+                        (pl.col("home_night_per_pers") * pl.col("n_persons")).sum()
+                        / pl.col("n_persons").sum().clip(1e-18),
+                        pl.lit(two_minutes),
+                    ]
+                )
+            )
+            .collect(engine="streaming")
         )
 
+        country_population = (
+            demand_groups
+            .with_columns(country=pl.col("country").cast(pl.String()))
+            .group_by("country")
+            .agg(pl.col("n_persons").sum().alias("country_n_persons"))
+        )
         activity_demand_per_pers = (
-            survey_plan_assets.get_activity_demand_per_pers()
-            .filter(pl.col("is_weekday") == is_weekday)
-            .drop("is_weekday")
+            weighted_plan_steps
+            .group_by(["country", "activity"])
+            .agg(total_duration=(pl.col("duration_per_pers") * pl.col("n_persons")).sum())
+            .join(country_population.lazy(), on="country", how="inner")
+            .with_columns(duration_per_pers=pl.col("total_duration") / pl.col("country_n_persons").clip(1e-18))
+            .select(["country", "activity", "duration_per_pers"])
+            .collect(engine="streaming")
         )
 
         return self._cast_summary_domains(
@@ -196,7 +259,7 @@ class PlanInitializer:
             mean_home_night_durations,
             activity_demand_per_pers,
             demand_groups,
-            survey_plan_steps,
+            weighted_plan_step_schema["activity"],
         )
 
     def get_stay_home_state(

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -58,6 +58,7 @@ class PlanUpdater:
             transport_costs,
             destination_saturation,
             activity_dur,
+            transport_zones,
             iteration,
             resolved_activity_parameters,
             parameters.min_activity_time_constant,
@@ -194,6 +195,7 @@ class PlanUpdater:
         transport_costs,
         destination_saturation,
         activity_dur,
+        transport_zones,
         iteration: int,
         resolved_activity_parameters: dict[str, Any],
         min_activity_time_constant,
@@ -223,6 +225,7 @@ class PlanUpdater:
             transport_costs=transport_costs,
             destination_saturation=destination_saturation,
             activity_dur=activity_dur,
+            transport_zones=transport_zones,
             resolved_activity_parameters=resolved_activity_parameters,
             min_activity_time_constant=min_activity_time_constant,
             allow_missing_costs_for_current_plans=(candidate_plan_steps is not None),
@@ -235,6 +238,7 @@ class PlanUpdater:
         transport_costs,
         destination_saturation: pl.DataFrame,
         activity_dur: pl.DataFrame,
+        transport_zones,
         resolved_activity_parameters: dict[str, Any],
         min_activity_time_constant,
         allow_missing_costs_for_current_plans: bool,
@@ -258,6 +262,30 @@ class PlanUpdater:
             ).with_columns(
                 activity=pl.col("activity").cast(pl.Enum(activity_dur["activity"].dtype.categories))
             )
+        )
+        destination_country = pl.from_pandas(
+            transport_zones.get().drop("geometry", axis=1, errors="ignore")[["transport_zone_id", "local_admin_unit_id"]]
+        ).with_columns(
+            to=pl.col("transport_zone_id").cast(pl.Int32),
+            destination_country=pl.col("local_admin_unit_id").str.slice(0, 2),
+        ).select(["to", "destination_country"])
+        country_value_coefficients = pl.from_dicts(
+            [
+                {
+                    "activity": activity_name,
+                    "destination_country": destination_country,
+                    "country_value_coefficient": coefficient,
+                }
+                for activity_name, activity_parameters in resolved_activity_parameters.items()
+                for destination_country, coefficient in (activity_parameters.country_value_coefficients or {}).items()
+            ],
+            schema={
+                "activity": pl.Utf8,
+                "destination_country": pl.Utf8,
+                "country_value_coefficient": pl.Float64,
+            },
+        ).with_columns(
+            activity=pl.col("activity").cast(pl.Enum(activity_dur["activity"].dtype.categories))
         )
         possible_plan_step_columns = [
             "demand_group_id",
@@ -306,22 +334,31 @@ class PlanUpdater:
                 on=["to", "activity"],
                 how="left",
             )
+            .join(destination_country.lazy(), on="to", how="left")
+            .join(
+                country_value_coefficients.lazy(),
+                on=["activity", "destination_country"],
+                how="left",
+            )
             .with_columns(
                 cost=pl.col("cost").fill_null(1e9) if allow_missing_costs_for_current_plans else pl.col("cost"),
                 distance=pl.col("distance").fill_null(0.0),
                 time=pl.col("time").fill_null(0.0),
                 k_saturation_utility=pl.col("k_saturation_utility").fill_null(1.0),
+                country_value_coefficient=pl.col("country_value_coefficient").fill_null(1.0),
                 min_activity_time=pl.col("mean_duration_per_pers") * math.exp(-min_activity_time_constant),
             )
             .with_columns(
                 utility=(
-                    pl.col("k_saturation_utility")
+                    pl.col("country_value_coefficient")
+                    * pl.col("k_saturation_utility")
                     * pl.col("value_of_time")
                     * pl.col("mean_duration_per_pers")
                     * (pl.col("duration_per_pers") / pl.col("min_activity_time")).log().clip(0.0)
                     - pl.col("cost")
                 )
             )
+            .drop(["destination_country", "country_value_coefficient"])
             .select(possible_plan_step_columns)
         )
 

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -1,7 +1,9 @@
 import math
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
+import pytest
 
 from mobility.trips.group_day_trips import BehaviorChangePhase, BehaviorChangeScope, Parameters
 from mobility.trips.group_day_trips.plans.destination_sequences import DestinationSequences
@@ -205,6 +207,58 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
     destination_sequences._sample_active_destination_sequences()
 
     assert seen["chains"].select("activity_seq_id").to_series().to_list() == [10]
+
+
+def test_destination_probability_inputs_use_cost_and_sink_even_without_destination_utilities(tmp_path):
+    destination_sequences = DestinationSequences(
+        run_key="run",
+        is_weekday=True,
+        iteration=1,
+        base_folder=_make_local_tmp_path(tmp_path, "destination_utilities_default_zero"),
+        activities=[],
+        transport_zones=None,
+        destination_saturation=pl.DataFrame(),
+        demand_groups=pl.DataFrame(),
+        costs=pl.DataFrame(),
+        parameters=Parameters(),
+        seed=123,
+        resolved_activity_parameters={},
+        current_plans=pl.DataFrame(),
+    )
+
+    class _TransportCosts:
+        def __init__(self):
+            self.modes = [SimpleNamespace(inputs={"parameters": SimpleNamespace(name="car")})]
+
+        def get_costs_by_od_and_mode(self, columns, detail_distances=False):
+            return pl.DataFrame(
+                {
+                    "from": [1],
+                    "to": [10],
+                    "mode": ["car"],
+                    "cost": [3.0],
+                    "distance": [10.0],
+                    "time": [1.0],
+                }
+            )
+
+    opportunities = pl.DataFrame(
+        {
+            "to": [10],
+            "activity": ["work"],
+            "opportunity_capacity": [100.0],
+            "k_saturation_utility": [1.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+
+    costs_by_bin, cost_bin_to_destination = destination_sequences._get_destination_probability_inputs(
+        opportunities=opportunities,
+        costs=_TransportCosts().get_costs_by_od_and_mode(["cost", "distance", "time"]),
+        cost_uncertainty_sd=1.0,
+    )
+
+    assert costs_by_bin.collect().height > 0
+    assert cost_bin_to_destination.collect().height > 0
 
 
 def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path):

--- a/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
+++ b/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
@@ -11,11 +11,16 @@ def _make_results(
     plan_steps: pl.DataFrame,
     demand_groups: pl.DataFrame | None = None,
     run: SimpleNamespace | None = None,
+    population_weighted_plan_steps: pl.DataFrame | None = None,
 ) -> RunResults:
     if demand_groups is None:
         demand_groups = pl.DataFrame({"n_persons": [float(plan_steps["n_persons"].sum())]})
     if run is None:
         run = SimpleNamespace()
+    if population_weighted_plan_steps is None:
+        population_weighted_plan_steps = plan_steps
+        if "home_zone_id" not in population_weighted_plan_steps.columns:
+            population_weighted_plan_steps = population_weighted_plan_steps.with_columns(home_zone_id=pl.lit(0))
     return RunResults(
         inputs_hash="run",
         is_weekday=True,
@@ -24,7 +29,7 @@ def _make_results(
         plan_steps=plan_steps.lazy(),
         opportunities=pl.DataFrame().lazy(),
         costs=pl.DataFrame().lazy(),
-        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=population_weighted_plan_steps.lazy(),
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
@@ -56,6 +61,7 @@ def test_activity_time_series_uses_average_bin_occupancy_and_splits_transit_by_m
     results = _make_results(plan_steps)
 
     series = results.metrics.activity_time_series(interval_minutes=15)
+    series = series.filter(pl.col("source") == "observed").drop("source")
 
     at_0800 = series.filter(pl.col("time_label") == "08:00").sort("label")
     assert at_0800["label"].to_list() == ["home", "in_transit:car", "work"]
@@ -99,6 +105,7 @@ def test_activity_time_series_completes_missing_home_time_so_totals_stay_constan
 
     totals = (
         results.metrics.activity_time_series(interval_minutes=15)
+        .filter(pl.col("source") == "observed")
         .group_by("time_label")
         .agg(total=pl.col("n_persons").sum())
     )
@@ -106,31 +113,67 @@ def test_activity_time_series_completes_missing_home_time_so_totals_stay_constan
     assert totals["total"].to_list() == pytest.approx([3.0] * totals.height)
 
 
-def test_activity_time_series_can_trigger_plotting_from_same_entrypoint(monkeypatch):
-    """Check that callers can request the plot from the activity_time_series entrypoint.
+def test_activity_time_series_plot_builds_survey_panel_when_survey_assets_are_available(monkeypatch):
+    """Check that plotting can attach a survey-derived comparison panel.
 
-    In plain language: the same method should still return the table, but when
-    `plot=True` it should also call the plotting path so callers can use the
-    grouped `results.metrics` API directly for both data and charts.
+    In plain language: when the results object carries the canonical
+    population-weighted survey reference steps with timing fields, the plotting
+    entrypoint should prepare both the modeled time series and a survey-derived
+    counterpart so the chart can place survey on the left and model on the
+    right.
     """
+    plan_steps = pl.DataFrame(
+        {
+            "activity": ["work"],
+            "mode": ["car"],
+            "n_persons": [2.0],
+            "departure_time": [8.0],
+            "arrival_time": [8.25],
+            "next_departure_time": [9.0],
+        }
+    )
+    demand_groups = pl.DataFrame(
+        {
+            "country": ["fr"],
+            "city_category": ["urban"],
+            "csp": ["A"],
+            "n_cars": ["1"],
+            "n_persons": [2.0],
+        }
+    )
+    population_weighted_plan_steps = pl.DataFrame(
+        {
+            "country": ["fr"],
+            "home_zone_id": [1],
+            "city_category": ["urban"],
+            "csp": ["A"],
+            "n_cars": ["1"],
+            "activity_seq_id": [1],
+            "time_seq_id": [1],
+            "seq_step_index": [0],
+            "activity": ["work"],
+            "mode": ["car"],
+            "is_anchor": [True],
+            "departure_time": [8.0],
+            "arrival_time": [8.25],
+            "next_departure_time": [9.0],
+            "duration_per_pers": [0.75],
+            "travel_time": [0.25],
+            "distance": [10.0],
+            "n_persons": [2.0],
+        }
+    )
     results = _make_results(
-        pl.DataFrame(
-            {
-                "activity": ["home"],
-                "mode": ["stay_home"],
-                "n_persons": [1.0],
-                "departure_time": [0.0],
-                "arrival_time": [0.0],
-                "next_departure_time": [24.0],
-            }
-        )
+        plan_steps,
+        demand_groups=demand_groups,
+        population_weighted_plan_steps=population_weighted_plan_steps,
     )
 
     seen = {}
 
-    def fake_plot(df, *, survey_time_series=None):
+    def fake_plot(df):
         seen["rows"] = df.height
-        seen["survey_rows"] = None if survey_time_series is None else survey_time_series.height
+        seen["sources"] = sorted(df["source"].unique().to_list())
         return "figure"
 
     monkeypatch.setattr(results.metrics, "_plot_activity_time_series", fake_plot)
@@ -138,7 +181,64 @@ def test_activity_time_series_can_trigger_plotting_from_same_entrypoint(monkeypa
     series = results.metrics.activity_time_series(interval_minutes=15, plot=True)
 
     assert seen["rows"] == series.height
-    assert seen["survey_rows"] is None
+    assert seen["sources"] == ["observed", "survey"]
+    assert series.filter(pl.col("source") == "survey").height > 0
+
+
+def test_activity_time_series_can_match_inner_zone_resident_scope():
+    """Check that callers can restrict the series to inner-zone residents only.
+
+    In plain language: this should use the same resident subset logic as
+    opportunity-based metrics, so people living outside the inner study area do
+    not contribute to the returned occupancy totals.
+    """
+    plan_steps = pl.DataFrame(
+        {
+            "activity": ["work", "work"],
+            "mode": ["car", "car"],
+            "n_persons": [2.0, 3.0],
+            "departure_time": [8.0, 8.0],
+            "arrival_time": [8.25, 8.25],
+            "next_departure_time": [9.0, 9.0],
+            "home_zone_id": [1, 2],
+        }
+    )
+    demand_groups = pl.DataFrame(
+        {
+            "home_zone_id": [1, 2],
+            "n_persons": [2.0, 3.0],
+        }
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: __import__("pandas").DataFrame(
+            {
+                "transport_zone_id": [1, 2],
+                "is_inner_zone": [True, False],
+            }
+        ),
+        study_area=SimpleNamespace(get=lambda: None),
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=demand_groups.lazy(),
+        plan_steps=plan_steps.lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=plan_steps.lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=SimpleNamespace(),
+    )
+
+    series = results.metrics.activity_time_series(interval_minutes=15, inner_zone_residents_only=True)
+    observed = series.filter(pl.col("source") == "observed")
+    totals = observed.group_by("time_label").agg(total=pl.col("n_persons").sum()).sort("time_label")
+
+    assert totals["total"].to_list() == pytest.approx([2.0] * totals.height)
 
 
 def test_activity_time_series_rejects_intervals_that_do_not_divide_the_day():
@@ -159,7 +259,7 @@ def test_activity_time_series_rejects_intervals_that_do_not_divide_the_day():
         results.metrics.activity_time_series(interval_minutes=7)
 
 
-def test_plot_activity_time_series_wrapper_returns_plot_result(monkeypatch):
+def test_plot_activity_time_series_wrapper_passes_scope_and_returns_plot_result(monkeypatch):
     results = _make_results(
         pl.DataFrame(
             {
@@ -176,6 +276,7 @@ def test_plot_activity_time_series_wrapper_returns_plot_result(monkeypatch):
     seen = {}
     expected_series = pl.DataFrame(
         {
+            "source": ["observed"],
             "time_bin_start": [0.0],
             "time_label": ["00:00"],
             "label": ["home"],
@@ -183,8 +284,9 @@ def test_plot_activity_time_series_wrapper_returns_plot_result(monkeypatch):
         }
     )
 
-    def fake_activity_time_series(*, interval_minutes):
+    def fake_activity_time_series(*, interval_minutes, inner_zone_residents_only):
         seen["interval_minutes"] = interval_minutes
+        seen["inner_zone_residents_only"] = inner_zone_residents_only
         return expected_series
 
     def fake_plot(df):
@@ -194,14 +296,18 @@ def test_plot_activity_time_series_wrapper_returns_plot_result(monkeypatch):
     monkeypatch.setattr(results.metrics, "activity_time_series", fake_activity_time_series)
     monkeypatch.setattr(results.metrics, "_plot_activity_time_series", fake_plot)
 
-    figure = results.metrics.plot_activity_time_series(interval_minutes=30)
+    figure = results.metrics.plot_activity_time_series(
+        interval_minutes=30,
+        inner_zone_residents_only=True,
+    )
 
     assert figure == "figure"
     assert seen["interval_minutes"] == 30
+    assert seen["inner_zone_residents_only"] is True
     assert seen["plotted_series"].equals(expected_series)
 
 
-def test_plot_activity_time_series_builds_stacked_figure_without_opening_browser(monkeypatch):
+def test_plot_activity_time_series_builds_one_panel_per_available_source(monkeypatch):
     results = _make_results(
         pl.DataFrame(
             {
@@ -216,10 +322,11 @@ def test_plot_activity_time_series_builds_stacked_figure_without_opening_browser
     )
     time_series = pl.DataFrame(
         {
-            "time_bin_start": [8.0, 8.0, 8.25, 8.25],
-            "time_label": ["08:00", "08:00", "08:15", "08:15"],
-            "label": ["work", "home", "work", "custom"],
-            "n_persons": [1.0, 2.0, 2.0, 0.5],
+            "source": ["survey", "survey", "observed", "observed"],
+            "time_bin_start": [8.0, 8.25, 8.0, 8.25],
+            "time_label": ["08:00", "08:15", "08:00", "08:15"],
+            "label": ["work", "mystery", "work", "mystery"],
+            "n_persons": [1.0, 0.5, 2.0, 1.5],
         }
     )
     seen = {}
@@ -232,7 +339,25 @@ def test_plot_activity_time_series_builds_stacked_figure_without_opening_browser
     fig = results.metrics._plot_activity_time_series(time_series)
 
     assert seen["show_called"] is True
+    assert len(fig.data) == 4
     assert fig.layout.barmode == "stack"
-    assert list(dict.fromkeys(fig.layout.xaxis.categoryarray)) == ["08:00", "08:15"]
+    assert list(fig.layout.xaxis.categoryarray) == ["08:00", "08:15"]
+    assert list(fig.layout.xaxis2.categoryarray) == ["08:00", "08:15"]
 
 
+def test_activity_time_series_color_map_uses_fixed_and_fallback_colors():
+    color_map = _make_results(
+        pl.DataFrame(
+            {
+                "activity": ["home"],
+                "mode": ["stay_home"],
+                "n_persons": [1.0],
+                "departure_time": [0.0],
+                "arrival_time": [0.0],
+                "next_departure_time": [24.0],
+            }
+        )
+    ).metrics._activity_time_series_color_map(["work", "custom_a", "custom_b"])
+
+    assert color_map["work"] == "#355CDE"
+    assert color_map["custom_a"] != color_map["custom_b"]

--- a/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
+++ b/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
@@ -108,6 +108,68 @@ def test_metrics_aggregate_and_travel_indicators_by_match_reference_when_inputs_
     assert by_time_bin["delta"].to_list() == pytest.approx([0.0] * by_time_bin.height)
 
 
+def test_opportunity_occupation_includes_full_capacity_stock_once_per_destination_activity():
+    """Check that diagnostics include the full opportunity stock once.
+
+    In plain language: if one destination/activity pair receives duration from
+    several resident-scope segments, aggregated opportunity capacity should
+    still match the underlying unique destination supply. Unused destinations
+    should remain visible with zero duration so summed capacity reflects the
+    full stock, not only occupied sinks.
+    """
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": [1, 2, 10, 11],
+                "is_inner_zone": [True, False, True, False],
+                "geometry": [None, None, None, None],
+            }
+        ),
+        study_area=SimpleNamespace(get=lambda: None),
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame({"n_persons": [5.0]}).lazy(),
+        plan_steps=pl.DataFrame(
+            {
+                "activity_seq_id": [1, 1],
+                "home_zone_id": [1, 2],
+                "activity": ["work", "work"],
+                "to": [10, 10],
+                "duration": [2.0, 3.0],
+            }
+        ).lazy(),
+        opportunities=pl.DataFrame(
+            {
+                "to": [10, 11],
+                "activity": ["work", "work"],
+                "opportunity_capacity": [100.0, 50.0],
+            }
+        ).lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=SimpleNamespace(),
+    )
+
+    occupation = results.metrics.opportunity_occupation(inner_zone_residents_only=False)
+    unused_destination = occupation.filter(pl.col("transport_zone_id") == 11)
+    totals = occupation.group_by("activity").agg(
+        duration=pl.col("duration").sum(),
+        opportunity_capacity=pl.col("opportunity_capacity").sum(),
+    )
+
+    assert unused_destination["duration"].to_list() == pytest.approx([0.0])
+    assert unused_destination["opportunity_occupation"].to_list() == pytest.approx([0.0])
+    assert totals["duration"].to_list() == pytest.approx([5.0])
+    assert totals["opportunity_capacity"].to_list() == pytest.approx([150.0])
+
+
 def test_opportunity_occupation_plot_path_masks_outliers_and_plots(monkeypatch):
     class _GeoFrame(pd.DataFrame):
         @property
@@ -174,6 +236,7 @@ def test_opportunity_occupation_plot_path_masks_outliers_and_plots(monkeypatch):
     occupation = results.metrics.opportunity_occupation(
         plot_activity="work",
         mask_outliers=True,
+        inner_zone_residents_only=True,
     )
 
     assert occupation["opportunity_occupation"].to_list() == pytest.approx([0.02])

--- a/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
+++ b/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
@@ -712,8 +712,6 @@ def test_mask_outliers_replaces_extreme_values_with_nan():
 
     assert pd.isna(masked.iloc[-1])
     assert masked.iloc[0] == pytest.approx(1.0)
-
-
 def test_model_loss_summary_history_and_validation():
     expected = pl.DataFrame(
         {

--- a/tests/back/unit/domain/group_day_trips/test_010_population_weighted_survey_summaries.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_population_weighted_survey_summaries.py
@@ -1,0 +1,67 @@
+import polars as pl
+import pytest
+
+from mobility.trips.group_day_trips.plans.plan_initializer import PlanInitializer
+
+
+def test_population_weighted_survey_summaries_use_one_asset_with_correct_aggregations():
+    """Check that runtime survey summaries come from one weighted step asset.
+
+    In plain language: the same weighted survey step table should drive both
+    activity-duration utilities and opportunity-demand totals, but with two
+    different aggregations:
+
+    - mean activity duration is averaged across activity occurrences
+    - activity demand per person is summed across all represented persons
+    """
+    initializer = PlanInitializer()
+    population_weighted_plan_steps = pl.DataFrame(
+        {
+            "country": ["fr"] * 7,
+            "home_zone_id": [1] * 7,
+            "city_category": ["urban"] * 7,
+            "csp": ["A"] * 7,
+            "n_cars": ["1"] * 7,
+            "activity_seq_id": [1, 1, 2, 2, 2, 2, 2],
+            "time_seq_id": [1, 1, 2, 2, 2, 2, 2],
+            "seq_step_index": [0, 1, 0, 1, 2, 3, 4],
+            "activity": ["work", "home", "work", "shopping", "shopping", "other", "home"],
+            "duration_per_pers": [8.0, 16.0, 4.0, 1.0, 1.0, 1.0, 17.0],
+            "n_persons": [6.0, 6.0, 4.0, 4.0, 4.0, 4.0, 4.0],
+        }
+    ).lazy()
+    demand_groups = pl.DataFrame(
+        {
+            "country": ["fr"],
+            "home_zone_id": [1],
+            "city_category": ["urban"],
+            "csp": ["A"],
+            "n_cars": ["1"],
+            "n_persons": [10.0],
+        }
+    )
+    mean_activity_durations, mean_home_night_durations, activity_demand_per_pers = (
+        initializer.get_survey_duration_summaries(
+            population_weighted_plan_steps,
+            demand_groups,
+        )
+    )
+
+    mean_activity_duration_by_activity = {
+        row["activity"]: row["mean_duration_per_pers"]
+        for row in mean_activity_durations.to_dicts()
+    }
+    assert mean_activity_duration_by_activity["work"] == pytest.approx((8.0 * 6.0 + 4.0 * 4.0) / 10.0)
+    assert mean_activity_duration_by_activity["shopping"] == pytest.approx(1.0)
+    assert mean_activity_duration_by_activity["other"] == pytest.approx(1.0)
+
+    assert mean_home_night_durations["mean_home_night_per_pers"].to_list() == pytest.approx([120.0 / 3600.0])
+
+    activity_demand_by_activity = {
+        row["activity"]: row["duration_per_pers"]
+        for row in activity_demand_per_pers.to_dicts()
+    }
+    assert activity_demand_by_activity["work"] == pytest.approx((8.0 * 6.0 + 4.0 * 4.0) / 10.0)
+    assert activity_demand_by_activity["shopping"] == pytest.approx((1.0 * 4.0 + 1.0 * 4.0) / 10.0)
+    assert activity_demand_by_activity["other"] == pytest.approx((1.0 * 4.0) / 10.0)
+    assert activity_demand_by_activity["home"] == pytest.approx((16.0 * 6.0 + 17.0 * 4.0) / 10.0)

--- a/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
+++ b/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from mobility.trips.group_day_trips.plans.plan_updater import PlanUpdater
+
+
+def test_plan_updater_applies_destination_country_value_coefficient():
+    updater = PlanUpdater()
+    candidates = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1],
+            "country": ["fr", "fr"],
+            "activity_seq_id": [10, 10],
+            "time_seq_id": [1, 1],
+            "dest_seq_id": [100, 101],
+            "mode_seq_id": [1000, 1001],
+            "seq_step_index": [0, 0],
+            "activity": ["work", "work"],
+            "from": [1, 1],
+            "to": [10, 20],
+            "mode": ["car", "car"],
+            "duration_per_pers": [8.0, 8.0],
+            "departure_time": [8.0, 8.0],
+            "arrival_time": [9.0, 9.0],
+            "next_departure_time": [17.0, 17.0],
+            "iteration": [1, 1],
+            "csp": ["x", "x"],
+            "first_seen_iteration": [None, None],
+            "last_active_iteration": [None, None],
+        }
+    ).with_columns(mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"]))).lazy()
+    activity_dur = pl.DataFrame(
+        {
+            "country": ["fr"],
+            "csp": ["x"],
+            "activity": ["work"],
+            "mean_duration_per_pers": [8.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+    destination_saturation = pl.DataFrame(
+        {
+            "to": [10, 20],
+            "activity": ["work", "work"],
+            "k_saturation_utility": [1.0, 1.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+
+    class _StubTransportCosts:
+        def __init__(self):
+            self.modes = [SimpleNamespace(inputs={"parameters": SimpleNamespace(name="car")})]
+
+        def get_costs_by_od_and_mode(self, columns, detail_distances=False):
+            return pl.DataFrame(
+                {
+                    "from": [1, 1],
+                    "to": [10, 20],
+                    "mode": ["car", "car"],
+                    "cost": [1.0, 1.0],
+                    "distance": [10.0, 10.0],
+                    "time": [1.0, 1.0],
+                }
+            )
+
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": [10, 20],
+                "local_admin_unit_id": ["fr001", "ch001"],
+            }
+        )
+    )
+    resolved_activity_parameters = {
+        "work": SimpleNamespace(value_of_time=1.0, country_value_coefficients={"fr": 1.0, "ch": 2.0}),
+    }
+
+    result = updater.compute_plan_steps_candidates_utility(
+        candidates=candidates,
+        transport_costs=_StubTransportCosts(),
+        destination_saturation=destination_saturation,
+        activity_dur=activity_dur,
+        transport_zones=transport_zones,
+        resolved_activity_parameters=resolved_activity_parameters,
+        min_activity_time_constant=1.0,
+        allow_missing_costs_for_current_plans=False,
+    ).collect()
+
+    utilities_by_destination = dict(zip(result["to"].to_list(), result["utility"].to_list(), strict=True))
+    assert utilities_by_destination[10] == pytest.approx(7.0)
+    assert utilities_by_destination[20] == pytest.approx(15.0)


### PR DESCRIPTION
### Motivation
This PR makes the `group_day_trips` survey references and diagnostics more consistent.

Before this change, some runtime summaries and diagnostics were built from different survey assets or with different aggregation rules. So model vs survey comparisons were a bit off.

This PR also adds destination-country value utility multipliers, instead of constants, which should be more behaviorally correct: working in Switzerland is modelled as a change in wage per hour, instead of a fixed payoff. This multiplier applies only to plan utility calculations, not the radiation models, so destination sampling does not take this multiplier into account for now.

### Changes
This PR updates the grouped day-trips model in four areas.

- Survey-weighted reference plan steps:
  `PopulationWeightedPlanSteps` now keeps the fields needed for runtime summaries and diagnostics, including timing fields and segmentation fields.
- Survey-derived summaries:
  `PlanInitializer.get_survey_duration_summaries()` now builds mean activity durations, mean home-night durations, and activity demand per person from one canonical population-weighted step table.
- Diagnostics and metrics:
  `RunMetrics.activity_time_series()` now supports modeled-versus-survey comparisons from the same reference source and can restrict results to inner-zone residents.
  `RunMetrics.opportunity_occupation()` now keeps the full modeled opportunity stock, including destinations with zero realized occupation.
- Destination and plan scoring:
  `country_utilities` is replaced with `country_value_coefficients` in activity parameters.
  `PlanUpdater.compute_plan_steps_candidates_utility()` now applies destination-country coefficients.
  `DestinationSequences` is simplified so destination probability inputs depend on travel costs and destination sinks.
- Tests:
  Added and updated unit tests for activity time series, opportunity occupation, weighted survey summaries, destination-country value coefficients, and destination probability inputs.

### Example (if relevant)
A modeler can now define destination-country value coefficients for an activity, for example:

```python
WorkActivity(
    country_value_coefficients={
        "fr": 1.0,
        "ch": 2.0,
    }
)
```

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: refactoring support for survey-summary and diagnostics code, test updates, and branch splitting from a mixed local change set.
- What you reviewed or changed: reviewed the code paths, checked that diagnostics and runtime changes were consistent, and cleaned up branch-specific test mismatches.
- How you validated it (tests, checks, manual verification): ran targeted unit tests, checked the code on a case study.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior