### PR TITLE
Add Python transport zone backend

### DIFF
--- a/mobility/spatial/prepare_transport_zones.py
+++ b/mobility/spatial/prepare_transport_zones.py
@@ -1,0 +1,565 @@
+"""Create transport zones from building footprints with Python spatial tools."""
+from __future__ import annotations
+
+import hashlib
+import pathlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import shapely
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from shapely.geometry import GeometryCollection
+from scipy.spatial import cKDTree
+from sklearn.cluster import KMeans, MiniBatchKMeans
+
+
+BUILDINGS_AREA_THRESHOLD = 2e5
+MIN_BUILDING_AREA = 20
+MAX_BUILDING_AREA = 500e3
+RNG_SEED = 0
+TARGET_CRS = "EPSG:3035"
+MINIBATCH_BUILDING_THRESHOLD = 20_000
+DEFAULT_MAX_WORKERS = 4
+
+
+def prepare_transport_zones(
+    study_area_fp: str | pathlib.Path,
+    osm_buildings_fp: str | pathlib.Path,
+    level_of_detail: int,
+    output_fp: str | pathlib.Path,
+    max_workers: int | None = None,
+) -> None:
+    """Create transport zones and building cluster files.
+
+    The Python backend follows the same broad method as the R backend: it
+    clusters building centroids, snaps cluster centers to real buildings, builds
+    Voronoi polygons, and clips them to each local admin unit.
+    """
+    output_fp = pathlib.Path(output_fp)
+    clusters_fp, clusters_geoms_fp = _get_sidecar_paths(output_fp)
+
+    study_area = gpd.read_file(study_area_fp, engine="pyogrio").to_crs(TARGET_CRS)
+    if study_area.empty:
+        raise ValueError("Cannot create transport zones from an empty study area.")
+
+    tasks = [
+        (
+            lau_position,
+            study_area_row.local_admin_unit_id,
+            study_area_row.geometry,
+            pathlib.Path(osm_buildings_fp),
+            level_of_detail,
+        )
+        for lau_position, study_area_row in enumerate(study_area.itertuples(index=False))
+    ]
+
+    results = _run_lau_tasks(tasks, max_workers=max_workers)
+    results = sorted(results, key=lambda result: result["lau_position"])
+
+    zone_tables = [result["transport_zones"] for result in results]
+    cluster_tables = [result["clusters"] for result in results]
+
+    transport_zones = gpd.GeoDataFrame(
+        pd.concat(zone_tables, ignore_index=True),
+        geometry="geometry",
+        crs=TARGET_CRS,
+    )
+    clusters = pd.concat(cluster_tables, ignore_index=True)
+
+    transport_zones, clusters = _renumber_transport_zones(transport_zones, clusters)
+
+    transport_zones.to_file(output_fp, driver="GPKG", index=False)
+    clusters.to_parquet(clusters_fp, index=False)
+
+    clusters_geoms = gpd.GeoDataFrame(
+        clusters,
+        geometry=gpd.points_from_xy(clusters["x"], clusters["y"], crs=TARGET_CRS),
+        crs=TARGET_CRS,
+    )
+    clusters_geoms.to_file(
+        clusters_geoms_fp,
+        layer="cluster_buildings",
+        driver="GPKG",
+        index=False,
+    )
+
+
+def _run_lau_tasks(tasks: list[tuple], max_workers: int | None) -> list[dict]:
+    if not tasks:
+        return []
+
+    max_workers = _resolve_max_workers(len(tasks), max_workers)
+
+    results = []
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("{task.completed}/{task.total} LAUs"),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+    ) as progress:
+        progress_task = progress.add_task("Creating transport zones", total=len(tasks))
+
+        if max_workers == 1:
+            for task in tasks:
+                results.append(_create_lau_transport_zones_worker(task))
+                progress.advance(progress_task)
+            return results
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_create_lau_transport_zones_worker, task) for task in tasks]
+            for future in as_completed(futures):
+                results.append(future.result())
+                progress.advance(progress_task)
+    return results
+
+
+def _resolve_max_workers(task_count: int, max_workers: int | None) -> int:
+    if task_count <= 0:
+        return 0
+
+    if max_workers is not None:
+        return max(1, min(int(max_workers), task_count))
+
+    return max(1, min(DEFAULT_MAX_WORKERS, task_count))
+
+
+def _create_lau_transport_zones_worker(task: tuple) -> dict:
+    lau_position, lau_id, lau_geom, osm_buildings_fp, level_of_detail = task
+
+    rng = np.random.default_rng(_seed_for_lau(lau_id, lau_position))
+    transport_zones, clusters = _create_lau_transport_zones(
+        lau_id=lau_id,
+        lau_geom=lau_geom,
+        osm_buildings_fp=osm_buildings_fp,
+        level_of_detail=level_of_detail,
+        rng=rng,
+    )
+    return {
+        "lau_position": lau_position,
+        "transport_zones": transport_zones,
+        "clusters": clusters,
+    }
+
+
+def _renumber_transport_zones(
+    transport_zones: gpd.GeoDataFrame,
+    clusters: pd.DataFrame,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    transport_zones = transport_zones.copy()
+    clusters = clusters.copy()
+
+    transport_zones["new_transport_zone_id"] = np.arange(1, len(transport_zones) + 1)
+    zone_ids = transport_zones[
+        ["local_admin_unit_id", "transport_zone_id", "new_transport_zone_id"]
+    ]
+
+    clusters = clusters.merge(
+        zone_ids,
+        on=["local_admin_unit_id", "transport_zone_id"],
+        how="left",
+        validate="many_to_one",
+    )
+    clusters = clusters.drop(columns=["transport_zone_id"]).rename(
+        columns={"new_transport_zone_id": "transport_zone_id"}
+    )
+    transport_zones = transport_zones.drop(columns=["transport_zone_id"]).rename(
+        columns={"new_transport_zone_id": "transport_zone_id"}
+    )
+
+    return transport_zones, clusters
+
+
+def _create_lau_transport_zones(
+    lau_id: str,
+    lau_geom,
+    osm_buildings_fp: pathlib.Path,
+    level_of_detail: int,
+    rng: np.random.Generator,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    buildings = _read_lau_buildings(osm_buildings_fp, lau_id)
+    buildings = _prepare_building_centroids(buildings, lau_geom)
+
+    if buildings.empty:
+        return _create_empty_building_lau(lau_id, lau_geom)
+
+    n_clusters = int(np.ceil(buildings["area"].sum() / BUILDINGS_AREA_THRESHOLD))
+
+    if level_of_detail == 1 and n_clusters > 1:
+        labels, medoids = _kmeans_with_nearest_building_centers(
+            buildings,
+            k=n_clusters,
+            random_state=_rng_integer(rng),
+        )
+        buildings = buildings.copy()
+        buildings["cluster"] = labels
+
+        cluster_area = buildings.groupby("cluster", as_index=False)["area"].sum()
+        medoids = medoids.merge(cluster_area, on="cluster", how="left")
+
+        transport_zones = medoids.rename(
+            columns={"cluster": "transport_zone_id", "X": "x", "Y": "y"}
+        )
+        transport_zones["weight"] = transport_zones["area"] / transport_zones["area"].sum()
+        transport_zones = transport_zones.drop(columns=["area"])
+
+        internal_distances = _compute_cluster_internal_distance(buildings, rng)
+        transport_zones = transport_zones.merge(
+            internal_distances,
+            left_on="transport_zone_id",
+            right_on="cluster",
+            how="left",
+        ).drop(columns=["cluster"])
+
+        transport_zones["geometry"] = _create_voronoi_geometries(
+            medoids[["cluster", "X", "Y"]],
+            lau_geom,
+            buildings,
+        )
+
+        k_medoids = buildings.groupby("cluster", group_keys=True).apply(
+            lambda group: _compute_k_medoids(group, _rng_integer(rng)),
+            include_groups=False,
+        )
+        k_medoids = k_medoids.reset_index(level=0).rename(
+            columns={"cluster": "transport_zone_id"}
+        )
+    else:
+        buildings = buildings.copy()
+        buildings["cluster"] = 1
+        internal_distances = _compute_cluster_internal_distance(buildings, rng)
+        k_medoids = _compute_k_medoids(buildings, _rng_integer(rng))
+        k_medoids["transport_zone_id"] = 1
+
+        center = k_medoids.loc[k_medoids["n_clusters"] == 1].iloc[0]
+        transport_zones = gpd.GeoDataFrame(
+            {
+                "transport_zone_id": [1],
+                "weight": [1.0],
+                "internal_distance": [internal_distances["internal_distance"].iloc[0]],
+                "x": [center["x"]],
+                "y": [center["y"]],
+                "geometry": [lau_geom],
+            },
+            geometry="geometry",
+            crs=TARGET_CRS,
+        )
+
+    transport_zones["local_admin_unit_id"] = lau_id
+    k_medoids["local_admin_unit_id"] = lau_id
+
+    transport_zones = gpd.GeoDataFrame(
+        transport_zones,
+        geometry="geometry",
+        crs=TARGET_CRS,
+    )
+    k_medoids = k_medoids[
+        ["n_clusters", "x", "y", "weight", "transport_zone_id", "local_admin_unit_id"]
+    ]
+
+    return transport_zones, k_medoids
+
+
+def _read_lau_buildings(osm_buildings_fp: pathlib.Path, lau_id: str) -> gpd.GeoDataFrame:
+    building_fp = osm_buildings_fp / lau_id / "building.pbf"
+    return gpd.read_file(
+        building_fp,
+        layer="multipolygons",
+        columns=["osm_id"],
+        engine="pyogrio",
+    )
+
+
+def _prepare_building_centroids(buildings: gpd.GeoDataFrame, lau_geom) -> pd.DataFrame:
+    if buildings.empty:
+        return pd.DataFrame(columns=["area", "X", "Y", "building_id"])
+
+    buildings = buildings.to_crs(TARGET_CRS)
+    geometry = buildings.geometry.array
+    area = shapely.area(geometry)
+    keep = (area > MIN_BUILDING_AREA) & (area < MAX_BUILDING_AREA)
+
+    if not np.any(keep):
+        return pd.DataFrame(columns=["area", "X", "Y", "building_id"])
+
+    geometry = geometry[keep]
+    centroids = shapely.centroid(geometry)
+    x = shapely.get_x(centroids)
+    y = shapely.get_y(centroids)
+
+    inside = shapely.intersects(centroids, lau_geom)
+    return pd.DataFrame(
+        {
+            "area": area[keep][inside].astype(float),
+            "X": x[inside].astype(float),
+            "Y": y[inside].astype(float),
+        }
+    ).assign(building_id=lambda df: np.arange(1, len(df) + 1))
+
+
+def _create_empty_building_lau(
+    lau_id: str,
+    lau_geom,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    point = shapely.point_on_surface(lau_geom)
+    x = float(shapely.get_x(point))
+    y = float(shapely.get_y(point))
+
+    transport_zones = gpd.GeoDataFrame(
+        {
+            "transport_zone_id": [1],
+            "weight": [1.0],
+            "internal_distance": [0.0],
+            "x": [x],
+            "y": [y],
+            "local_admin_unit_id": [lau_id],
+            "geometry": [lau_geom],
+        },
+        geometry="geometry",
+        crs=TARGET_CRS,
+    )
+    clusters = pd.DataFrame(
+        {
+            "n_clusters": [1],
+            "x": [x],
+            "y": [y],
+            "weight": [1.0],
+            "transport_zone_id": [1],
+            "local_admin_unit_id": [lau_id],
+        }
+    )
+    return transport_zones, clusters
+
+
+def _kmeans_with_nearest_building_centers(
+    buildings: pd.DataFrame,
+    k: int,
+    random_state: int,
+) -> tuple[np.ndarray, pd.DataFrame]:
+    coords = buildings[["X", "Y"]].to_numpy()
+    n_unique = len(np.unique(coords, axis=0))
+    k = max(1, min(int(k), len(coords), n_unique))
+
+    if k == 1:
+        return _one_cluster_labels_and_medoids(buildings)
+
+    if len(coords) >= MINIBATCH_BUILDING_THRESHOLD:
+        model = MiniBatchKMeans(
+            n_clusters=k,
+            random_state=random_state,
+            n_init=1,
+            batch_size=4096,
+        )
+    else:
+        model = KMeans(
+            n_clusters=k,
+            random_state=random_state,
+            n_init=1,
+            max_iter=10,
+        )
+
+    labels = model.fit_predict(coords)
+    return _snap_centers_to_buildings(coords, labels, model.cluster_centers_)
+
+
+def _one_cluster_labels_and_medoids(buildings: pd.DataFrame) -> tuple[np.ndarray, pd.DataFrame]:
+    coords = buildings[["X", "Y"]].to_numpy()
+    medoid_idx = _nearest_to_weighted_center(buildings)
+    medoids = pd.DataFrame(
+        {
+            "cluster": [1],
+            "X": [coords[medoid_idx, 0]],
+            "Y": [coords[medoid_idx, 1]],
+        }
+    )
+    return np.ones(len(coords), dtype=int), medoids
+
+
+def _snap_centers_to_buildings(
+    coords: np.ndarray,
+    labels: np.ndarray,
+    centers: np.ndarray,
+) -> tuple[np.ndarray, pd.DataFrame]:
+    """Snap centers to real buildings and return stable one-based labels."""
+    tree = cKDTree(coords)
+    _, medoid_idx = tree.query(centers, k=1)
+
+    order = np.argsort(medoid_idx)
+    old_to_new = {
+        old_label: new_label
+        for new_label, old_label in enumerate(order, start=1)
+    }
+    labels = np.array([old_to_new[label] for label in labels], dtype=int)
+    medoid_idx = medoid_idx[order]
+
+    medoids = pd.DataFrame(
+        {
+            "cluster": np.arange(1, len(medoid_idx) + 1),
+            "X": coords[medoid_idx, 0],
+            "Y": coords[medoid_idx, 1],
+        }
+    )
+    return labels, medoids
+
+
+def _nearest_to_weighted_center(buildings: pd.DataFrame) -> int:
+    coords = buildings[["X", "Y"]].to_numpy()
+    weights = buildings["area"].to_numpy()
+    center = np.average(coords, axis=0, weights=weights)
+    tree = cKDTree(coords)
+    _, idx = tree.query(center, k=1)
+    return int(idx)
+
+
+def _compute_cluster_internal_distance(
+    buildings: pd.DataFrame,
+    rng: np.random.Generator,
+) -> pd.DataFrame:
+    rows = []
+    for cluster, group in buildings.groupby("cluster", sort=True):
+        coords = group[["X", "Y"]].to_numpy()
+        probabilities = group["area"].to_numpy(dtype=float)
+        probabilities = probabilities / probabilities.sum()
+
+        from_idx = rng.choice(len(group), size=1000, replace=True, p=probabilities)
+        to_idx = rng.choice(len(group), size=1000, replace=True, p=probabilities)
+        distances = np.linalg.norm(coords[from_idx] - coords[to_idx], axis=1)
+        distances = distances * (1.1 + 0.3 * np.exp(-distances / 20))
+        rows.append(
+            {
+                "cluster": cluster,
+                "internal_distance": float(np.median(distances)),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _compute_k_medoids(buildings: pd.DataFrame, random_state: int) -> pd.DataFrame:
+    rows = []
+    n_buildings = len(buildings)
+
+    for requested_k in range(1, 6):
+        k = max(1, min(requested_k, n_buildings // 10))
+        labels, medoids = _small_kmeans_with_nearest_building_centers(
+            buildings,
+            k=k,
+            random_state=random_state + requested_k,
+        )
+
+        area_by_subcluster = np.bincount(
+            labels,
+            weights=buildings["area"].to_numpy(dtype=float),
+            minlength=len(medoids) + 1,
+        )[1:]
+        current = medoids.rename(columns={"cluster": "subcluster", "X": "x", "Y": "y"})
+        current["weight"] = area_by_subcluster / area_by_subcluster.sum()
+        current["n_clusters"] = requested_k
+        rows.append(current[["n_clusters", "x", "y", "weight"]])
+
+    return pd.concat(rows, ignore_index=True)
+
+
+def _small_kmeans_with_nearest_building_centers(
+    buildings: pd.DataFrame,
+    k: int,
+    random_state: int,
+    iter_max: int = 10,
+) -> tuple[np.ndarray, pd.DataFrame]:
+    """Run a small NumPy k-means for routing medoids.
+
+    Routing medoids ask for at most five centers. Using scikit-learn for these
+    small repeated fits costs more in setup than in math, so this helper keeps
+    the same simple Lloyd method in NumPy.
+    """
+    coords = buildings[["X", "Y"]].to_numpy(dtype=float)
+    n_unique = len(np.unique(coords, axis=0))
+    k = max(1, min(int(k), len(coords), n_unique))
+
+    if k == 1:
+        return _one_cluster_labels_and_medoids(buildings)
+
+    rng = np.random.default_rng(random_state)
+    _, unique_indices = np.unique(coords, axis=0, return_index=True)
+    center_indices = rng.choice(unique_indices, size=k, replace=False)
+    centers = coords[center_indices].copy()
+
+    raw_labels = None
+    for _ in range(iter_max):
+        distances = np.sum((coords[:, None, :] - centers[None, :, :]) ** 2, axis=2)
+        new_labels = np.argmin(distances, axis=1)
+
+        if raw_labels is not None and np.array_equal(raw_labels, new_labels):
+            break
+
+        raw_labels = new_labels
+        for cluster_index in range(k):
+            in_cluster = raw_labels == cluster_index
+            if np.any(in_cluster):
+                centers[cluster_index] = coords[in_cluster].mean(axis=0)
+
+    return _snap_centers_to_buildings(coords, raw_labels, centers)
+
+
+def _create_voronoi_geometries(
+    medoids: pd.DataFrame,
+    lau_geom,
+    buildings: pd.DataFrame,
+) -> list:
+    points = shapely.points(medoids["X"].to_numpy(), medoids["Y"].to_numpy())
+    points_collection = GeometryCollection(points.tolist())
+    envelope = shapely.box(
+        buildings["X"].min(),
+        buildings["Y"].min(),
+        buildings["X"].max(),
+        buildings["Y"].max(),
+    )
+    envelope = shapely.buffer(envelope, 100_000)
+
+    voronoi = shapely.voronoi_polygons(points_collection, extend_to=envelope)
+    polygons = list(shapely.get_parts(voronoi))
+    clipped = shapely.intersection(np.array(polygons, dtype=object), lau_geom)
+
+    voronoi_gdf = gpd.GeoDataFrame(
+        {"geometry": clipped},
+        geometry="geometry",
+        crs=TARGET_CRS,
+    )
+    points_gdf = gpd.GeoDataFrame(
+        medoids[["cluster"]].copy(),
+        geometry=gpd.points_from_xy(medoids["X"], medoids["Y"], crs=TARGET_CRS),
+        crs=TARGET_CRS,
+    )
+    joined = gpd.sjoin(points_gdf, voronoi_gdf.reset_index(), predicate="intersects")
+    joined = joined.sort_values(["cluster", "index"]).drop_duplicates("cluster")
+    geometry_by_cluster = joined.set_index("cluster")["index"].to_dict()
+
+    return [
+        voronoi_gdf.geometry.iloc[geometry_by_cluster[cluster]]
+        for cluster in medoids["cluster"]
+    ]
+
+
+def _get_sidecar_paths(output_fp: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    stem = output_fp.stem
+    return (
+        output_fp.parent / f"{stem}_buildings.parquet",
+        output_fp.parent / f"{stem}_buildings_geoms.gpkg",
+    )
+
+
+def _seed_for_lau(lau_id: str, lau_position: int) -> int:
+    stable_hash = hashlib.blake2b(lau_id.encode("utf-8"), digest_size=4).digest()
+    lau_seed = int.from_bytes(stable_hash, "little")
+    return int((RNG_SEED + lau_seed + lau_position) % np.iinfo(np.int32).max)
+
+
+def _rng_integer(rng: np.random.Generator) -> int:
+    return int(rng.integers(0, np.iinfo(np.int32).max))

--- a/mobility/spatial/transport_zones.py
+++ b/mobility/spatial/transport_zones.py
@@ -15,6 +15,7 @@ from mobility.runtime.assets.file_asset import FileAsset
 from mobility.spatial.study_area import StudyArea, StudyAreaParameters
 from mobility.spatial.osm import OSMData
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
+from mobility.spatial.prepare_transport_zones import prepare_transport_zones
 
 class TransportZones(FileAsset):
     """
@@ -26,7 +27,8 @@ class TransportZones(FileAsset):
     The transport zone is based on either a list of local admin units ids
     or one local admin unit id and a radius within which all local admin unit ids should be included.
 
-    It uses the R script 'prepare_transport_zones' to do so.
+    It uses either the reference R backend or the experimental Python backend
+    to create the transport zones.
 
     Parameters
     ----------
@@ -43,6 +45,10 @@ class TransportZones(FileAsset):
             
     radius : float, default=40.0
         Local admin units within this radius (in km) of the center admin unit will be included.
+    backend : {"r", "python"}, default="r"
+        Backend used to create transport zones. The Python backend follows the
+        same building clustering and Voronoi method, but its results are not
+        exactly identical to the R backend.
 
     Methods
     -------
@@ -60,6 +66,8 @@ class TransportZones(FileAsset):
             radius: float | None = None,
             inner_radius: float | None = None,
             inner_local_admin_unit_id: List[str] | None = None,
+            backend: Literal["r", "python"] | None = None,
+            backend_workers: int | None = None,
             cutout_geometries: gpd.GeoDataFrame = None,
             parameters: "TransportZonesParameters" | None = None,
         ):
@@ -73,6 +81,8 @@ class TransportZones(FileAsset):
                 "radius": radius,
                 "inner_radius": inner_radius,
                 "inner_local_admin_unit_id": inner_local_admin_unit_id,
+                "backend": backend,
+                "backend_workers": backend_workers,
             },
             required_fields=["local_admin_unit_id"],
             owner_name="TransportZones",
@@ -136,7 +146,7 @@ class TransportZones(FileAsset):
         """
         Create and retrieve transport zones with the given inputs.
         
-        It uses the R script 'prepare_transport_zones' to do so.
+        It uses the selected transport zone backend to do so.
 
         Returns
         -------
@@ -148,7 +158,45 @@ class TransportZones(FileAsset):
         
         study_area_fp = self.study_area.cache_path["polygons"]
         osm_buildings_fp = self.osm_buildings.get()
-        
+
+        if self.inputs["parameters"].backend == "r":
+            self.create_transport_zones_with_r(study_area_fp, osm_buildings_fp)
+        elif self.inputs["parameters"].backend == "python":
+            self.create_transport_zones_with_python(study_area_fp, osm_buildings_fp)
+        else:
+            raise ValueError(f"Unknown transport zones backend: {self.inputs['parameters'].backend}")
+
+        transport_zones = gpd.read_file(self.cache_path)
+
+        # Remove transport zones that are not adjacent to at least another one
+        # (= filter "islands" that were selected but are not connected to the
+        # study area)
+        transport_zones = self.remove_isolated_zones(transport_zones)
+
+        # Set inner / outer flag
+        local_admin_unit_id = self.inputs["parameters"].local_admin_unit_id
+        inner_radius = self.inputs["parameters"].inner_radius
+        inner_local_admin_unit_id = self.inputs["parameters"].inner_local_admin_unit_id
+
+        transport_zones = self.flag_inner_zones(
+            transport_zones,
+            local_admin_unit_id,
+            inner_radius,
+            inner_local_admin_unit_id
+        )
+
+        # Cut the transport zones
+        transport_zones = self.apply_cutout(
+            transport_zones,
+            self.inputs["cutout_geometries"]
+        )
+
+        transport_zones.to_file(self.cache_path)
+
+        return transport_zones
+
+    def create_transport_zones_with_r(self, study_area_fp, osm_buildings_fp):
+        """Create raw transport zones with the reference R backend."""
         script = RScriptRunner(resources.files('mobility.spatial').joinpath('prepare_transport_zones.R'))
         script.run(
             args=[
@@ -158,35 +206,16 @@ class TransportZones(FileAsset):
                 str(self.cache_path)
             ]
         )
-        
-        transport_zones = gpd.read_file(self.cache_path)
-        
-        # Remove transport zones that are not adjacent to at least another one
-        # (= filter "islands" that were selected but are not connected to the 
-        # study area)
-        transport_zones = self.remove_isolated_zones(transport_zones)
-        
-        # Set inner / outer flag
-        local_admin_unit_id = self.inputs["parameters"].local_admin_unit_id
-        inner_radius = self.inputs["parameters"].inner_radius
-        inner_local_admin_unit_id = self.inputs["parameters"].inner_local_admin_unit_id
-        
-        transport_zones = self.flag_inner_zones(
-            transport_zones,
-            local_admin_unit_id,
-            inner_radius,
-            inner_local_admin_unit_id
+
+    def create_transport_zones_with_python(self, study_area_fp, osm_buildings_fp):
+        """Create raw transport zones with the experimental Python backend."""
+        prepare_transport_zones(
+            study_area_fp=study_area_fp,
+            osm_buildings_fp=osm_buildings_fp,
+            level_of_detail=self.inputs["parameters"].level_of_detail,
+            output_fp=self.cache_path,
+            max_workers=self.inputs["parameters"].backend_workers,
         )
-        
-        # Cut the transport zones 
-        transport_zones = self.apply_cutout(
-            transport_zones,
-            self.inputs["cutout_geometries"]
-        )
-        
-        transport_zones.to_file(self.cache_path)
-        
-        return transport_zones
     
     
     def remove_isolated_zones(self, transport_zones):
@@ -282,6 +311,33 @@ class TransportZonesParameters(BaseModel):
             description=(
                 "Whether local admin units will be split into subzones "
                 "(level of detail = 1), according to their building footprint density."
+            ),
+        ),
+    ]
+
+    backend: Annotated[
+        Literal["r", "python"],
+        Field(
+            default="r",
+            title="Transport zones backend",
+            description=(
+                "Backend used to create transport zones. The R backend is the "
+                "reference. The Python backend is experimental and follows the "
+                "same building-clustering and Voronoi method."
+            ),
+        ),
+    ]
+
+    backend_workers: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=1,
+            title="Transport zones backend workers",
+            description=(
+                "Number of workers used by the Python backend. If omitted, "
+                "the Python backend chooses a conservative default. This "
+                "setting is ignored by the R backend."
             ),
         ),
     ]

--- a/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
+++ b/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
@@ -1,8 +1,18 @@
 import types
 import pathlib
 
+import geopandas as gpd
+import numpy as np
+import pandas as pd
 import pytest
+from shapely.geometry import box
 
+from mobility.spatial.prepare_transport_zones import (
+    _create_lau_transport_zones,
+    _get_sidecar_paths,
+    _resolve_max_workers,
+    prepare_transport_zones,
+)
 from mobility.spatial.transport_zones import TransportZones
 
 
@@ -117,8 +127,220 @@ def test_init_builds_inputs_and_cache_path(project_dir, dependency_fakes):
 
     # Inputs surfaced as attributes (via patched Asset.__init__)
     assert transport_zones.inputs["parameters"].level_of_detail == level_of_detail
+    assert transport_zones.inputs["parameters"].backend == "r"
     assert getattr(transport_zones, "study_area") is not None
     assert getattr(transport_zones, "osm_buildings") is not None
 
     # New instance has no value cached in memory yet
     assert transport_zones.value is None
+
+
+def test_python_backend_dispatches_to_python_preparation(dependency_fakes, monkeypatch, tmp_path):
+    calls = []
+
+    def _prepare_transport_zones_spy(study_area_fp, osm_buildings_fp, level_of_detail, output_fp, max_workers):
+        calls.append(
+            {
+                "study_area_fp": pathlib.Path(study_area_fp),
+                "osm_buildings_fp": pathlib.Path(osm_buildings_fp),
+                "level_of_detail": level_of_detail,
+                "output_fp": pathlib.Path(output_fp),
+                "max_workers": max_workers,
+            }
+        )
+
+    import mobility.spatial.transport_zones as tz_module
+
+    monkeypatch.setattr(
+        tz_module,
+        "prepare_transport_zones",
+        _prepare_transport_zones_spy,
+        raising=True,
+    )
+
+    transport_zones = TransportZones(
+        local_admin_unit_id="fr-09122",
+        level_of_detail=1,
+        radius=30,
+        backend="python",
+        backend_workers=8,
+    )
+
+    transport_zones.create_transport_zones_with_python(
+        study_area_fp=tmp_path / "study_area_polygons.gpkg",
+        osm_buildings_fp=tmp_path / "osm_buildings",
+    )
+
+    assert calls == [
+        {
+            "study_area_fp": tmp_path / "study_area_polygons.gpkg",
+            "osm_buildings_fp": tmp_path / "osm_buildings",
+            "level_of_detail": 1,
+            "output_fp": transport_zones.cache_path,
+            "max_workers": 8,
+        }
+    ]
+
+
+def test_create_and_get_asset_dispatches_to_selected_python_backend(
+    dependency_fakes,
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+    raw_zones = gpd.GeoDataFrame(
+        {
+            "transport_zone_id": [1],
+            "local_admin_unit_id": ["fr-09122"],
+            "x": [0.0],
+            "y": [0.0],
+        },
+        geometry=[box(0, 0, 1, 1)],
+        crs="EPSG:3035",
+    )
+
+    def fake_create_transport_zones_with_python(self, study_area_fp, osm_buildings_fp):
+        calls.append(
+            {
+                "backend": "python",
+                "study_area_fp": pathlib.Path(study_area_fp),
+                "osm_buildings_fp": pathlib.Path(osm_buildings_fp),
+            }
+        )
+
+    def fake_create_transport_zones_with_r(self, study_area_fp, osm_buildings_fp):
+        calls.append({"backend": "r"})
+
+    monkeypatch.setattr(
+        TransportZones,
+        "create_transport_zones_with_python",
+        fake_create_transport_zones_with_python,
+    )
+    monkeypatch.setattr(
+        TransportZones,
+        "create_transport_zones_with_r",
+        fake_create_transport_zones_with_r,
+    )
+    monkeypatch.setattr(
+        "mobility.spatial.transport_zones.gpd.read_file",
+        lambda _path: raw_zones.copy(),
+    )
+    monkeypatch.setattr(
+        TransportZones,
+        "remove_isolated_zones",
+        lambda self, zones: zones,
+    )
+    monkeypatch.setattr(
+        TransportZones,
+        "flag_inner_zones",
+        lambda self, zones, *_args: zones.assign(is_inner_zone=True),
+    )
+    monkeypatch.setattr(
+        TransportZones,
+        "apply_cutout",
+        lambda self, zones, _cutout_geometries: zones,
+    )
+    monkeypatch.setattr(gpd.GeoDataFrame, "to_file", lambda self, *_args, **_kwargs: None)
+
+    transport_zones = TransportZones(
+        local_admin_unit_id="fr-09122",
+        level_of_detail=1,
+        radius=30,
+        backend="python",
+    )
+
+    result = transport_zones.create_and_get_asset()
+
+    assert calls == [
+        {
+            "backend": "python",
+            "study_area_fp": tmp_path / "study_area_polygons.gpkg",
+            "osm_buildings_fp": tmp_path / "osm_buildings.gpkg",
+        }
+    ]
+    assert result["is_inner_zone"].to_list() == [True]
+
+
+def test_sidecar_paths_use_transport_zone_output_stem(tmp_path):
+    clusters_path, cluster_geometries_path = _get_sidecar_paths(
+        tmp_path / "transport_zones.gpkg"
+    )
+
+    assert clusters_path == tmp_path / "transport_zones_buildings.parquet"
+    assert cluster_geometries_path == tmp_path / "transport_zones_buildings_geoms.gpkg"
+
+
+def test_resolve_max_workers_uses_task_count_as_upper_bound():
+    assert _resolve_max_workers(task_count=0, max_workers=None) == 0
+    assert _resolve_max_workers(task_count=2, max_workers=8) == 2
+    assert _resolve_max_workers(task_count=3, max_workers=None) == 3
+
+
+def test_python_backend_builds_one_zone_when_lau_has_no_buildings(monkeypatch):
+    monkeypatch.setattr(
+        "mobility.spatial.prepare_transport_zones._read_lau_buildings",
+        lambda _osm_buildings_fp, _lau_id: gpd.GeoDataFrame(geometry=[], crs="EPSG:4326"),
+    )
+
+    zones, clusters = _create_lau_transport_zones(
+        lau_id="fr-09122",
+        lau_geom=box(0, 0, 1000, 1000),
+        osm_buildings_fp=pathlib.Path("unused"),
+        level_of_detail=1,
+        rng=np.random.default_rng(0),
+    )
+
+    assert zones["transport_zone_id"].to_list() == [1]
+    assert zones["local_admin_unit_id"].to_list() == ["fr-09122"]
+    assert clusters["transport_zone_id"].to_list() == [1]
+    assert clusters["local_admin_unit_id"].to_list() == ["fr-09122"]
+
+
+def test_python_backend_writes_transport_zones_and_building_sidecars(
+    monkeypatch,
+    tmp_path,
+):
+    study_area_fp = tmp_path / "study_area.gpkg"
+    output_fp = tmp_path / "transport_zones.gpkg"
+    clusters_fp, cluster_geometries_fp = _get_sidecar_paths(output_fp)
+
+    study_area = gpd.GeoDataFrame(
+        {"local_admin_unit_id": ["fr-09122"]},
+        geometry=[box(0, 0, 5000, 1000)],
+        crs="EPSG:3035",
+    )
+    study_area.to_file(study_area_fp, driver="GPKG", index=False)
+
+    buildings = gpd.GeoDataFrame(
+        geometry=[
+            box(100, 100, 350, 350),
+            box(360, 100, 610, 350),
+            box(3000, 100, 3250, 350),
+            box(3260, 100, 3510, 350),
+        ],
+        crs="EPSG:3035",
+    )
+    monkeypatch.setattr(
+        "mobility.spatial.prepare_transport_zones._read_lau_buildings",
+        lambda _osm_buildings_fp, _lau_id: buildings.copy(),
+    )
+
+    prepare_transport_zones(
+        study_area_fp=study_area_fp,
+        osm_buildings_fp=tmp_path / "osm_buildings",
+        level_of_detail=1,
+        output_fp=output_fp,
+        max_workers=1,
+    )
+
+    zones = gpd.read_file(output_fp)
+    clusters = pd.read_parquet(clusters_fp)
+
+    assert output_fp.exists()
+    assert clusters_fp.exists()
+    assert cluster_geometries_fp.exists()
+    assert len(zones) == 2
+    assert zones["local_admin_unit_id"].to_list() == ["fr-09122", "fr-09122"]
+    assert zones["transport_zone_id"].to_list() == [1, 2]
+    assert pytest.approx(zones["weight"].sum()) == 1.0
+    assert set(clusters["transport_zone_id"]) == {1, 2}


### PR DESCRIPTION
### Motivation

Transport zones are currently created with the R backend.

This PR adds a Python backend for transport zone creation. The default behavior stays unchanged: `TransportZones` still uses the R backend unless the user explicitly asks for the Python backend.

This makes it possible to test and improve a Python implementation without breaking existing users.

### Changes

This PR adds `mobility.spatial.prepare_transport_zones`.

The new Python backend:

- reads the study area;
- reads OSM buildings split by local admin unit;
- filters very small and very large buildings;
- creates building centroids;
- creates one or several transport zones per local admin unit;
- uses building area to weight zones;
- creates Voronoi geometries when a commune is split into several zones;
- writes the transport zones to the normal `transport_zones.gpkg` output;
- also writes building cluster sidecar files.

`TransportZones` now accepts two new parameters:

```python
TransportZones(
    local_admin_unit_id="fr-09122",
    backend="python",
    backend_workers=4,
)
```

`backend` can be:

- `r`: default, existing behavior;
- `python`: new experimental Python backend.

`backend_workers` controls the number of workers used by the Python backend. It is ignored by the R backend.

The PR also adds unit tests for:

- default backend selection;
- dispatch to the Python backend;
- worker count bounds;
- sidecar file paths;
- communes with no buildings;
- a small end-to-end Python backend run that writes transport zones and building sidecar files.

### Example

```python
transport_zones = mobility.TransportZones(
    local_admin_unit_id=fr-09122,
    radius=30,
    level_of_detail=1,
    backend=python,
    backend_workers=4,
)
```

Before this PR, transport zones were always created by the R script.

After this PR, users can keep the existing R backend or opt into the Python backend.

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: helped review and clean the Python backend split, backend selection code, and tests.
- What you reviewed or changed: checked that the R backend remains the default, added tests around the new backend behavior, and added a small backend output test.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior