### PR TITLE
Fix high memory usage

### DIFF
--- a/mobility/__init__.py
+++ b/mobility/__init__.py
@@ -1,4 +1,8 @@
-from .config import set_params
+from .config import apply_import_time_memory_reclaim_policy, set_params
+
+# Apply startup memory policy before importing submodules that import Polars.
+# This has to stay at the very top of the package import chain to be useful.
+apply_import_time_memory_reclaim_policy()
 
 from .spatial.study_area import StudyArea
 from .spatial.transport_zones import TransportZones

--- a/mobility/config.py
+++ b/mobility/config.py
@@ -1,12 +1,20 @@
-import os
-import sys
-import pathlib
-import logging
-import platform
 import json
+import logging
+import os
+import pathlib
+import platform
+import sys
+import warnings
 
 from importlib import resources
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
+
+# This is a workaround for retained native memory after heavy Polars workloads.
+# Keep the references below so we can revisit this if upstream behavior improves:
+# - https://github.com/pola-rs/polars/issues/22871
+# - https://github.com/pola-rs/polars/issues/23128
+# - https://github.com/pola-rs/polars/issues/27061
+# - https://github.com/pola-rs/polars/pull/27395
 
 
 def set_params(
@@ -29,7 +37,7 @@ def set_params(
     """
     Sets up the necessary environment for the Mobility package.
 
-    This function configures logging, sets various environment variables, and establishes default paths 
+    This function configures logging, sets various environment variables, and establishes default paths
     for package and project data folders.
 
     Parameters:
@@ -51,7 +59,7 @@ def set_params(
     """
 
     setup_logging(logging_level)
-    
+
     set_env_variable("MOBILITY_ENV_PATH", str(pathlib.Path(sys.executable).parent))
     set_env_variable("MOBILITY_CERT_FILE", path_to_pem_file)
     set_env_variable("HTTP_PROXY", http_proxy_url)
@@ -60,7 +68,7 @@ def set_params(
     set_env_variable("MOBILITY_R_MAX_RETRIES", r_max_retries)
     set_env_variable("MOBILITY_R_RETRY_DELAY_SECONDS", r_retry_delay_seconds)
     set_env_variable("MOBILITY_R_HEARTBEAT_INTERVAL_SECONDS", r_heartbeat_interval_seconds)
-    
+
     os.environ["MOBILITY_DEBUG"] = "1" if debug else "0"
     setup_ssl_truststore(inject_into_ssl)
 
@@ -68,6 +76,121 @@ def set_params(
     setup_project_data_folder_path(project_data_folder_path)
 
     install_r_packages(r_packages, r_packages_force_reinstall, r_packages_download_method)
+
+
+def update(memory_reclaim_policy=None):
+    """
+    Creates or updates the Mobility user config file.
+
+    Parameters:
+    memory_reclaim_policy (str, optional): Startup memory reclaim policy.
+    Returns:
+    pathlib.Path: Path to the updated config file.
+
+    This function persists the preferred startup policy for future Python
+    sessions in ``~/.mobility/mobility_config.json``. It does not try to
+    reconfigure the current process, because allocator settings are usually
+    applied too early for a live update to be reliable once Polars has already
+    been imported.
+    """
+    if memory_reclaim_policy is None:
+        raise ValueError(
+            "update() needs a memory_reclaim_policy value. "
+            "Use 'aggressive' or 'default'."
+        )
+
+    config_path = pathlib.Path.home() / ".mobility" / "mobility_config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = json.load(handle)
+        if not isinstance(config, dict):
+            raise ValueError(
+                "Mobility config file must contain a JSON object. "
+                f"Please check this file: {config_path}"
+            )
+    else:
+        config = {}
+
+    if memory_reclaim_policy not in {"aggressive", "default"}:
+        raise ValueError(
+            "Unknown memory reclaim policy: "
+            f"{memory_reclaim_policy}. Supported values are: "
+            "'aggressive' and 'default'."
+        )
+    config["memory_reclaim_policy"] = memory_reclaim_policy
+
+    with config_path.open("w", encoding="utf-8") as handle:
+        json.dump(config, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    warnings.warn(
+        "Saved Mobility config to "
+        f"{config_path}. Restart Python or your notebook kernel to apply the new "
+        "startup memory policy. Import mobility before polars, otherwise the "
+        "allocator settings will be applied too late for the current process.",
+        stacklevel=2,
+    )
+
+    return config_path
+
+
+def apply_import_time_memory_reclaim_policy():
+    """
+    Applies the startup memory reclaim policy before Polars is imported.
+
+    Parameters:
+    Returns:
+    str: Applied memory reclaim policy.
+
+    Why this exists:
+    heavy Polars workloads can keep a high amount of reserved native memory
+    after peak operations. More aggressive allocator reclaim settings can
+    reduce retained RAM a lot on long simulations, which is usually a better
+    default for Mobility users than maximizing raw throughput.
+
+    The startup config is read from ``~/.mobility/mobility_config.json`` on
+    purpose. It must be available before runtime setup, because custom package
+    data folders are usually only known later in the process.
+
+    Upstream context:
+    - https://github.com/pola-rs/polars/issues/22871
+    - https://github.com/pola-rs/polars/issues/23128
+    - https://github.com/pola-rs/polars/issues/27061
+    - https://github.com/pola-rs/polars/pull/27395
+    """
+    config_path = pathlib.Path.home() / ".mobility" / "mobility_config.json"
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = json.load(handle)
+        if not isinstance(config, dict):
+            raise ValueError(
+                "Mobility config file must contain a JSON object. "
+                f"Please check this file: {config_path}"
+            )
+    else:
+        config = {}
+    policy = config.get("memory_reclaim_policy", "aggressive")
+    if policy not in {"aggressive", "default"}:
+        raise ValueError(
+            "Unknown memory reclaim policy in Mobility config file: "
+            f"{policy}. Supported values are: 'aggressive' and 'default'. "
+            f"Please update this file: {config_path}"
+        )
+
+    if policy == "default":
+        return policy
+
+    if platform.system() == "Windows":
+        # Windows Python Polars builds use mimalloc, so this is the relevant
+        # low-level knob to encourage faster purge of unused pages.
+        os.environ.setdefault("MIMALLOC_PURGE_DELAY", "0")
+    else:
+        # Unix Python Polars builds typically use jemalloc. Setting both decay
+        # values to zero makes unused pages eligible for release immediately.
+        os.environ.setdefault("_RJEM_MALLOC_CONF", "dirty_decay_ms:0,muzzy_decay_ms:0")
+
+    return policy
 
 
 def set_env_variable(key, value):
@@ -102,6 +225,11 @@ def setup_logging(logging_level="INFO"):
         force=True,
     )
 
+    # Keep Mobility debug logs available while muting very noisy third-party
+    # internals that do not help most users, like Matplotlib font discovery.
+    logging.getLogger("matplotlib").setLevel(logging.WARNING)
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.WARNING)
+
 
 def setup_ssl_truststore(inject_into_ssl=False):
     """
@@ -126,7 +254,7 @@ def setup_package_data_folder_path(package_data_folder_path):
     """
     Sets up the package data folder path.
 
-    If a path is provided, it is used; otherwise, a default path is set. This function also ensures 
+    If a path is provided, it is used; otherwise, a default path is set. This function also ensures
     the creation of the default folder if it doesn't exist, after user confirmation.
 
     Parameters:
@@ -134,17 +262,17 @@ def setup_package_data_folder_path(package_data_folder_path):
     """
 
     if package_data_folder_path is not None:
-        
+
         if not pathlib.Path(package_data_folder_path).exists():
             os.makedirs(package_data_folder_path)
-            
+
         os.environ["MOBILITY_PACKAGE_DATA_FOLDER"] = str(package_data_folder_path)
 
     else:
         default_path = pathlib.Path.home() / ".mobility/data"
         os.environ["MOBILITY_PACKAGE_DATA_FOLDER"] = str(default_path)
 
-        if default_path.exists() is False:
+        if not default_path.exists():
             logging.info("Mobility needs a folder to store common datasets, that will be used for every project.")
             logging.info("You did not provide the package_data_folder_path argument, so we'll use a default folder : " + str(default_path))
 
@@ -161,7 +289,7 @@ def setup_project_data_folder_path(project_data_folder_path):
     """
     Sets up the project data folder path.
 
-    If a path is provided, it is used; otherwise, a default path is set. This function also ensures 
+    If a path is provided, it is used; otherwise, a default path is set. This function also ensures
     the creation of the default folder if it doesn't exist, after user confirmation.
 
     Parameters:
@@ -169,17 +297,17 @@ def setup_project_data_folder_path(project_data_folder_path):
     """
 
     if project_data_folder_path is not None:
-        
+
         if not pathlib.Path(project_data_folder_path).exists():
             os.makedirs(project_data_folder_path)
-            
+
         os.environ["MOBILITY_PROJECT_DATA_FOLDER"] = str(project_data_folder_path)
 
     else:
         default_path = pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"]) / "projects"
         os.environ["MOBILITY_PROJECT_DATA_FOLDER"] = str(default_path)
 
-        if default_path.exists() is False:
+        if not default_path.exists():
 
             logging.info("Mobility needs a folder to cache datasets that are specific to projects.")
             logging.info("You did not provide the project_data_folder_path argument, so we'll use a default folder : " + str(default_path))
@@ -194,9 +322,8 @@ def setup_project_data_folder_path(project_data_folder_path):
 
 
 def install_r_packages(r_packages, r_packages_force_reinstall, r_packages_download_method):
+    if r_packages:
 
-    if r_packages is True:
-    
         packages = [
             {'source': 'CRAN', 'name': 'remotes'},
             {'source': 'CRAN', 'name': 'dodgr'},
@@ -219,7 +346,7 @@ def install_r_packages(r_packages, r_packages_force_reinstall, r_packages_downlo
             {'source': 'CRAN', 'name': 'cluster'},
             {'source': 'CRAN', 'name': 'dbscan'}
         ]
-        
+
         if platform.system() == "Windows":
             packages.append(
                 {
@@ -229,13 +356,12 @@ def install_r_packages(r_packages, r_packages_force_reinstall, r_packages_downlo
             )
         else:
             packages.append({'source': 'CRAN', 'name': 'osmdata'})
-            
-            
+
         args = [
             json.dumps(packages),
             str(r_packages_force_reinstall),
             r_packages_download_method
         ]
-            
+
         script = RScriptRunner(resources.files('mobility.runtime.r_integration').joinpath('install_packages.R'))
         script.run(args)

--- a/tests/back/unit/domain/set_params/conftest.py
+++ b/tests/back/unit/domain/set_params/conftest.py
@@ -20,6 +20,8 @@ def clean_env(monkeypatch):
         "MOBILITY_DEBUG",
         "MOBILITY_PACKAGE_DATA_FOLDER",
         "MOBILITY_PROJECT_DATA_FOLDER",
+        "MIMALLOC_PURGE_DELAY",
+        "_RJEM_MALLOC_CONF",
     ]:
         monkeypatch.delenv(key, raising=False)
 

--- a/tests/back/unit/domain/set_params/test_030_memory_reclaim_config.py
+++ b/tests/back/unit/domain/set_params/test_030_memory_reclaim_config.py
@@ -1,0 +1,95 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mobility.config import (
+    apply_import_time_memory_reclaim_policy,
+    update,
+)
+
+
+def test_update_uses_default_package_data_folder(tmp_home):
+    with pytest.warns(UserWarning):
+        config_path = update(memory_reclaim_policy="default")
+
+    assert config_path == Path(tmp_home) / ".mobility" / "mobility_config.json"
+    assert config_path.exists()
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {"memory_reclaim_policy": "default"}
+
+
+def test_update_uses_stable_user_config_path_even_if_package_data_exists(tmp_home, tmp_path):
+    (tmp_path / "custom_pkg_data").mkdir(parents=True, exist_ok=True)
+    with pytest.warns(UserWarning, match="Restart Python or your notebook kernel"):
+        written_path = update(memory_reclaim_policy="default")
+
+    assert written_path == Path(tmp_home) / ".mobility" / "mobility_config.json"
+    assert written_path.exists()
+    assert json.loads(written_path.read_text(encoding="utf-8")) == {"memory_reclaim_policy": "default"}
+
+
+def test_update_preserves_existing_config_keys(tmp_home):
+    config_path = Path(tmp_home) / ".mobility" / "mobility_config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"foo": "bar"}), encoding="utf-8")
+
+    with pytest.warns(UserWarning):
+        update(memory_reclaim_policy="aggressive")
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {
+        "foo": "bar",
+        "memory_reclaim_policy": "aggressive",
+    }
+
+
+def test_update_rejects_unknown_memory_reclaim_policy(tmp_path):
+    with pytest.raises(ValueError, match="Unknown memory reclaim policy"):
+        update(memory_reclaim_policy="fast")
+
+
+def test_apply_import_time_memory_reclaim_policy_uses_default_when_file_is_missing(tmp_home):
+    policy = apply_import_time_memory_reclaim_policy()
+
+    assert policy == "aggressive"
+
+
+@pytest.mark.parametrize(
+    "system_name, policy_value, env_key, expected_env_value",
+    [
+        ("Windows", "aggressive", "MIMALLOC_PURGE_DELAY", "0"),
+        ("Linux", "aggressive", "_RJEM_MALLOC_CONF", "dirty_decay_ms:0,muzzy_decay_ms:0"),
+        ("Windows", "default", "MIMALLOC_PURGE_DELAY", None),
+    ],
+)
+def test_apply_import_time_memory_reclaim_policy_sets_expected_allocator_env(
+    monkeypatch,
+    system_name,
+    policy_value,
+    env_key,
+    expected_env_value,
+):
+    monkeypatch.setattr("platform.system", lambda: system_name, raising=True)
+
+    with pytest.warns(UserWarning):
+        update(memory_reclaim_policy=policy_value)
+
+    policy = apply_import_time_memory_reclaim_policy()
+
+    assert policy == policy_value
+    if expected_env_value is None:
+        assert env_key not in os.environ
+    else:
+        assert os.environ[env_key] == expected_env_value
+
+
+def test_apply_import_time_memory_reclaim_policy_does_not_override_existing_allocator_env(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows", raising=True)
+    monkeypatch.setenv("MIMALLOC_PURGE_DELAY", "123")
+
+    with pytest.warns(UserWarning):
+        update(memory_reclaim_policy="aggressive")
+
+    apply_import_time_memory_reclaim_policy()
+
+    assert os.environ["MIMALLOC_PURGE_DELAY"] == "123"


### PR DESCRIPTION
### Motivation
This PR is needed to reduce RAM kept by the Python process after heavy Polars steps.

In Mobility runs with more than a few iteration (> 5), Polars can keep a lot of memory after peak operations. This behavior is still under investigation on the Polars side, so this Mobility workaround may become unnecessary in the future.

Relevant upstream context:
- Polars issue 22871
- Polars issue 23128
- Polars issue 27061
- Polars PR 27395

### Changes
This PR adds a startup memory reclaim setting for Mobility. In my tests on a 5 iteration case study I see RAM build up to 10 Go in the current setting, and to 3 Go with the new aggressive setting.

Main changes:
- apply a startup memory policy at the top of `mobility/__init__.py`, before submodules import `polars`
- add `mobility.config.update(memory_reclaim_policy=...)` to save the user preference
- store this preference in `~/.mobility/mobility_config.json`
- support two values:
  - `aggressive`
  - `default`
- use `aggressive` as the default
- for `aggressive`, apply allocator settings by platform:
  - Windows: `MIMALLOC_PURGE_DELAY=0`
  - Unix: `_RJEM_MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0`
- warn the user that they must restart Python or their notebook kernel after changing the setting
- warn the user that `mobility` must be imported before `polars`
- add unit tests for the new config behavior
- unrelated but still useful change: mute noisy Matplotlib font debug logs in `setup_logging()`

### Example (if relevant)
Example for a user:

```python
import mobility

mobility.config.update(memory_reclaim_policy="default")
```

After this, the user must restart Python or the notebook kernel.

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: config logic and tests
- What you reviewed or changed: simplified the implementation and kept the startup config path stable
- How you validated it (tests, checks, manual verification): ran unit test, compared the RAM usage of the aggressive / default options on a case study.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior