### PR TITLE
Configure transport graph congestion loading

### DIFF
--- a/mobility/runtime/io/download_file.py
+++ b/mobility/runtime/io/download_file.py
@@ -56,7 +56,7 @@ def download_file(url, path, max_retries=3, timeout=(10, 120), raise_on_error=Tr
         stop=stop_after_attempt(max_retries + 1),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         retry=retry_if_exception_type(requests.exceptions.RequestException),
-        before_sleep=before_sleep_log(logging.getLogger(__name__), logging.WARNING),
+        before_sleep=before_sleep_log(logging.root, logging.WARNING),
         reraise=True,
     )
 

--- a/mobility/surveys/survey_plan_steps.py
+++ b/mobility/surveys/survey_plan_steps.py
@@ -60,7 +60,7 @@ class MobilitySurveyPlanSteps(FileAsset):
         )
         cache_path = folder_path / "group_day_trip_plan_steps.parquet"
         inputs = {
-            "version": 3.1,
+            "version": 3.2,
             "survey": survey,
             "activities": activities,
             "modes": modes,
@@ -173,11 +173,11 @@ class MobilitySurveyPlanSteps(FileAsset):
             .with_columns(mode=pl.col("mode_id").cast(pl.Utf8).replace_strict(mode_mapping, default="other"))
             .filter(pl.col("seq_step_index") < 11)
             .filter((pl.col("departure_time") < 24.0) & (pl.col("arrival_time") < 24.0))
-            .with_columns(max_seq_step_index=pl.col("seq_step_index").max().over(["individual_id", "day_id"]))
-            .filter(pl.col("max_seq_step_index") > 1)
+            .with_columns(step_count=pl.len().over(["individual_id", "day_id"]).cast(pl.UInt8))
+            .filter(pl.col("step_count") > 1)
             .with_columns(
                 activity=pl.when(
-                    (pl.col("seq_step_index") == pl.col("max_seq_step_index")) & (pl.col("activity") != "home")
+                    (pl.col("seq_step_index") == pl.col("step_count")) & (pl.col("activity") != "home")
                 )
                 .then(pl.lit("home"))
                 .otherwise(pl.col("activity"))
@@ -212,7 +212,7 @@ class MobilitySurveyPlanSteps(FileAsset):
                     "pondki",
                     "activity_seq",
                     "mode_seq",
-                    "max_seq_step_index",
+                    "step_count",
                 ]
             )
         )
@@ -327,6 +327,7 @@ class MobilitySurveyPlanSteps(FileAsset):
                     "csp",
                     "n_cars",
                     "seq_step_index",
+                    "step_count",
                     "activity",
                     "mode",
                     "is_anchor",
@@ -365,6 +366,7 @@ class MobilitySurveyPlanSteps(FileAsset):
             .sort(["time_seq_id", "seq_step_index"])
             .with_columns(
                 seq_step_index=pl.col("seq_step_index").cast(pl.UInt8),
+                step_count=pl.col("step_count").cast(pl.UInt8),
                 mode=pl.col("mode").cast(pl.Enum(mode_values)),
                 departure_time=pl.col("departure_time").cast(pl.Float32),
                 arrival_time=pl.col("arrival_time").cast(pl.Float32),

--- a/mobility/transport/costs/path/path_travel_costs.py
+++ b/mobility/transport/costs/path/path_travel_costs.py
@@ -50,6 +50,9 @@ class PathTravelCosts(TravelCostsAsset):
             congestion: bool = False,
             congestion_flows_scaling_factor: float = 1.0,
             target_max_vehicles_per_od_endpoint: float = 1000.0,
+            congestion_assignment_max_iterations: int = 10,
+            congestion_assignment_max_gap: float = 0.05,
+            congestion_assignment_retained_volume_share: float = 0.95,
             speed_modifiers: List[SpeedModifier] = [],
             contracted_graph: ContractedPathGraph | None = None,
         ):
@@ -69,6 +72,9 @@ class PathTravelCosts(TravelCostsAsset):
                 congestion,
                 congestion_flows_scaling_factor,
                 target_max_vehicles_per_od_endpoint,
+                congestion_assignment_max_iterations,
+                congestion_assignment_max_gap,
+                congestion_assignment_retained_volume_share,
                 speed_modifiers
             )
             simplified_path_graph = path_graph.simplified
@@ -92,6 +98,9 @@ class PathTravelCosts(TravelCostsAsset):
             "routing_parameters": routing_parameters,
             "osm_capacity_parameters": osm_capacity_parameters,
             "target_max_vehicles_per_od_endpoint": target_max_vehicles_per_od_endpoint,
+            "congestion_assignment_max_iterations": congestion_assignment_max_iterations,
+            "congestion_assignment_max_gap": congestion_assignment_max_gap,
+            "congestion_assignment_retained_volume_share": congestion_assignment_retained_volume_share,
         }
 
         cache_path = {
@@ -242,6 +251,9 @@ class PathTravelCosts(TravelCostsAsset):
             handles_congestion=self.inputs["congested_path_graph"].handles_congestion,
             congestion_flows_scaling_factor=self.inputs["congested_path_graph"].congestion_flows_scaling_factor,
             target_max_vehicles_per_od_endpoint=self.inputs["congested_path_graph"].target_max_vehicles_per_od_endpoint,
+            congestion_assignment_max_iterations=self.inputs["congested_path_graph"].congestion_assignment_max_iterations,
+            congestion_assignment_max_gap=self.inputs["congested_path_graph"].congestion_assignment_max_gap,
+            congestion_assignment_retained_volume_share=self.inputs["congested_path_graph"].congestion_assignment_retained_volume_share,
             vehicle_flows=flow_asset,
         )
         contracted_graph = ContractedPathGraph(congested_graph)
@@ -252,6 +264,9 @@ class PathTravelCosts(TravelCostsAsset):
             routing_parameters=self.inputs["routing_parameters"],
             osm_capacity_parameters=self.inputs["osm_capacity_parameters"],
             target_max_vehicles_per_od_endpoint=self.inputs["target_max_vehicles_per_od_endpoint"],
+            congestion_assignment_max_iterations=self.inputs["congestion_assignment_max_iterations"],
+            congestion_assignment_max_gap=self.inputs["congestion_assignment_max_gap"],
+            congestion_assignment_retained_volume_share=self.inputs["congestion_assignment_retained_volume_share"],
             contracted_graph=contracted_graph,
         )
         return variant

--- a/mobility/transport/graphs/congested/congested_path_graph.py
+++ b/mobility/transport/graphs/congested/congested_path_graph.py
@@ -18,6 +18,9 @@ class CongestedPathGraph(FileAsset):
             handles_congestion: bool = False,
             congestion_flows_scaling_factor: float = 1.0,
             target_max_vehicles_per_od_endpoint: float = 1000.0,
+            congestion_assignment_max_iterations: int = 10,
+            congestion_assignment_max_gap: float = 0.05,
+            congestion_assignment_retained_volume_share: float = 0.95,
             vehicle_flows: VehicleODFlowsAsset | None = None,
         ):
         
@@ -30,6 +33,9 @@ class CongestedPathGraph(FileAsset):
             "handles_congestion": handles_congestion,
             "congestion_flows_scaling_factor": congestion_flows_scaling_factor,
             "target_max_vehicles_per_od_endpoint": target_max_vehicles_per_od_endpoint,
+            "congestion_assignment_max_iterations": congestion_assignment_max_iterations,
+            "congestion_assignment_max_gap": congestion_assignment_max_gap,
+            "congestion_assignment_retained_volume_share": congestion_assignment_retained_volume_share,
         }
         
         mode_name = modified_graph.mode_name
@@ -66,6 +72,9 @@ class CongestedPathGraph(FileAsset):
             flows_file_path,
             self.inputs["congestion_flows_scaling_factor"],
             self.inputs["target_max_vehicles_per_od_endpoint"],
+            self.inputs["congestion_assignment_max_iterations"],
+            self.inputs["congestion_assignment_max_gap"],
+            self.inputs["congestion_assignment_retained_volume_share"],
         )
 
         return self.cache_path
@@ -78,6 +87,9 @@ class CongestedPathGraph(FileAsset):
             flows_file_path: pathlib.Path,
             congestion_flows_scaling_factor: float,
             target_max_vehicles_per_od_endpoint: float,
+            congestion_assignment_max_iterations: int,
+            congestion_assignment_max_gap: float,
+            congestion_assignment_retained_volume_share: float,
         ) -> None:
          
         script = RScriptRunner(resources.files('mobility.transport.graphs.congested').joinpath('load_path_graph.R'))
@@ -90,6 +102,9 @@ class CongestedPathGraph(FileAsset):
                 str(flows_file_path),
                 str(congestion_flows_scaling_factor),
                 str(target_max_vehicles_per_od_endpoint),
+                str(congestion_assignment_max_iterations),
+                str(congestion_assignment_max_gap),
+                str(congestion_assignment_retained_volume_share),
                 str(self.cache_path)
             ]
         )
@@ -116,6 +131,9 @@ class CongestedPathGraph(FileAsset):
             handles_congestion=self.inputs["handles_congestion"],
             congestion_flows_scaling_factor=self.inputs["congestion_flows_scaling_factor"],
             target_max_vehicles_per_od_endpoint=self.inputs["target_max_vehicles_per_od_endpoint"],
+            congestion_assignment_max_iterations=self.inputs["congestion_assignment_max_iterations"],
+            congestion_assignment_max_gap=self.inputs["congestion_assignment_max_gap"],
+            congestion_assignment_retained_volume_share=self.inputs["congestion_assignment_retained_volume_share"],
         )
 
     def get_for_iteration(self, run, iteration: int):

--- a/mobility/transport/graphs/congested/load_path_graph.R
+++ b/mobility/transport/graphs/congested/load_path_graph.R
@@ -17,6 +17,9 @@ args <- commandArgs(trailingOnly = TRUE)
 #   'D:\\data\\mobility\\projects\\grand-geneve\\path_graph_car\\simplified\\flows.parquet',
 #   '0.1',
 #   '1000.0',
+#   '10',
+#   '0.05',
+#   '0.95',
 #   'D:\\data\\mobility\\projects\\grand-geneve\\path_graph_car\\congested\\7e5144cf3db620565c9a9797be8a6df0-car-congested-path-graph'
 # )
 
@@ -27,7 +30,10 @@ congestion <- args[4]
 flows_fp <- args[5]
 congestion_flows_scaling_factor <- args[6]
 target_max_vehicles_per_od_endpoint <- args[7]
-output_fp <- args[8]
+congestion_assignment_max_iterations <- args[8]
+congestion_assignment_max_gap <- args[9]
+congestion_assignment_retained_volume_share <- args[10]
+output_fp <- args[11]
 
 
 source(file.path(package_fp, "transport", "graphs", "core", "cpprouting_io.R"))
@@ -38,6 +44,23 @@ logger <- logger(appenders = console_appender())
 congestion <- as.logical(congestion)
 congestion_flows_scaling_factor <- as.numeric(congestion_flows_scaling_factor)
 target_max_vehicles_per_od_endpoint <- as.numeric(target_max_vehicles_per_od_endpoint)
+congestion_assignment_max_iterations <- as.integer(congestion_assignment_max_iterations)
+congestion_assignment_max_gap <- as.numeric(congestion_assignment_max_gap)
+congestion_assignment_retained_volume_share <- as.numeric(congestion_assignment_retained_volume_share)
+
+if (is.na(congestion_assignment_max_iterations) || congestion_assignment_max_iterations < 1) {
+  stop("congestion_assignment_max_iterations must be an integer greater than or equal to 1.")
+}
+if (is.na(congestion_assignment_max_gap) || congestion_assignment_max_gap <= 0) {
+  stop("congestion_assignment_max_gap must be greater than 0.")
+}
+if (
+  is.na(congestion_assignment_retained_volume_share) ||
+  congestion_assignment_retained_volume_share <= 0 ||
+  congestion_assignment_retained_volume_share > 1
+) {
+  stop("congestion_assignment_retained_volume_share must be greater than 0 and less than or equal to 1.")
+}
 
 # Load the cpprouting graph
 info(logger, "Loading simplified/modified graph...")
@@ -107,17 +130,19 @@ if (congestion == TRUE & file.exists(flows_fp)) {
   od_flows[, vehicle_volume := vehicle_volume*weight]
   info(logger, paste0("Expanded OD flows to ", format(nrow(od_flows), big.mark = ","), " weighted vertex-flow rows."))
   
-  # Retain only the largest flows accounting for 95 % of the total volume
+  # Retain only the largest flows accounting for the requested total-volume share
   # and upscale them to match the total volume
   info(logger, "Sorting vertex-flow rows by decreasing vehicle volume...")
   od_flows <- od_flows[order(-vehicle_volume)]
   info(logger, "Computing cumulative vehicle volume shares...")
   od_flows[, cum_share := cumsum(vehicle_volume)/sum(vehicle_volume)]
-  info(logger, "Filtering vertex-flow rows to retain the top 95% of total volume...")
-  od_flows <- od_flows[cum_share < 0.95]
-  info(logger, "Rescaling retained vehicle volumes after 95% filtering...")
-  od_flows[, vehicle_volume := vehicle_volume/0.95*congestion_flows_scaling_factor]
-  info(logger, paste0("Retained ", format(nrow(od_flows), big.mark = ","), " vertex-flow rows after 95% volume filtering."))
+  info(logger, paste0("Filtering vertex-flow rows to retain the top ", congestion_assignment_retained_volume_share * 100, "% of total volume..."))
+  od_flows[, flow_rank := .I]
+  od_flows <- od_flows[cum_share <= congestion_assignment_retained_volume_share | flow_rank == 1]
+  info(logger, "Rescaling retained vehicle volumes after volume-share filtering...")
+  od_flows[, vehicle_volume := vehicle_volume/congestion_assignment_retained_volume_share*congestion_flows_scaling_factor]
+  od_flows[, flow_rank := NULL]
+  info(logger, paste0("Retained ", format(nrow(od_flows), big.mark = ","), " vertex-flow rows after volume-share filtering."))
   
   # Assign traffic 
   info(logger, "Assigning traffic...")
@@ -129,8 +154,8 @@ if (congestion == TRUE & file.exists(flows_fp)) {
     demand = od_flows$vehicle_volume,
     algorithm = "cfw",
     aon_method = "cbi",
-    max_gap = 0.05,
-    max_it = 10,
+    max_gap = congestion_assignment_max_gap,
+    max_it = congestion_assignment_max_iterations,
     verbose = TRUE
   )
   

--- a/mobility/transport/graphs/core/path_graph.py
+++ b/mobility/transport/graphs/core/path_graph.py
@@ -21,6 +21,9 @@ class PathGraph:
         congestion: bool = False,
         congestion_flows_scaling_factor: float = 1.0,
         target_max_vehicles_per_od_endpoint: float = 1000.0,
+        congestion_assignment_max_iterations: int = 10,
+        congestion_assignment_max_gap: float = 0.05,
+        congestion_assignment_retained_volume_share: float = 0.95,
         speed_modifiers: List[SpeedModifier] = []
     ):
         
@@ -40,7 +43,10 @@ class PathGraph:
             transport_zones,
             congestion,
             congestion_flows_scaling_factor,
-            target_max_vehicles_per_od_endpoint
+            target_max_vehicles_per_od_endpoint,
+            congestion_assignment_max_iterations,
+            congestion_assignment_max_gap,
+            congestion_assignment_retained_volume_share
         )
         
         self.contracted = ContractedPathGraph(

--- a/mobility/transport/graphs/modified/modifiers/apply_border_crossing_speed_modifier.R
+++ b/mobility/transport/graphs/modified/modifiers/apply_border_crossing_speed_modifier.R
@@ -44,9 +44,18 @@ apply_border_crossing_speed_modifier <- function(
     st_crs(edges_sf) <- 3035
     
     # Find the ones intersecting a border
-    borders <- lapply(borders, st_read, quiet = TRUE)
-    borders <- lapply(borders, "[", "admin_level")
-    borders <- st_as_sf(rbindlist(borders))
+    borders <- lapply(borders, function(border_file_path) {
+      border <- st_read(border_file_path, quiet = TRUE)
+      if (nrow(border) == 0) {
+        return(NULL)
+      }
+      st_geometry(border)
+    })
+    borders <- Filter(Negate(is.null), borders)
+    if (length(borders) == 0) {
+      return(cppr_graph)
+    }
+    borders <- st_sf(geometry = do.call(c, borders))
     borders <- st_transform(borders, 3035)
     
     index <- st_intersects(edges_sf, borders)

--- a/mobility/transport/graphs/modified/modifiers/speed_modifier.py
+++ b/mobility/transport/graphs/modified/modifiers/speed_modifier.py
@@ -1,5 +1,4 @@
 import pathlib
-import json
 import geopandas as gpd
 
 from mobility.runtime.assets.in_memory_asset import InMemoryAsset
@@ -59,12 +58,18 @@ class BorderCrossingSpeedModifier(SpeedModifier):
         borders = []
         has_borders = False
 
-        for index, region in regions.iterrows():
+        for _index, region in regions.iterrows():
             extract = GeofabrikExtract(region.url)
             border = OSMCountryBorder(extract)
-            borders.append(str(border.get()))
-            border_geometry = gpd.read_file(border.get())
-            has_borders = bool(border_geometry.intersects(boundary).any())
+            border_path = border.get()
+            border_geometry = gpd.read_file(border_path)
+            border_intersects_boundary = bool(
+                not border_geometry.empty
+                and border_geometry.intersects(boundary).any()
+            )
+            if border_intersects_boundary:
+                borders.append(str(border_path))
+                has_borders = True
             
 
         return {

--- a/mobility/transport/modes/car.py
+++ b/mobility/transport/modes/car.py
@@ -33,6 +33,9 @@ class CarMode(TransportMode):
         congestion: bool | None = None,
         congestion_flows_scaling_factor: float = 0.1,
         target_max_vehicles_per_od_endpoint: float | None = None,
+        congestion_assignment_max_iterations: int | None = None,
+        congestion_assignment_max_gap: float | None = None,
+        congestion_assignment_retained_volume_share: float | None = None,
         speed_modifiers: List[SpeedModifier] = [],
         survey_ids: List[str] | None = None,
         ghg_intensity: float | None = None,
@@ -52,6 +55,9 @@ class CarMode(TransportMode):
                 "return_mode": None,
                 "survey_ids": survey_ids,
                 "target_max_vehicles_per_od_endpoint": target_max_vehicles_per_od_endpoint,
+                "congestion_assignment_max_iterations": congestion_assignment_max_iterations,
+                "congestion_assignment_max_gap": congestion_assignment_max_gap,
+                "congestion_assignment_retained_volume_share": congestion_assignment_retained_volume_share,
             },
             owner_name="CarMode",
         )
@@ -82,6 +88,9 @@ class CarMode(TransportMode):
             congestion=mode_congestion,
             congestion_flows_scaling_factor=congestion_flows_scaling_factor,
             target_max_vehicles_per_od_endpoint=mode_target_max_vehicles_per_od_endpoint,
+            congestion_assignment_max_iterations=mode_parameters.congestion_assignment_max_iterations,
+            congestion_assignment_max_gap=mode_parameters.congestion_assignment_max_gap,
+            congestion_assignment_retained_volume_share=mode_parameters.congestion_assignment_retained_volume_share,
             speed_modifiers=speed_modifiers,
         )
         
@@ -132,6 +141,35 @@ class CarParameters(TransportModeParameters):
             "representative origin/destination points before congestion assignment."
         ),
         json_schema_extra={"unit": "veh"},
+    )
+    congestion_assignment_max_iterations: int = Field(
+        default=10,
+        ge=1,
+        title="Traffic assignment maximum iterations",
+        description=(
+            "Maximum number of route-assignment iterations used when loading "
+            "car traffic on the road graph."
+        ),
+    )
+    congestion_assignment_max_gap: float = Field(
+        default=0.05,
+        gt=0.0,
+        title="Traffic assignment maximum gap",
+        description=(
+            "Convergence gap used to stop traffic assignment early. Higher "
+            "values are faster and rougher."
+        ),
+    )
+    congestion_assignment_retained_volume_share: float = Field(
+        default=0.95,
+        gt=0.0,
+        le=1.0,
+        title="Traffic assignment retained volume share",
+        description=(
+            "Share of the largest disaggregated vertex-pair vehicle flows kept "
+            "before traffic assignment. Dropped demand is redistributed by "
+            "rescaling the retained flows."
+        ),
     )
     vehicle: Literal["car"] = "car"
     multimodal: bool = False

--- a/mobility/transport/modes/public_transport/public_transport_travel_costs.py
+++ b/mobility/transport/modes/public_transport/public_transport_travel_costs.py
@@ -78,6 +78,7 @@ class PublicTransportTravelCosts(TravelCostsAsset):
         )
 
         inputs = {
+            "version": "1",
             "intermodal_graph": intermodal_graph,
             "transport_zones": transport_zones,
             "first_modal_transfer": first_modal_transfer,

--- a/mobility/trips/group_day_trips/core/memory_logging.py
+++ b/mobility/trips/group_day_trips/core/memory_logging.py
@@ -45,6 +45,9 @@ def log_memory_checkpoint(
     **objects: Any,
 ) -> None:
     """Log process memory plus cheap summaries of already-available objects."""
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        return
+
     memory_info = psutil.Process().memory_info()
     parts = [
         f"rss={format_bytes(memory_info.rss)}",

--- a/mobility/trips/group_day_trips/plans/activity_sequences.py
+++ b/mobility/trips/group_day_trips/plans/activity_sequences.py
@@ -17,6 +17,7 @@ class ActivitySequences(FileAsset):
         "activity",
         "is_anchor",
         "seq_step_index",
+        "step_count",
         "departure_time",
         "arrival_time",
         "next_departure_time",
@@ -43,7 +44,7 @@ class ActivitySequences(FileAsset):
         self.parameters = parameters
         self.seed = seed
         inputs = {
-            "version": 2,
+            "version": 3,
             "run_key": run_key,
             "is_weekday": is_weekday,
             "iteration": iteration,
@@ -161,6 +162,7 @@ class ActivitySequences(FileAsset):
                 "activity": self.survey_plan_steps.schema["activity"],
                 "is_anchor": self.survey_plan_steps.schema["is_anchor"],
                 "seq_step_index": self.survey_plan_steps.schema["seq_step_index"],
+                "step_count": self.survey_plan_steps.schema["step_count"],
                 "departure_time": self.survey_plan_steps.schema["departure_time"],
                 "arrival_time": self.survey_plan_steps.schema["arrival_time"],
                 "next_departure_time": self.survey_plan_steps.schema["next_departure_time"],

--- a/mobility/trips/group_day_trips/plans/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/debug_logs.py
@@ -1,0 +1,307 @@
+import logging
+from typing import Any
+
+import polars as pl
+
+
+def log_destination_sequence_diagnostics(
+    *,
+    iteration: int,
+    source_activity_sequences: pl.DataFrame,
+    destination_sequences: pl.DataFrame,
+) -> None:
+    """Log destination-chain diagnostics only when debug logging is enabled."""
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        return
+
+    chain_lengths = _destination_chain_lengths(destination_sequences)
+    logging.debug(
+        "Destination sequence step counts at iteration %s | grouped=%s",
+        iteration,
+        _distribution_by_count(chain_lengths, "step_count"),
+    )
+
+    one_step_chains = chain_lengths.filter(pl.col("step_count") == 1)
+    if one_step_chains.height == 0:
+        return
+
+    one_step_keys = one_step_chains.select(
+        ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"]
+    )
+    logging.warning(
+        "Destination sequences contain %s one-step chains at iteration %s. "
+        "Sample grouped chains: %s | Sample raw rows: %s",
+        one_step_chains.height,
+        iteration,
+        one_step_chains.head(10).to_dicts(),
+        _one_step_chain_rows(
+            destination_sequences=destination_sequences,
+            one_step_keys=one_step_keys,
+        ).head(20).to_dicts(),
+    )
+    logging.warning(
+        "Activity-sequence source rows behind one-step destination chains at iteration %s: %s",
+        iteration,
+        _source_rows_for_chain_keys(
+            source_activity_sequences=source_activity_sequences,
+            one_step_keys=one_step_keys,
+        ).head(20).to_dicts(),
+    )
+
+
+def _destination_chain_lengths(destination_sequences: pl.DataFrame) -> pl.DataFrame:
+    """Build one row per destination chain with ordered locations."""
+    return (
+        destination_sequences
+        .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"])
+        .agg(
+            step_count=pl.len(),
+            from_locations=pl.col("from").sort_by("seq_step_index"),
+            to_locations=pl.col("to").sort_by("seq_step_index"),
+        )
+        .sort(["step_count", "dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id"])
+    )
+
+
+def _distribution_by_count(frame: pl.DataFrame, count_col: str) -> list[dict[str, Any]]:
+    """Return a compact count distribution for debug logging."""
+    return (
+        frame
+        .group_by(count_col)
+        .len()
+        .sort(count_col)
+        .to_dicts()
+    )
+
+
+def _one_step_chain_rows(
+    *,
+    destination_sequences: pl.DataFrame,
+    one_step_keys: pl.DataFrame,
+) -> pl.DataFrame:
+    """Return the raw step rows behind one-step destination chains."""
+    return (
+        destination_sequences
+        .join(
+            one_step_keys,
+            on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"],
+            how="inner",
+        )
+        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+    )
+
+
+def _source_rows_for_chain_keys(
+    *,
+    source_activity_sequences: pl.DataFrame,
+    one_step_keys: pl.DataFrame,
+) -> pl.DataFrame:
+    """Return the source activity rows behind the problematic destination chains."""
+    return (
+        source_activity_sequences
+        .join(
+            one_step_keys.select(["demand_group_id", "activity_seq_id", "time_seq_id"]).unique(),
+            on=["demand_group_id", "activity_seq_id", "time_seq_id"],
+            how="inner",
+        )
+        .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+    )
+
+
+def log_step_dropout_diagnostics(
+    *,
+    seq_step_index: int,
+    chains_step: pl.DataFrame,
+    costs: pl.DataFrame,
+    non_anchor_candidates: pl.LazyFrame,
+    candidates_with_origin_costs: pl.LazyFrame,
+    candidates_with_costs: pl.LazyFrame,
+    sampled_non_anchor_steps: pl.LazyFrame,
+    chain_key_cols: list[str],
+    transport_zones: Any | None,
+) -> None:
+    """Log spatialization dropouts only when debug logging is enabled."""
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        return
+
+    # Start from the non-anchor rows that must survive this step.
+    non_anchor_input = (
+        chains_step
+        .filter(pl.col("is_anchor").not_())
+        .select(chain_key_cols + ["activity", "seq_step_index", "from", "anchor_to"])
+        .unique()
+    )
+    if non_anchor_input.height == 0:
+        return
+
+    candidate_keys = _collect_unique_keys(non_anchor_candidates, chain_key_cols)
+    origin_cost_keys = _collect_unique_keys(candidates_with_origin_costs, chain_key_cols)
+    costed_keys = _collect_unique_keys(candidates_with_costs, chain_key_cols)
+    sampled_keys = _collect_unique_keys(sampled_non_anchor_steps, chain_key_cols)
+
+    # Compute the first stage where each chain disappears.
+    missing_after_probability = non_anchor_input.join(candidate_keys, on=chain_key_cols, how="anti")
+    missing_after_origin_costs = (
+        non_anchor_input
+        .join(candidate_keys, on=chain_key_cols, how="inner")
+        .join(origin_cost_keys, on=chain_key_cols, how="anti")
+    )
+    missing_after_anchor_costs = (
+        non_anchor_input
+        .join(origin_cost_keys, on=chain_key_cols, how="inner")
+        .join(costed_keys, on=chain_key_cols, how="anti")
+    )
+    missing_after_sampling = (
+        non_anchor_input
+        .join(costed_keys, on=chain_key_cols, how="inner")
+        .join(sampled_keys, on=chain_key_cols, how="anti")
+    )
+
+    if (
+        missing_after_probability.height == 0
+        and missing_after_origin_costs.height == 0
+        and missing_after_anchor_costs.height == 0
+        and missing_after_sampling.height == 0
+    ):
+        return
+
+    logging.warning(
+        "Destination spatialization dropouts at step %s | input_non_anchor=%s | after_probability_missing=%s | after_origin_cost_missing=%s | "
+        "after_anchor_cost_missing=%s | after_sampling_missing=%s | probability_samples=%s | origin_cost_samples=%s | "
+        "anchor_cost_samples=%s | sampling_samples=%s | probability_candidates=%s | origin_cost_candidates=%s | "
+        "anchor_cost_candidates=%s | sampling_candidates=%s | origin_cost_traces=%s | anchor_cost_traces=%s",
+        seq_step_index,
+        non_anchor_input.height,
+        missing_after_probability.height,
+        missing_after_origin_costs.height,
+        missing_after_anchor_costs.height,
+        missing_after_sampling.height,
+        missing_after_probability.head(10).to_dicts(),
+        missing_after_origin_costs.head(10).to_dicts(),
+        missing_after_anchor_costs.head(10).to_dicts(),
+        missing_after_sampling.head(10).to_dicts(),
+        _candidate_samples_for_dropouts(
+            dropouts=missing_after_probability,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+        ),
+        _candidate_samples_for_dropouts(
+            dropouts=missing_after_origin_costs,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+        ),
+        _candidate_samples_for_dropouts(
+            dropouts=missing_after_anchor_costs,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+        ),
+        _candidate_samples_for_dropouts(
+            dropouts=missing_after_sampling,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+        ),
+        _cost_trace_for_dropouts(
+            dropouts=missing_after_origin_costs,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+            costs=costs,
+            transport_zones=transport_zones,
+        ),
+        _cost_trace_for_dropouts(
+            dropouts=missing_after_anchor_costs,
+            non_anchor_candidates=non_anchor_candidates,
+            chain_key_cols=chain_key_cols,
+            costs=costs,
+            transport_zones=transport_zones,
+        ),
+    )
+
+
+def _collect_unique_keys(frame: pl.LazyFrame, chain_key_cols: list[str]) -> pl.DataFrame:
+    """Collect one unique key row per surviving chain."""
+    return (
+        frame
+        .select(chain_key_cols)
+        .unique()
+        .collect(engine="streaming")
+    )
+
+
+def _candidate_samples_for_dropouts(
+    *,
+    dropouts: pl.DataFrame,
+    non_anchor_candidates: pl.LazyFrame,
+    chain_key_cols: list[str],
+) -> list[dict[str, Any]]:
+    """Return a small sample of destination candidates for dropped chains."""
+    if dropouts.height == 0:
+        return []
+    return (
+        non_anchor_candidates
+        .join(dropouts.lazy().select(chain_key_cols), on=chain_key_cols, how="inner")
+        .select(chain_key_cols + ["activity", "seq_step_index", "from", "to", "anchor_to", "p_ij"])
+        .sort(chain_key_cols + ["to"])
+        .limit(20)
+        .collect(engine="streaming")
+        .to_dicts()
+    )
+
+
+def _cost_trace_for_dropouts(
+    *,
+    dropouts: pl.DataFrame,
+    non_anchor_candidates: pl.LazyFrame,
+    chain_key_cols: list[str],
+    costs: pl.DataFrame,
+    transport_zones: Any | None,
+) -> list[dict[str, Any]]:
+    """Trace OD cost availability for a few dropped chains."""
+    if dropouts.height == 0:
+        return []
+
+    candidate_rows = (
+        non_anchor_candidates
+        .join(dropouts.lazy().select(chain_key_cols), on=chain_key_cols, how="inner")
+        .select(chain_key_cols + ["from", "to", "anchor_to"])
+        .sort(chain_key_cols + ["to"])
+        .limit(10)
+        .collect(engine="streaming")
+    )
+    if candidate_rows.height == 0:
+        return []
+
+    zones = _transport_zone_lookup(transport_zones)
+    traces: list[dict[str, Any]] = []
+    for row in candidate_rows.to_dicts():
+        # Include a beeline distance hint to spot obvious disconnected OD pairs.
+        beeline_km = None
+        if zones is not None and row["to"] in zones.index and row["anchor_to"] in zones.index:
+            from_zone = zones.loc[row["to"]]
+            anchor_zone = zones.loc[row["anchor_to"]]
+            if from_zone is not None and anchor_zone is not None:
+                dx = float(from_zone["x"]) - float(anchor_zone["x"])
+                dy = float(from_zone["y"]) - float(anchor_zone["y"])
+                beeline_km = (dx ** 2 + dy ** 2) ** 0.5 / 1000.0
+        traces.append(
+            {
+                **row,
+                "candidate_anchor_beeline_km": beeline_km,
+                "origin_cost_rows": costs.filter(
+                    (pl.col("from") == row["from"]) & (pl.col("to") == row["to"])
+                ).head(3).to_dicts(),
+                "anchor_cost_rows": costs.filter(
+                    (pl.col("from") == row["to"]) & (pl.col("to") == row["anchor_to"])
+                ).head(3).to_dicts(),
+                "reverse_anchor_cost_rows": costs.filter(
+                    (pl.col("from") == row["anchor_to"]) & (pl.col("to") == row["to"])
+                ).head(3).to_dicts(),
+            }
+        )
+    return traces
+
+
+def _transport_zone_lookup(transport_zones: Any | None):
+    """Build a simple lookup table for beeline checks when available."""
+    if transport_zones is None:
+        return None
+    return transport_zones.get().drop(columns="geometry").set_index("transport_zone_id")

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -6,9 +6,12 @@ import polars as pl
 from scipy.stats import norm
 
 from mobility.trips.group_day_trips.core.parameters import BehaviorChangeScope
+from .debug_logs import (
+    log_destination_sequence_diagnostics,
+    log_step_dropout_diagnostics,
+)
 from .sequence_index import add_index
 from mobility.runtime.assets.file_asset import FileAsset
-
 
 class DestinationSequences(FileAsset):
     """Persist destination sequences produced for one PopulationGroupDayTrips iteration."""
@@ -46,7 +49,7 @@ class DestinationSequences(FileAsset):
         self.parameters = parameters
         self.seed = seed
         inputs = {
-            "version": 2,
+            "version": 3,
             "run_key": run_key,
             "is_weekday": is_weekday,
             "iteration": iteration,
@@ -88,95 +91,6 @@ class DestinationSequences(FileAsset):
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
         destination_sequences.write_parquet(self.cache_path)
         return self.get_cached_asset()
-
-    def run(
-        self,
-        activities: list[Any],
-        transport_zones: Any,
-        destination_saturation: pl.DataFrame,
-        activity_sequences: pl.DataFrame,
-        demand_groups: pl.DataFrame,
-        costs: pl.DataFrame,
-        parameters: Any,
-        seed: int,
-    ) -> pl.DataFrame:
-        """Compute destination sequences for one iteration."""
-        utility_inputs = self._get_destination_probability_inputs(
-            destination_saturation,
-            costs,
-            parameters.cost_uncertainty_sd,
-        )
-        destination_probability = self._get_destination_probability(
-            utility_inputs,
-            activities,
-            self.resolved_activity_parameters,
-            parameters.dest_prob_cutoff,
-        )
-        activity_sequences = (
-            activity_sequences
-            .filter(pl.col("activity_seq_id") != 0)
-            .join(demand_groups.select(["demand_group_id", "home_zone_id"]), on="demand_group_id")
-            .select(
-                [
-                    "demand_group_id",
-                    "home_zone_id",
-                    "activity_seq_id",
-                    "time_seq_id",
-                    "activity",
-                    "is_anchor",
-                    "seq_step_index",
-                    "departure_time",
-                    "arrival_time",
-                    "next_departure_time",
-                ]
-            )
-        )
-        activity_sequences = self._spatialize_anchor_activities(activity_sequences, destination_probability, seed)
-        activity_sequences = self._spatialize_other_activities(
-            activity_sequences,
-            destination_probability,
-            costs,
-            parameters.alpha,
-            seed,
-        )
-
-        destination_sequences = (
-            activity_sequences
-            .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
-            .agg(to=pl.col("to").sort_by("seq_step_index").cast(pl.Utf8()))
-            .with_columns(to=pl.col("to").list.join("-"))
-            .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
-        )
-        destination_sequences = (
-            destination_sequences
-            .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "to"])
-            .agg(dest_draw_id=pl.col("dest_draw_id").min())
-            .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
-        )
-        destination_sequences = add_index(
-            destination_sequences,
-            col="to",
-            index_col_name="dest_seq_id",
-            index_folder=self.sequence_index_folder,
-        )
-        destination_sequences = (
-            activity_sequences
-            .join(
-                destination_sequences.select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "dest_seq_id"]),
-                on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"],
-            )
-            .drop(["home_zone_id", "activity", "dest_draw_id"])
-            .with_columns(
-                pl.col("seq_step_index").cast(pl.UInt8),
-                pl.col("from").cast(pl.UInt16),
-                pl.col("to").cast(pl.UInt16),
-                pl.col("departure_time").cast(pl.Float32),
-                pl.col("arrival_time").cast(pl.Float32),
-                pl.col("next_departure_time").cast(pl.Float32),
-                pl.lit(self.iteration).cast(pl.UInt16).alias("iteration"),
-            )
-        )
-        return destination_sequences
 
     def _build_destination_sequences_for_scope(self) -> pl.DataFrame:
         """Return the destination sequences to use for this iteration."""
@@ -306,6 +220,110 @@ class DestinationSequences(FileAsset):
                 "iteration": pl.UInt16,
             }
         )
+
+    def run(
+        self,
+        activities: list[Any],
+        transport_zones: Any,
+        destination_saturation: pl.DataFrame,
+        activity_sequences: pl.DataFrame,
+        demand_groups: pl.DataFrame,
+        costs: pl.DataFrame,
+        parameters: Any,
+        seed: int,
+    ) -> pl.DataFrame:
+        """Compute destination sequences for one iteration."""
+        utility_inputs = self._get_destination_probability_inputs(
+            destination_saturation,
+            costs,
+            parameters.cost_uncertainty_sd,
+        )
+        destination_probability = self._get_destination_probability(
+            utility_inputs,
+            activities,
+            self.resolved_activity_parameters,
+            parameters.dest_prob_cutoff,
+        )
+        activity_sequences = (
+            activity_sequences
+            .filter(pl.col("activity_seq_id") != 0)
+            .join(demand_groups.select(["demand_group_id", "home_zone_id"]), on="demand_group_id")
+            .select(
+                [
+                    "demand_group_id",
+                    "home_zone_id",
+                    "activity_seq_id",
+                    "time_seq_id",
+                    "activity",
+                    "is_anchor",
+                    "seq_step_index",
+                    "step_count",
+                    "departure_time",
+                    "arrival_time",
+                    "next_departure_time",
+                ]
+            )
+        )
+        source_activity_sequences = activity_sequences
+        anchor_spatialized_sequences = self._spatialize_anchor_activities(
+            source_activity_sequences,
+            destination_probability,
+            seed,
+        )
+        spatialized_activity_sequences = self._spatialize_other_activities(
+            anchor_spatialized_sequences,
+            destination_probability,
+            costs,
+            parameters.alpha,
+            seed,
+        )
+        complete_activity_sequences = self._drop_incomplete_destination_draws(
+            activity_sequences=spatialized_activity_sequences,
+            iteration=self.iteration,
+        )
+
+        destination_sequences = (
+            complete_activity_sequences
+            .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
+            .agg(to=pl.col("to").sort_by("seq_step_index").cast(pl.Utf8()))
+            .with_columns(to=pl.col("to").list.join("-"))
+            .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
+        )
+        destination_sequences = (
+            destination_sequences
+            .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "to"])
+            .agg(dest_draw_id=pl.col("dest_draw_id").min())
+            .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"])
+        )
+        destination_sequences = add_index(
+            destination_sequences,
+            col="to",
+            index_col_name="dest_seq_id",
+            index_folder=self.sequence_index_folder,
+        )
+        destination_sequences = (
+            complete_activity_sequences
+            .join(
+                destination_sequences.select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "dest_seq_id"]),
+                on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"],
+            )
+            .drop(["home_zone_id", "activity", "dest_draw_id"])
+            .with_columns(
+                pl.col("seq_step_index").cast(pl.UInt8),
+                pl.col("from").cast(pl.UInt16),
+                pl.col("to").cast(pl.UInt16),
+                pl.col("departure_time").cast(pl.Float32),
+                pl.col("arrival_time").cast(pl.Float32),
+                pl.col("next_departure_time").cast(pl.Float32),
+                pl.lit(self.iteration).cast(pl.UInt16).alias("iteration"),
+            )
+        )
+        log_destination_sequence_diagnostics(
+            iteration=self.iteration,
+            source_activity_sequences=source_activity_sequences,
+            destination_sequences=destination_sequences,
+        )
+        return destination_sequences
 
     def _get_destination_probability_inputs(
         self,
@@ -561,6 +579,16 @@ class DestinationSequences(FileAsset):
         seq_step_index = 1
         spatialized_chains: list[pl.DataFrame] = []
         while chains_step.height > 0:
+            logging.debug(
+                "Destination spatialization step %s input rows=%s non_anchor=%s anchor=%s unique_draws=%s",
+                seq_step_index,
+                chains_step.height,
+                chains_step.filter(pl.col("is_anchor").not_()).height,
+                chains_step.filter(pl.col("is_anchor")).height,
+                chains_step.select(
+                    ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+                ).unique().height,
+            )
             logging.info("Spatializing step %s...", str(seq_step_index))
             spatialized_step = (
                 self._spatialize_trip_chain_step(
@@ -602,6 +630,13 @@ class DestinationSequences(FileAsset):
         chains_step_lf = chains_step.lazy()
         destination_probability_lf = destination_probability.lazy()
         costs_lf = costs.lazy()
+        chain_key_cols = [
+            "demand_group_id",
+            "home_zone_id",
+            "activity_seq_id",
+            "time_seq_id",
+            "dest_draw_id",
+        ]
 
         # Start from the base destination probabilities for non-anchor activities.
         # These probabilities come from the radiation model and only depend on the
@@ -614,7 +649,7 @@ class DestinationSequences(FileAsset):
 
         # Attach the two legs that define the chain cost of visiting a candidate
         # destination before continuing to the next anchor destination.
-        candidates_with_costs = (
+        candidates_with_origin_costs = (
             non_anchor_candidates
             .join(
                 costs_lf
@@ -628,6 +663,9 @@ class DestinationSequences(FileAsset):
                 left_on=["from", "to"],
                 right_on=["candidate_from", "candidate_to"],
             )
+        )
+        candidates_with_costs = (
+            candidates_with_origin_costs
             .join(
                 costs_lf
                 .select(
@@ -699,6 +737,7 @@ class DestinationSequences(FileAsset):
                     "departure_time",
                     "arrival_time",
                     "next_departure_time",
+                    "step_count",
                 ]
             )
         )
@@ -721,7 +760,61 @@ class DestinationSequences(FileAsset):
                     "departure_time",
                     "arrival_time",
                     "next_departure_time",
+                    "step_count",
                 ]
             )
         )
+        log_step_dropout_diagnostics(
+            seq_step_index=seq_step_index,
+            chains_step=chains_step,
+            costs=costs,
+            non_anchor_candidates=non_anchor_candidates,
+            candidates_with_origin_costs=candidates_with_origin_costs,
+            candidates_with_costs=candidates_with_costs,
+            sampled_non_anchor_steps=sampled_non_anchor_steps,
+            chain_key_cols=chain_key_cols,
+            transport_zones=self.transport_zones,
+        )
         return pl.concat([steps, steps_anchor]).collect(engine="streaming")
+
+    @staticmethod
+    def _drop_incomplete_destination_draws(
+        *,
+        activity_sequences: pl.DataFrame,
+        iteration: int,
+    ) -> pl.DataFrame:
+        """Drop destination draws that lost one or more steps during spatialization.
+
+        A non-anchor step can disappear when there is no valid travel-cost path from
+        the sampled destination to the next anchor destination. If we keep the
+        remaining earlier steps, we create a truncated destination chain that later
+        becomes invalid input for mode-sequence search.
+        """
+        chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+        activity_sequences_with_counts = (
+            activity_sequences
+            .with_columns(
+                step_count_after_spatialization=pl.len().over(chain_key_cols).cast(pl.UInt8),
+            )
+        )
+        incomplete_draws = (
+            activity_sequences_with_counts
+            .filter(pl.col("step_count_after_spatialization") != pl.col("step_count"))
+            .select(chain_key_cols + ["step_count", "step_count_after_spatialization"])
+            .unique()
+            .sort(chain_key_cols)
+        )
+        if incomplete_draws.height > 0:
+            logging.warning(
+                "Dropping %s incomplete destination draws at iteration %s because one or more steps disappeared during spatialization. "
+                "Sample draws: %s",
+                incomplete_draws.height,
+                iteration,
+                incomplete_draws.head(20).to_dicts(),
+            )
+        return (
+            activity_sequences_with_counts
+            .filter(pl.col("step_count_after_spatialization") == pl.col("step_count"))
+            .drop(["step_count", "step_count_after_spatialization"])
+            .sort(chain_key_cols + ["seq_step_index"])
+        )

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Any
+
+import polars as pl
+
+
+def log_location_chain_diagnostics(
+    *,
+    iteration: int,
+    destination_steps: pl.DataFrame,
+    trip_chains: pl.DataFrame,
+    unique_destination_chains: pl.DataFrame,
+) -> None:
+    """Log mode-search chain diagnostics only when debug logging is enabled."""
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        return
+
+    trip_chain_lengths = _trip_chain_lengths(trip_chains)
+    unique_chain_lengths = _unique_chain_lengths(unique_destination_chains)
+    logging.debug(
+        "Mode search chain lengths at iteration %s | grouped=%s | unique_dest_seq=%s",
+        iteration,
+        _chain_length_distribution(trip_chain_lengths),
+        _chain_length_distribution(unique_chain_lengths),
+    )
+
+    invalid_unique_chains = unique_chain_lengths.filter(pl.col("location_count") < 2)
+    if invalid_unique_chains.height == 0:
+        return
+
+    grouped_invalid_chains = _grouped_invalid_chains(
+        trip_chain_lengths=trip_chain_lengths,
+        invalid_unique_chains=invalid_unique_chains,
+    )
+
+    # A one-location chain means the destination-step sequence was truncated
+    # before mode search prepared the grouped `from` locations for Rust.
+    logging.warning(
+        "Mode search invalid location chains at iteration %s: %s unique dest_seq_id values and %s grouped chains have fewer than two locations. "
+        "This usually means a one-leg destination chain was reduced to one `from` location before Rust search. "
+        "Sample grouped chains: %s | Sample destination steps: %s",
+        iteration,
+        invalid_unique_chains.height,
+        grouped_invalid_chains.height,
+        grouped_invalid_chains.head(10).to_dicts(),
+        _invalid_destination_steps(
+            destination_steps=destination_steps,
+            grouped_invalid_chains=grouped_invalid_chains,
+        ).head(20).to_dicts(),
+    )
+
+
+def _trip_chain_lengths(trip_chains: pl.DataFrame) -> pl.DataFrame:
+    """Attach a grouped location count to each trip chain."""
+    return trip_chains.with_columns(
+        location_count=pl.col("locations").list.len(),
+    )
+
+
+def _unique_chain_lengths(unique_destination_chains: pl.DataFrame) -> pl.DataFrame:
+    """Attach a grouped location count to each unique destination chain."""
+    return unique_destination_chains.with_columns(
+        location_count=pl.col("locations").list.len(),
+    )
+
+
+def _chain_length_distribution(frame: pl.DataFrame) -> list[dict[str, Any]]:
+    """Return a compact grouped distribution of chain lengths."""
+    return (
+        frame
+        .group_by("location_count")
+        .len()
+        .sort("location_count")
+        .to_dicts()
+    )
+
+
+def _grouped_invalid_chains(
+    *,
+    trip_chain_lengths: pl.DataFrame,
+    invalid_unique_chains: pl.DataFrame,
+) -> pl.DataFrame:
+    """Return the grouped chains that reuse invalid unique destination sequences."""
+    return (
+        trip_chain_lengths
+        .join(invalid_unique_chains.select("dest_seq_id"), on="dest_seq_id", how="inner")
+        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id"])
+    )
+
+
+def _invalid_destination_steps(
+    *,
+    destination_steps: pl.DataFrame,
+    grouped_invalid_chains: pl.DataFrame,
+) -> pl.DataFrame:
+    """Return the raw destination rows behind invalid location chains."""
+    invalid_chain_keys = grouped_invalid_chains.select(
+        ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"]
+    )
+    return (
+        destination_steps
+        .join(
+            invalid_chain_keys,
+            on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"],
+            how="inner",
+        )
+        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+    )

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
@@ -12,6 +12,7 @@ from .assemble import (
     build_mode_sequence_keys,
     finalize_mode_sequence_rows,
 )
+from .debug_logs import log_location_chain_diagnostics
 from .prepare import build_location_chains, build_search_inputs
 from .search_python import run_python_mode_sequence_search
 from .search_rust import run_rust_mode_sequence_search
@@ -100,6 +101,12 @@ class ModeSequences(FileAsset):
         log_memory_checkpoint(
             f"mode_sequences:iteration:{self.iteration}:unique_location_chains",
             unique_location_chains=unique_destination_chains,
+        )
+        log_location_chain_diagnostics(
+            iteration=self.iteration,
+            destination_steps=destination_steps,
+            trip_chains=trip_chains,
+            unique_destination_chains=unique_destination_chains,
         )
 
         search_inputs = build_search_inputs(self.transport_costs)

--- a/mobility/trips/group_day_trips/plans/plan_initializer.py
+++ b/mobility/trips/group_day_trips/plans/plan_initializer.py
@@ -55,6 +55,7 @@ class PlanInitializer:
                 "departure_time",
                 "arrival_time",
                 "next_departure_time",
+                "step_count",
                 "duration_per_pers",
             ]
         )

--- a/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
+++ b/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
@@ -221,6 +221,8 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
             "dest_draw_id": [1],
             "activity": ["shop"],
             "is_anchor": [False],
+            "seq_step_index": [1],
+            "step_count": [1],
             "anchor_to": [anchor_destination],
             "from": [1],
             "departure_time": [8.0],
@@ -233,11 +235,13 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_draw_id": pl.UInt32,
-            "activity": pl.Utf8,
-            "is_anchor": pl.Boolean,
-            "anchor_to": pl.UInt16,
-            "from": pl.UInt16,
-            "departure_time": pl.Float64,
+                "activity": pl.Utf8,
+                "is_anchor": pl.Boolean,
+                "seq_step_index": pl.UInt8,
+                "step_count": pl.UInt8,
+                "anchor_to": pl.UInt16,
+                "from": pl.UInt16,
+                "departure_time": pl.Float64,
             "arrival_time": pl.Float64,
             "next_departure_time": pl.Float64,
         },
@@ -292,6 +296,58 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
     assert result_without_chain_penalty["to"].to_list() == [lowest_noise_candidate]
     assert result_with_chain_penalty["to"].to_list() == [highest_noise_candidate]
     assert result_with_chain_penalty["to"].to_list() != result_without_chain_penalty["to"].to_list()
+
+
+def test_drop_incomplete_destination_draws_removes_partial_draws():
+    activity_sequences = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 2, 2],
+            "home_zone_id": [100, 100, 200, 200],
+            "activity_seq_id": [10, 10, 20, 20],
+            "time_seq_id": [1, 1, 2, 2],
+            "dest_draw_id": [1, 1, 1, 1],
+            "activity": ["shop", "study", "work", "home"],
+            "anchor_to": [100, 100, 200, 200],
+            "from": [100, 110, 200, 210],
+            "to": [110, 120, 210, 200],
+            "departure_time": [8.0, 9.0, 8.5, 17.0],
+            "arrival_time": [8.5, 9.5, 9.0, 17.5],
+            "next_departure_time": [9.0, 10.0, 17.0, 17.5],
+            "seq_step_index": [1, 2, 1, 2],
+            "step_count": [3, 3, 2, 2],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "home_zone_id": pl.UInt16,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_draw_id": pl.UInt32,
+            "activity": pl.Utf8,
+            "anchor_to": pl.UInt16,
+            "from": pl.UInt16,
+            "to": pl.UInt16,
+            "departure_time": pl.Float64,
+            "arrival_time": pl.Float64,
+            "next_departure_time": pl.Float64,
+            "seq_step_index": pl.UInt8,
+            "step_count": pl.UInt8,
+        },
+    )
+
+    result = DestinationSequences._drop_incomplete_destination_draws(
+        activity_sequences=activity_sequences,
+        iteration=4,
+    )
+
+    assert result.select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]).unique().to_dicts() == [
+        {
+            "demand_group_id": 2,
+            "activity_seq_id": 20,
+            "time_seq_id": 2,
+            "dest_draw_id": 1,
+        }
+    ]
+    assert result["seq_step_index"].to_list() == [1, 2]
 
 
 def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path):

--- a/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
+++ b/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
@@ -1,0 +1,347 @@
+import logging
+from types import SimpleNamespace
+
+import pandas as pd
+import polars as pl
+
+from mobility.trips.group_day_trips.plans.debug_logs import (
+    log_destination_sequence_diagnostics,
+    log_step_dropout_diagnostics,
+)
+from mobility.trips.group_day_trips.plans.mode_sequence_search.debug_logs import (
+    log_location_chain_diagnostics,
+)
+
+
+def test_debug_diagnostics_do_not_collect_inputs_when_debug_is_disabled(caplog):
+    with caplog.at_level(logging.INFO):
+        log_destination_sequence_diagnostics(
+            iteration=1,
+            source_activity_sequences=pl.DataFrame(),
+            destination_sequences=pl.DataFrame(),
+        )
+        log_step_dropout_diagnostics(
+            seq_step_index=1,
+            chains_step=pl.DataFrame(),
+            costs=pl.DataFrame(),
+            non_anchor_candidates=pl.DataFrame().lazy(),
+            candidates_with_origin_costs=pl.DataFrame().lazy(),
+            candidates_with_costs=pl.DataFrame().lazy(),
+            sampled_non_anchor_steps=pl.DataFrame().lazy(),
+            chain_key_cols=[],
+            transport_zones=None,
+        )
+        log_location_chain_diagnostics(
+            iteration=1,
+            destination_steps=pl.DataFrame(),
+            trip_chains=pl.DataFrame(),
+            unique_destination_chains=pl.DataFrame(),
+        )
+
+
+def test_log_destination_sequence_diagnostics_reports_one_step_chains(caplog):
+    source_activity_sequences = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 2],
+            "activity_seq_id": [10, 10, 20],
+            "time_seq_id": [100, 100, 200],
+            "seq_step_index": [0, 1, 0],
+            "activity": ["home", "work", "home"],
+        }
+    )
+    destination_sequences = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 2],
+            "activity_seq_id": [10, 10, 20],
+            "time_seq_id": [100, 100, 200],
+            "dest_seq_id": [1000, 1000, 2000],
+            "seq_step_index": [0, 1, 0],
+            "from": [1, 2, 3],
+            "to": [2, 1, 4],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_destination_sequence_diagnostics(
+            iteration=7,
+            source_activity_sequences=source_activity_sequences,
+            destination_sequences=destination_sequences,
+        )
+
+    assert "Destination sequence step counts at iteration 7" in caplog.text
+    assert "Destination sequences contain 1 one-step chains at iteration 7" in caplog.text
+    assert "Activity-sequence source rows behind one-step destination chains at iteration 7" in caplog.text
+    assert "'dest_seq_id': 2000" in caplog.text
+    assert "'activity': 'home'" in caplog.text
+
+
+def test_log_destination_sequence_diagnostics_skips_warning_for_complete_chains(caplog):
+    destination_sequences = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1],
+            "activity_seq_id": [10, 10],
+            "time_seq_id": [100, 100],
+            "dest_seq_id": [1000, 1000],
+            "seq_step_index": [0, 1],
+            "from": [1, 2],
+            "to": [2, 1],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_destination_sequence_diagnostics(
+            iteration=7,
+            source_activity_sequences=pl.DataFrame(),
+            destination_sequences=destination_sequences,
+        )
+
+    assert "Destination sequence step counts at iteration 7" in caplog.text
+    assert "Destination sequences contain" not in caplog.text
+
+
+def test_log_step_dropout_diagnostics_reports_each_dropout_stage(caplog):
+    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    chains_step = pl.DataFrame(
+        {
+            "demand_group_id": [1, 2, 3, 4, 5],
+            "activity_seq_id": [10, 20, 30, 40, 50],
+            "time_seq_id": [100, 200, 300, 400, 500],
+            "dest_draw_id": [1000, 2000, 3000, 4000, 5000],
+            "activity": ["shop", "shop", "shop", "shop", "home"],
+            "seq_step_index": [2, 2, 2, 2, 2],
+            "from": [10, 20, 30, 40, 50],
+            "anchor_to": [110, 120, 130, 140, 150],
+            "is_anchor": [False, False, False, False, True],
+        }
+    )
+    non_anchor_candidates = pl.DataFrame(
+        {
+            "demand_group_id": [2, 3, 4],
+            "activity_seq_id": [20, 30, 40],
+            "time_seq_id": [200, 300, 400],
+            "dest_draw_id": [2000, 3000, 4000],
+            "activity": ["shop", "shop", "shop"],
+            "seq_step_index": [2, 2, 2],
+            "from": [20, 30, 40],
+            "to": [220, 230, 240],
+            "anchor_to": [120, 130, 140],
+            "p_ij": [0.2, 0.3, 0.4],
+        }
+    )
+    candidates_with_origin_costs = non_anchor_candidates.filter(pl.col("demand_group_id").is_in([3, 4]))
+    candidates_with_costs = non_anchor_candidates.filter(pl.col("demand_group_id") == 4)
+    sampled_non_anchor_steps = non_anchor_candidates.head(0)
+    costs = pl.DataFrame(
+        {
+            "from": [30, 230, 130, 240],
+            "to": [230, 130, 230, 140],
+            "cost": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": [130, 140, 230, 240],
+                "x": [0.0, 3000.0, 3000.0, 6000.0],
+                "y": [0.0, 4000.0, 4000.0, 8000.0],
+                "geometry": [None, None, None, None],
+            }
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_step_dropout_diagnostics(
+            seq_step_index=2,
+            chains_step=chains_step,
+            costs=costs,
+            non_anchor_candidates=non_anchor_candidates.lazy(),
+            candidates_with_origin_costs=candidates_with_origin_costs.lazy(),
+            candidates_with_costs=candidates_with_costs.lazy(),
+            sampled_non_anchor_steps=sampled_non_anchor_steps.lazy(),
+            chain_key_cols=chain_key_cols,
+            transport_zones=transport_zones,
+        )
+
+    assert "Destination spatialization dropouts at step 2" in caplog.text
+    assert "after_probability_missing=1" in caplog.text
+    assert "after_origin_cost_missing=1" in caplog.text
+    assert "after_anchor_cost_missing=1" in caplog.text
+    assert "after_sampling_missing=1" in caplog.text
+    assert "candidate_anchor_beeline_km" in caplog.text
+    assert "'reverse_anchor_cost_rows': [{'from': 130, 'to': 230, 'cost': 3.0}]" in caplog.text
+
+
+def test_log_step_dropout_diagnostics_skips_when_no_non_anchor_or_dropout(caplog):
+    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    anchor_only = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_draw_id": [1000],
+            "activity": ["home"],
+            "seq_step_index": [1],
+            "from": [10],
+            "anchor_to": [20],
+            "is_anchor": [True],
+        }
+    )
+    surviving_candidate = pl.DataFrame(
+        {
+            "demand_group_id": [2],
+            "activity_seq_id": [20],
+            "time_seq_id": [200],
+            "dest_draw_id": [2000],
+            "activity": ["shop"],
+            "seq_step_index": [1],
+            "from": [20],
+            "to": [30],
+            "anchor_to": [40],
+            "p_ij": [1.0],
+            "is_anchor": [False],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_step_dropout_diagnostics(
+            seq_step_index=1,
+            chains_step=anchor_only,
+            costs=pl.DataFrame(),
+            non_anchor_candidates=pl.DataFrame().lazy(),
+            candidates_with_origin_costs=pl.DataFrame().lazy(),
+            candidates_with_costs=pl.DataFrame().lazy(),
+            sampled_non_anchor_steps=pl.DataFrame().lazy(),
+            chain_key_cols=chain_key_cols,
+            transport_zones=None,
+        )
+        log_step_dropout_diagnostics(
+            seq_step_index=1,
+            chains_step=surviving_candidate,
+            costs=pl.DataFrame(),
+            non_anchor_candidates=surviving_candidate.lazy(),
+            candidates_with_origin_costs=surviving_candidate.lazy(),
+            candidates_with_costs=surviving_candidate.lazy(),
+            sampled_non_anchor_steps=surviving_candidate.lazy(),
+            chain_key_cols=chain_key_cols,
+            transport_zones=None,
+        )
+
+    assert "Destination spatialization dropouts" not in caplog.text
+
+
+def test_log_step_dropout_diagnostics_can_trace_costs_without_transport_zones(caplog):
+    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    chains_step = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_draw_id": [1000],
+            "activity": ["shop"],
+            "seq_step_index": [1],
+            "from": [10],
+            "anchor_to": [30],
+            "is_anchor": [False],
+        }
+    )
+    non_anchor_candidates = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_draw_id": [1000],
+            "activity": ["shop"],
+            "seq_step_index": [1],
+            "from": [10],
+            "to": [20],
+            "anchor_to": [30],
+            "p_ij": [1.0],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_step_dropout_diagnostics(
+            seq_step_index=1,
+            chains_step=chains_step,
+            costs=pl.DataFrame({"from": [10], "to": [20], "cost": [1.0]}),
+            non_anchor_candidates=non_anchor_candidates.lazy(),
+            candidates_with_origin_costs=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
+            candidates_with_costs=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
+            sampled_non_anchor_steps=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
+            chain_key_cols=chain_key_cols,
+            transport_zones=None,
+        )
+
+    assert "Destination spatialization dropouts at step 1" in caplog.text
+    assert "'candidate_anchor_beeline_km': None" in caplog.text
+
+
+def test_log_location_chain_diagnostics_reports_invalid_unique_chains(caplog):
+    destination_steps = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 2],
+            "activity_seq_id": [10, 10, 20],
+            "time_seq_id": [100, 100, 200],
+            "dest_seq_id": [1000, 1000, 2000],
+            "seq_step_index": [0, 1, 0],
+            "from": [1, 2, 3],
+            "to": [2, 1, 4],
+        }
+    )
+    trip_chains = pl.DataFrame(
+        {
+            "demand_group_id": [1, 2],
+            "activity_seq_id": [10, 20],
+            "time_seq_id": [100, 200],
+            "dest_seq_id": [1000, 2000],
+            "locations": [[1, 2, 1], [3]],
+        }
+    )
+    unique_destination_chains = pl.DataFrame(
+        {
+            "dest_seq_id": [1000, 2000],
+            "locations": [[1, 2, 1], [3]],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_location_chain_diagnostics(
+            iteration=5,
+            destination_steps=destination_steps,
+            trip_chains=trip_chains,
+            unique_destination_chains=unique_destination_chains,
+        )
+
+    assert "Mode search chain lengths at iteration 5" in caplog.text
+    assert "Mode search invalid location chains at iteration 5" in caplog.text
+    assert "1 unique dest_seq_id values and 1 grouped chains" in caplog.text
+    assert "'dest_seq_id': 2000" in caplog.text
+
+
+def test_log_location_chain_diagnostics_skips_warning_for_valid_chains(caplog):
+    trip_chains = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_seq_id": [1000],
+            "locations": [[1, 2]],
+        }
+    )
+    unique_destination_chains = pl.DataFrame(
+        {
+            "dest_seq_id": [1000],
+            "locations": [[1, 2]],
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        log_location_chain_diagnostics(
+            iteration=5,
+            destination_steps=pl.DataFrame(),
+            trip_chains=trip_chains,
+            unique_destination_chains=unique_destination_chains,
+        )
+
+    assert "Mode search chain lengths at iteration 5" in caplog.text
+    assert "Mode search invalid location chains" not in caplog.text

--- a/tests/back/unit/domain/transport_graphs/test_001_border_crossing_speed_modifier.py
+++ b/tests/back/unit/domain/transport_graphs/test_001_border_crossing_speed_modifier.py
@@ -1,0 +1,93 @@
+import geopandas as gpd
+from shapely.geometry import LineString, Polygon
+
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+from mobility.transport.graphs.modified.modifiers import speed_modifier
+
+
+class FakeStudyArea:
+    def __init__(self, boundary_path):
+        self.cache_path = {"boundary": boundary_path}
+
+
+class FakeTransportZones(InMemoryAsset):
+    def __init__(self, boundary_path):
+        super().__init__({})
+        self.inputs = {"study_area": FakeStudyArea(boundary_path)}
+        self.was_called = False
+
+    def get(self):
+        self.was_called = True
+
+
+class FakeGeofabrikRegions:
+    def __init__(self, extract_date):
+        self.extract_date = extract_date
+
+    def get(self):
+        return gpd.GeoDataFrame(
+            {
+                "url": ["empty", "outside", "inside"],
+                "geometry": [
+                    Polygon([(-1, -1), (3, -1), (3, 3), (-1, 3)]),
+                    Polygon([(-1, -1), (3, -1), (3, 3), (-1, 3)]),
+                    Polygon([(-1, -1), (3, -1), (3, 3), (-1, 3)]),
+                ],
+            },
+            crs=4326,
+        )
+
+
+class FakeGeofabrikExtract:
+    def __init__(self, url):
+        self.url = url
+
+
+class FakeOSMCountryBorder:
+    def __init__(self, extract):
+        self.path = f"{extract.url}.geojson"
+
+    def get(self):
+        return self.path
+
+
+def test_border_crossing_modifier_keeps_only_borders_crossing_the_study_area(monkeypatch):
+    """Ignore empty and unrelated border files before calling the R graph modifier."""
+
+    boundary_path = "boundary.geojson"
+    transport_zones = FakeTransportZones(boundary_path)
+    boundary = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+
+    empty_borders = gpd.GeoDataFrame(geometry=[], crs=4326)
+    outside_borders = gpd.GeoDataFrame(
+        geometry=[LineString([(10, 10), (11, 11)])],
+        crs=4326,
+    )
+    inside_borders = gpd.GeoDataFrame(
+        geometry=[LineString([(-1, 1), (3, 1)])],
+        crs=4326,
+    )
+    files = {
+        boundary_path: gpd.GeoDataFrame(geometry=[boundary], crs=4326),
+        "empty.geojson": empty_borders,
+        "outside.geojson": outside_borders,
+        "inside.geojson": inside_borders,
+    }
+
+    monkeypatch.setattr(speed_modifier, "GeofabrikRegions", FakeGeofabrikRegions)
+    monkeypatch.setattr(speed_modifier, "GeofabrikExtract", FakeGeofabrikExtract)
+    monkeypatch.setattr(speed_modifier, "OSMCountryBorder", FakeOSMCountryBorder)
+    monkeypatch.setattr(speed_modifier.gpd, "read_file", lambda path: files[path])
+
+    modifier = speed_modifier.BorderCrossingSpeedModifier(
+        transport_zones,
+        max_speed=30.0,
+        time_penalty=5.0,
+        geofabrik_extract_date="240101",
+    )
+
+    result = modifier.get()
+
+    assert transport_zones.was_called
+    assert result["has_borders"] is True
+    assert result["borders"] == ["inside.geojson"]

--- a/tests/back/unit/domain/transport_modes/test_001_car_mode.py
+++ b/tests/back/unit/domain/transport_modes/test_001_car_mode.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+from mobility.transport.modes import car as car_module
+
+
+def test_car_mode_forwards_congestion_assignment_parameters(monkeypatch):
+    """Check that public car-mode settings reach path travel costs."""
+    seen = {}
+
+    class FakePathTravelCosts:
+        def __init__(
+            self,
+            *,
+            mode_name,
+            transport_zones,
+            routing_parameters,
+            osm_capacity_parameters,
+            congestion,
+            congestion_flows_scaling_factor,
+            target_max_vehicles_per_od_endpoint,
+            congestion_assignment_max_iterations,
+            congestion_assignment_max_gap,
+            congestion_assignment_retained_volume_share,
+            speed_modifiers,
+        ):
+            seen.update(
+                {
+                    "mode_name": mode_name,
+                    "congestion": congestion,
+                    "target_max_vehicles_per_od_endpoint": (
+                        target_max_vehicles_per_od_endpoint
+                    ),
+                    "congestion_assignment_max_iterations": (
+                        congestion_assignment_max_iterations
+                    ),
+                    "congestion_assignment_max_gap": congestion_assignment_max_gap,
+                    "congestion_assignment_retained_volume_share": (
+                        congestion_assignment_retained_volume_share
+                    ),
+                    "speed_modifiers": speed_modifiers,
+                }
+            )
+
+    class FakePathGeneralizedCost:
+        def __init__(self, travel_costs, generalized_cost_parameters, mode_name):
+            self.travel_costs = travel_costs
+            self.generalized_cost_parameters = generalized_cost_parameters
+            self.mode_name = mode_name
+
+    monkeypatch.setattr(car_module, "PathTravelCosts", FakePathTravelCosts)
+    monkeypatch.setattr(car_module, "PathGeneralizedCost", FakePathGeneralizedCost)
+    monkeypatch.setattr(
+        car_module.TransportMode,
+        "compute_inputs_hash",
+        lambda self: "fake-car-mode-hash",
+    )
+
+    car_module.CarMode(
+        transport_zones=SimpleNamespace(),
+        congestion=True,
+        target_max_vehicles_per_od_endpoint=500.0,
+        congestion_assignment_max_iterations=7,
+        congestion_assignment_max_gap=0.03,
+        congestion_assignment_retained_volume_share=0.8,
+        speed_modifiers=["speed-modifier"],
+    )
+
+    assert seen == {
+        "mode_name": "car",
+        "congestion": True,
+        "target_max_vehicles_per_od_endpoint": 500.0,
+        "congestion_assignment_max_iterations": 7,
+        "congestion_assignment_max_gap": 0.03,
+        "congestion_assignment_retained_volume_share": 0.8,
+        "speed_modifiers": ["speed-modifier"],
+    }

--- a/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
+++ b/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
@@ -46,6 +46,9 @@ def test_congested_graph_iteration_asset_resolves_latest_active_refresh(monkeypa
         handles_congestion=True,
         congestion_flows_scaling_factor=0.5,
         target_max_vehicles_per_od_endpoint=1234.0,
+        congestion_assignment_max_iterations=3,
+        congestion_assignment_max_gap=0.2,
+        congestion_assignment_retained_volume_share=0.9,
     )
     run = SimpleNamespace(
         inputs_hash="run-key",
@@ -64,3 +67,6 @@ def test_congested_graph_iteration_asset_resolves_latest_active_refresh(monkeypa
     assert iter_graph.inputs["vehicle_flows"] is not None
     assert iter_graph.inputs["vehicle_flows"].cache_path == flow_asset.cache_path
     assert iter_graph.inputs["target_max_vehicles_per_od_endpoint"] == 1234.0
+    assert iter_graph.inputs["congestion_assignment_max_iterations"] == 3
+    assert iter_graph.inputs["congestion_assignment_max_gap"] == 0.2
+    assert iter_graph.inputs["congestion_assignment_retained_volume_share"] == 0.9

--- a/tests/back/unit/test_013_mobility_survey_plans.py
+++ b/tests/back/unit/test_013_mobility_survey_plans.py
@@ -147,8 +147,8 @@ def test_survey_plan_steps_truncate_to_ten_trips_then_force_last_trip_home():
 
     assert truncated_day["seq_step_index"].to_list() == list(range(1, 11))
     assert truncated_day["activity"].to_list() == ["work"] * 9 + ["home"]
-    assert truncated_day["max_seq_step_index"].to_list() == [10] * 10
+    assert truncated_day["step_count"].to_list() == [10] * 10
 
     assert short_day["seq_step_index"].to_list() == [1, 2]
     assert short_day["activity"].to_list() == ["work", "home"]
-    assert short_day["max_seq_step_index"].to_list() == [2, 2]
+    assert short_day["step_count"].to_list() == [2, 2]


### PR DESCRIPTION
### Motivation
Before this PR, congestion loading used fixed traffic assignment settings in the R graph loader:

- maximum assignment iterations was always `10`;
- convergence gap was always `0.05`;
- only the largest vertex-pair flows covering `95%` of demand were kept.

These values could not be changed from Python. This made heavy congestion runs hard to tune: a user could not trade speed for precision, or keep more OD demand when the default flow filtering was too aggressive.

The border-crossing speed modifier also loaded every border file for every intersecting Geofabrik region. Empty border files, or border files outside the study area, could still be passed to the R modifier.

### Changes
- Add car congestion assignment parameters:
  - `congestion_assignment_max_iterations`
  - `congestion_assignment_max_gap`
  - `congestion_assignment_retained_volume_share`
- Pass these settings from `CarMode` to `PathTravelCosts`, `PathGraph`, `CongestedPathGraph`, and finally to `load_path_graph.R`.
- Keep the old defaults, so default behavior stays close to the previous behavior.
- Make retained-flow filtering configurable in `load_path_graph.R`.
- Always keep at least one vertex-pair flow when congestion demand exists, even if the retained share is very small.
- Ignore empty and non-intersecting border files before applying the border-crossing speed modifier.
- Add a cache version input to public transport travel costs.

### Why This Is Better
Users can now tune congestion assignment without editing R code. For example, they can increase the retained flow share when they need more complete traffic loading, or lower the maximum gap when they need a more precise assignment.

The border modifier is also safer because it only passes useful border files to the R graph modifier.

### Example (if relevant)
```python
car = mobility.CarMode(
    transport_zones,
    congestion=True,
    congestion_assignment_max_iterations=20,
    congestion_assignment_max_gap=0.02,
    congestion_assignment_retained_volume_share=0.98,
)
```

### AI-assisted contribution
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: split this focused PR from a larger deadline branch and reviewed the transport graph changes.
- What you reviewed or changed: checked the PR diff, added missing coverage for `CarMode` parameter forwarding, and kept only transport graph related changes.
- How you validated it (tests, checks, manual verification): ran focused pytest tests, ran `py_compile` on changed Python files, and ran `git diff --check`.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior