### PR TITLE
Add destination shadow price controls

### DIFF
--- a/mobility/activities/activity.py
+++ b/mobility/activities/activity.py
@@ -31,6 +31,11 @@ class Activity(InMemoryAsset):
             utilities: pd.DataFrame = None,
             country_value_coefficients: Dict = None,
             sink_saturation_coeff: float = None,
+            destination_soft_capacity_factor: float = None,
+            destination_shadow_price_sensitivity_coefficient: float = None,
+            destination_shadow_price_min_coefficient: float = None,
+            destination_sampling_overload_gamma: float = None,
+            destination_sampling_min_attraction_factor: float = None,
             extra_inputs: dict | None = None,
             parameters: "ActivityParameters" | None = None,
         ):
@@ -47,6 +52,19 @@ class Activity(InMemoryAsset):
                 "radiation_lambda": radiation_lambda,
                 "country_value_coefficients": country_value_coefficients,
                 "sink_saturation_coeff": sink_saturation_coeff,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": (
+                    destination_sampling_overload_gamma
+                ),
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
             },
             required_fields=["value_of_time", "saturation_fun_ref_level", "saturation_fun_beta"],
             owner_name=f"Activity({name})",
@@ -175,6 +193,68 @@ class ActivityParameters(BaseModel):
             default=1.0,
             title="Sink saturation coefficient",
             description="Coefficient scaling sink saturation in activity utility.",
+        ),
+    ]
+
+    destination_soft_capacity_factor: Annotated[
+        NonNegativeFloat,
+        Field(
+            default=1.0,
+            title="Destination soft capacity factor",
+            description=(
+                "Multiplier applied to opportunity capacity before a destination "
+                "shadow price is charged. A value of 1.25 allows occupation up "
+                "to 125 percent of capacity before applying a penalty."
+            ),
+        ),
+    ]
+
+    destination_shadow_price_sensitivity_coefficient: Annotated[
+        NonNegativeFloat,
+        Field(
+            default=1.0,
+            title="Destination shadow price sensitivity coefficient",
+            description=(
+                "Coefficient applied to the activity value of time to compute "
+                "the default destination shadow price sensitivity."
+            ),
+        ),
+    ]
+
+    destination_shadow_price_min_coefficient: Annotated[
+        float,
+        Field(
+            default=-2.0,
+            le=0.0,
+            title="Destination shadow price floor coefficient",
+            description=(
+                "Coefficient applied to the activity value of time to compute "
+                "the default lower bound for the destination shadow price."
+            ),
+        ),
+    ]
+
+    destination_sampling_overload_gamma: Annotated[
+        NonNegativeFloat,
+        Field(
+            default=1.5,
+            title="Destination sampling overload gamma",
+            description=(
+                "Shape of the overload penalty applied to destination "
+                "opportunities during destination sampling."
+            ),
+        ),
+    ]
+
+    destination_sampling_min_attraction_factor: Annotated[
+        UnitIntervalFloat,
+        Field(
+            default=0.05,
+            title="Destination sampling minimum attraction factor",
+            description=(
+                "Lower bound for the destination sampling attraction factor "
+                "when a destination is overloaded."
+            ),
         ),
     ]
 

--- a/mobility/activities/leisure/leisure.py
+++ b/mobility/activities/leisure/leisure.py
@@ -23,6 +23,11 @@ class LeisureActivity(Activity):
         value_of_time: float = None,
         saturation_fun_ref_level: float = None,
         saturation_fun_beta: float = None,
+        destination_soft_capacity_factor: float = None,
+        destination_shadow_price_sensitivity_coefficient: float = None,
+        destination_shadow_price_min_coefficient: float = None,
+        destination_sampling_overload_gamma: float = None,
+        destination_sampling_min_attraction_factor: float = None,
         survey_ids: List[str] = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
@@ -36,6 +41,17 @@ class LeisureActivity(Activity):
                 "value_of_time": value_of_time,
                 "saturation_fun_ref_level": saturation_fun_ref_level,
                 "saturation_fun_beta": saturation_fun_beta,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": destination_sampling_overload_gamma,
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
             },

--- a/mobility/activities/other.py
+++ b/mobility/activities/other.py
@@ -19,6 +19,11 @@ class OtherActivity(Activity):
         value_of_time: float = None,
         saturation_fun_ref_level: float = None,
         saturation_fun_beta: float = None,
+        destination_soft_capacity_factor: float = None,
+        destination_shadow_price_sensitivity_coefficient: float = None,
+        destination_shadow_price_min_coefficient: float = None,
+        destination_sampling_overload_gamma: float = None,
+        destination_sampling_min_attraction_factor: float = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
         population: Population = None,
@@ -38,6 +43,17 @@ class OtherActivity(Activity):
                 "value_of_time": value_of_time,
                 "saturation_fun_ref_level": saturation_fun_ref_level,
                 "saturation_fun_beta": saturation_fun_beta,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": destination_sampling_overload_gamma,
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
                 "radiation_lambda": radiation_lambda,
             },
             owner_name="OtherActivity",

--- a/mobility/activities/shopping/shop.py
+++ b/mobility/activities/shopping/shop.py
@@ -20,6 +20,11 @@ class ShopActivity(Activity):
         value_of_time: float = None,
         saturation_fun_ref_level: float = None,
         saturation_fun_beta: float = None,
+        destination_soft_capacity_factor: float = None,
+        destination_shadow_price_sensitivity_coefficient: float = None,
+        destination_shadow_price_min_coefficient: float = None,
+        destination_sampling_overload_gamma: float = None,
+        destination_sampling_min_attraction_factor: float = None,
         survey_ids: List[str] = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
@@ -33,6 +38,17 @@ class ShopActivity(Activity):
                 "value_of_time": value_of_time,
                 "saturation_fun_ref_level": saturation_fun_ref_level,
                 "saturation_fun_beta": saturation_fun_beta,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": destination_sampling_overload_gamma,
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
             },

--- a/mobility/activities/studies/study.py
+++ b/mobility/activities/studies/study.py
@@ -22,6 +22,11 @@ class StudyActivity(Activity):
         value_of_time: float = None,
         saturation_fun_ref_level: float = None,
         saturation_fun_beta: float = None,
+        destination_soft_capacity_factor: float = None,
+        destination_shadow_price_sensitivity_coefficient: float = None,
+        destination_shadow_price_min_coefficient: float = None,
+        destination_sampling_overload_gamma: float = None,
+        destination_sampling_min_attraction_factor: float = None,
         survey_ids: List[str] = None, 
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
@@ -35,6 +40,17 @@ class StudyActivity(Activity):
                 "value_of_time": value_of_time,
                 "saturation_fun_ref_level": saturation_fun_ref_level,
                 "saturation_fun_beta": saturation_fun_beta,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": destination_sampling_overload_gamma,
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
             },

--- a/mobility/activities/work/work.py
+++ b/mobility/activities/work/work.py
@@ -20,6 +20,11 @@ class WorkActivity(Activity):
         value_of_time: float = None,
         saturation_fun_ref_level: float = None,
         saturation_fun_beta: float = None,
+        destination_soft_capacity_factor: float = None,
+        destination_shadow_price_sensitivity_coefficient: float = None,
+        destination_shadow_price_min_coefficient: float = None,
+        destination_sampling_overload_gamma: float = None,
+        destination_sampling_min_attraction_factor: float = None,
         survey_ids: List[str] = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
@@ -35,6 +40,17 @@ class WorkActivity(Activity):
                 "value_of_time": value_of_time,
                 "saturation_fun_ref_level": saturation_fun_ref_level,
                 "saturation_fun_beta": saturation_fun_beta,
+                "destination_soft_capacity_factor": destination_soft_capacity_factor,
+                "destination_shadow_price_sensitivity_coefficient": (
+                    destination_shadow_price_sensitivity_coefficient
+                ),
+                "destination_shadow_price_min_coefficient": (
+                    destination_shadow_price_min_coefficient
+                ),
+                "destination_sampling_overload_gamma": destination_sampling_overload_gamma,
+                "destination_sampling_min_attraction_factor": (
+                    destination_sampling_min_attraction_factor
+                ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
                 "country_value_coefficients": country_value_coefficients,

--- a/mobility/trips/group_day_trips/core/parameters.py
+++ b/mobility/trips/group_day_trips/core/parameters.py
@@ -282,6 +282,19 @@ class Parameters(BaseModel):
         ),
     ]
 
+    use_destination_shadow_prices: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Use destination shadow prices",
+            description=(
+                "Whether to use additive destination shadow prices for "
+                "opportunity-capacity feedback. When disabled, the legacy "
+                "multiplicative sink saturation utility is used."
+            ),
+        ),
+    ]
+
     min_activity_time_constant: Annotated[
         float,
         Field(

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -335,6 +335,19 @@ class DestinationSequences(FileAsset):
         x = [-2.0, -1.0, 0.0, 1.0, 2.0]
         probabilities = norm.pdf(x, loc=0.0, scale=cost_uncertainty_sd)
         probabilities /= probabilities.sum()
+        use_shadow_prices = bool(
+            getattr(self.parameters, "use_destination_shadow_prices", False)
+        )
+        opportunities_columns = set(opportunities.columns)
+        if (
+            use_shadow_prices
+            and "destination_sampling_attraction_factor" in opportunities_columns
+        ):
+            sink_factor = pl.col("destination_sampling_attraction_factor").fill_null(1.0)
+        elif "k_saturation_utility" in opportunities_columns:
+            sink_factor = pl.col("k_saturation_utility").fill_null(1.0)
+        else:
+            sink_factor = pl.lit(1.0)
 
         uncertainty_offsets = pl.DataFrame(
             {
@@ -355,7 +368,7 @@ class DestinationSequences(FileAsset):
             .with_columns(
                 effective_sink=(
                     pl.col("opportunity_capacity")
-                    * pl.col("k_saturation_utility").fill_null(1.0)
+                    * sink_factor
                     * pl.col("prob")
                 ).clip(0.0),
             )

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -229,6 +229,7 @@ class PlanUpdater:
             resolved_activity_parameters=resolved_activity_parameters,
             min_activity_time_constant=min_activity_time_constant,
             allow_missing_costs_for_current_plans=(candidate_plan_steps is not None),
+            use_destination_shadow_prices=parameters.use_destination_shadow_prices,
         )
 
     def compute_plan_steps_candidates_utility(
@@ -242,6 +243,7 @@ class PlanUpdater:
         resolved_activity_parameters: dict[str, Any],
         min_activity_time_constant,
         allow_missing_costs_for_current_plans: bool,
+        use_destination_shadow_prices: bool = False,
     ) -> pl.LazyFrame:
         """Score plan-step candidates under current costs and destination saturation."""
 
@@ -287,6 +289,9 @@ class PlanUpdater:
         ).with_columns(
             activity=pl.col("activity").cast(pl.Enum(activity_dur["activity"].dtype.categories))
         )
+        destination_saturation = self._ensure_destination_saturation_columns(
+            destination_saturation
+        )
         possible_plan_step_columns = [
             "demand_group_id",
             "country",
@@ -313,6 +318,7 @@ class PlanUpdater:
             "mean_duration_per_pers",
             "value_of_time",
             "k_saturation_utility",
+            "destination_shadow_price",
             "min_activity_time",
             "utility",
         ]
@@ -330,7 +336,14 @@ class PlanUpdater:
             .join(activity_dur.lazy(), on=["country", "csp", "activity"])
             .join(value_of_time.lazy(), on="activity")
             .join(
-                destination_saturation.select(["to", "activity", "k_saturation_utility"]).lazy(),
+                destination_saturation.select(
+                    [
+                        "to",
+                        "activity",
+                        "k_saturation_utility",
+                        "destination_shadow_price",
+                    ]
+                ).lazy(),
                 on=["to", "activity"],
                 how="left",
             )
@@ -345,14 +358,22 @@ class PlanUpdater:
                 distance=pl.col("distance").fill_null(0.0),
                 time=pl.col("time").fill_null(0.0),
                 k_saturation_utility=pl.col("k_saturation_utility").fill_null(1.0),
+                destination_shadow_price=pl.col("destination_shadow_price").fill_null(0.0),
                 country_value_coefficient=pl.col("country_value_coefficient").fill_null(1.0),
                 min_activity_time=pl.col("mean_duration_per_pers") * math.exp(-min_activity_time_constant),
             )
             .with_columns(
                 utility=(
-                    pl.col("country_value_coefficient")
-                    * pl.col("k_saturation_utility")
-                    * pl.col("value_of_time")
+                    (
+                        pl.col("country_value_coefficient") * pl.col("value_of_time")
+                        + pl.col("destination_shadow_price")
+                        if use_destination_shadow_prices
+                        else (
+                            pl.col("country_value_coefficient")
+                            * pl.col("k_saturation_utility")
+                            * pl.col("value_of_time")
+                        )
+                    )
                     * pl.col("mean_duration_per_pers")
                     * (pl.col("duration_per_pers") / pl.col("min_activity_time")).log().clip(0.0)
                     - pl.col("cost")
@@ -439,6 +460,7 @@ class PlanUpdater:
                 mean_duration_per_pers=pl.col("duration_per_pers"),
                 value_of_time=pl.lit(0.0),
                 k_saturation_utility=pl.lit(1.0),
+                destination_shadow_price=pl.lit(0.0),
                 min_activity_time=pl.lit(0.0),
                 first_seen_iteration=pl.lit(None, dtype=pl.UInt16),
                 last_active_iteration=pl.lit(None, dtype=pl.UInt16),
@@ -890,6 +912,23 @@ class PlanUpdater:
                         "activity": activity_name,
                         "beta": activity_parameters.saturation_fun_beta,
                         "ref_level": activity_parameters.saturation_fun_ref_level,
+                        "param_destination_soft_capacity_factor": (
+                            activity_parameters.destination_soft_capacity_factor
+                        ),
+                        "destination_shadow_price_sensitivity": (
+                            activity_parameters.destination_shadow_price_sensitivity_coefficient
+                            * activity_parameters.value_of_time
+                        ),
+                        "destination_shadow_price_min": (
+                            activity_parameters.destination_shadow_price_min_coefficient
+                            * activity_parameters.value_of_time
+                        ),
+                        "destination_sampling_overload_gamma": (
+                            activity_parameters.destination_sampling_overload_gamma
+                        ),
+                        "destination_sampling_min_attraction_factor": (
+                            activity_parameters.destination_sampling_min_attraction_factor
+                        ),
                     }
                     for activity_name, activity_parameters in resolved_activity_parameters.items()
                 ]
@@ -903,14 +942,96 @@ class PlanUpdater:
             .agg(opportunity_occupation=pl.col("duration").sum())
             .join(opportunities, on=["to", "activity"], how="full", coalesce=True)
             .join(saturation_fun_parameters, on="activity")
+            .with_columns(
+                destination_soft_capacity_factor=pl.col("param_destination_soft_capacity_factor")
+            )
             .with_columns(opportunity_occupation=pl.col("opportunity_occupation").fill_null(0.0))
-            .with_columns(k=pl.col("opportunity_occupation") / pl.col("opportunity_capacity"))
+            .with_columns(
+                capacity_ratio=pl.col("opportunity_occupation") / pl.col("opportunity_capacity").clip(1e-12),
+                soft_capacity=(
+                    pl.col("destination_soft_capacity_factor")
+                    * pl.col("opportunity_capacity")
+                ),
+            )
             .with_columns(
                 k_saturation_utility=(
-                    1.0 - pl.col("k").pow(pl.col("beta")) / (pl.col("ref_level").pow(pl.col("beta")))
+                    1.0 - pl.col("capacity_ratio").pow(pl.col("beta")) / (pl.col("ref_level").pow(pl.col("beta")))
                 ).clip(0.0)
             )
-            .select(["activity", "to", "opportunity_capacity", "k_saturation_utility"])
+            .with_columns(
+                overload=pl.col("opportunity_occupation") / pl.col("soft_capacity").clip(1e-12),
+            )
+            .with_columns(
+                destination_shadow_price=(
+                    pl.when(pl.col("overload") <= 1.0)
+                    .then(0.0)
+                    .otherwise(
+                        -pl.col("destination_shadow_price_sensitivity")
+                        * pl.col("overload").log()
+                    )
+                    .clip(pl.col("destination_shadow_price_min"), 0.0)
+                )
+            )
+            .with_columns(
+                destination_sampling_attraction_factor=(
+                    pl.when(pl.col("overload") <= 1.0)
+                    .then(1.0)
+                    .otherwise(
+                        pl.col("overload").pow(
+                            -pl.col("destination_sampling_overload_gamma")
+                        )
+                    )
+                    .clip(pl.col("destination_sampling_min_attraction_factor"), 1.0)
+                )
+            )
+            .select([
+                "activity",
+                "to",
+                "opportunity_capacity",
+                "opportunity_occupation",
+                "capacity_ratio",
+                "destination_soft_capacity_factor",
+                "k_saturation_utility",
+                "destination_shadow_price",
+                "destination_sampling_overload_gamma",
+                "destination_sampling_min_attraction_factor",
+                "destination_sampling_attraction_factor",
+            ])
         )
 
         return destination_saturation
+
+    @staticmethod
+    def _ensure_destination_saturation_columns(destination_saturation: pl.DataFrame) -> pl.DataFrame:
+        """Add shadow-price columns when an older saturation table is provided."""
+        columns = set(destination_saturation.columns)
+        expressions = []
+        if "k_saturation_utility" not in columns:
+            expressions.append(pl.lit(1.0, dtype=pl.Float64).alias("k_saturation_utility"))
+        if "destination_shadow_price" not in columns:
+            expressions.append(pl.lit(0.0, dtype=pl.Float64).alias("destination_shadow_price"))
+        if "destination_sampling_overload_gamma" not in columns:
+            expressions.append(
+                pl.lit(1.5, dtype=pl.Float64).alias("destination_sampling_overload_gamma")
+            )
+        if "destination_sampling_min_attraction_factor" not in columns:
+            expressions.append(
+                pl.lit(0.05, dtype=pl.Float64).alias(
+                    "destination_sampling_min_attraction_factor"
+                )
+            )
+        if "destination_sampling_attraction_factor" not in columns:
+            expressions.append(
+                pl.lit(1.0, dtype=pl.Float64).alias(
+                    "destination_sampling_attraction_factor"
+                )
+            )
+        if "opportunity_occupation" not in columns:
+            expressions.append(pl.lit(0.0, dtype=pl.Float64).alias("opportunity_occupation"))
+        if "capacity_ratio" not in columns:
+            expressions.append(pl.lit(0.0, dtype=pl.Float64).alias("capacity_ratio"))
+        if "destination_soft_capacity_factor" not in columns:
+            expressions.append(pl.lit(1.0, dtype=pl.Float64).alias("destination_soft_capacity_factor"))
+        if not expressions:
+            return destination_saturation
+        return destination_saturation.with_columns(expressions)

--- a/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
+++ b/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
@@ -81,7 +81,14 @@ def test_008e_group_day_trips_can_resume_from_saved_iteration(test_data):
         "activity",
         "to",
         "opportunity_capacity",
+        "opportunity_occupation",
+        "capacity_ratio",
+        "destination_soft_capacity_factor",
         "k_saturation_utility",
+        "destination_shadow_price",
+        "destination_sampling_overload_gamma",
+        "destination_sampling_min_attraction_factor",
+        "destination_sampling_attraction_factor",
     ]
 
     resumed_pop_trips = _build_group_day_trips(test_data)

--- a/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
+++ b/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import math
 import pandas as pd
 import polars as pl
 import pytest
@@ -90,3 +91,213 @@ def test_plan_updater_applies_destination_country_value_coefficient():
     utilities_by_destination = dict(zip(result["to"].to_list(), result["utility"].to_list(), strict=True))
     assert utilities_by_destination[10] == pytest.approx(7.0)
     assert utilities_by_destination[20] == pytest.approx(15.0)
+
+
+def test_plan_updater_integrates_shadow_price_in_activity_value_when_enabled():
+    updater = PlanUpdater()
+    candidates = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "country": ["fr"],
+            "activity_seq_id": [10],
+            "time_seq_id": [1],
+            "dest_seq_id": [100],
+            "mode_seq_id": [1000],
+            "seq_step_index": [0],
+            "activity": ["work"],
+            "from": [1],
+            "to": [10],
+            "mode": ["car"],
+            "duration_per_pers": [8.0],
+            "departure_time": [8.0],
+            "arrival_time": [9.0],
+            "next_departure_time": [17.0],
+            "iteration": [1],
+            "csp": ["x"],
+            "first_seen_iteration": [None],
+            "last_active_iteration": [None],
+        }
+    ).with_columns(mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"]))).lazy()
+    activity_dur = pl.DataFrame(
+        {
+            "country": ["fr"],
+            "csp": ["x"],
+            "activity": ["work"],
+            "mean_duration_per_pers": [8.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+    destination_saturation = pl.DataFrame(
+        {
+            "to": [10],
+            "activity": ["work"],
+            "k_saturation_utility": [0.25],
+            "destination_shadow_price": [-2.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+
+    class _StubTransportCosts:
+        def __init__(self):
+            self.modes = [SimpleNamespace(inputs={"parameters": SimpleNamespace(name="car")})]
+
+        def get_costs_by_od_and_mode(self, columns, detail_distances=False):
+            return pl.DataFrame(
+                {
+                    "from": [1],
+                    "to": [10],
+                    "mode": ["car"],
+                    "cost": [1.0],
+                    "distance": [10.0],
+                    "time": [1.0],
+                }
+            )
+
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": [10],
+                "local_admin_unit_id": ["fr001"],
+            }
+        )
+    )
+    resolved_activity_parameters = {
+        "work": SimpleNamespace(value_of_time=1.0, country_value_coefficients={"fr": 1.0}),
+    }
+
+    result = updater.compute_plan_steps_candidates_utility(
+        candidates=candidates,
+        transport_costs=_StubTransportCosts(),
+        destination_saturation=destination_saturation,
+        activity_dur=activity_dur,
+        transport_zones=transport_zones,
+        resolved_activity_parameters=resolved_activity_parameters,
+        min_activity_time_constant=1.0,
+        allow_missing_costs_for_current_plans=False,
+        use_destination_shadow_prices=True,
+    ).collect()
+
+    expected_utility = -8.0 * math.log(math.e) - 1.0
+    assert result["utility"].item() == pytest.approx(expected_utility)
+    assert result["destination_shadow_price"].item() == pytest.approx(-2.0)
+
+
+def test_destination_saturation_computes_shadow_price_above_soft_capacity():
+    updater = PlanUpdater()
+    current_plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [10, 10],
+            "activity": ["work", "work"],
+            "to": [1, 2],
+            "duration": [250.0, 100.0],
+        }
+    )
+    opportunities = pl.DataFrame(
+        {
+            "activity": ["work", "work"],
+            "to": [1, 2],
+            "opportunity_capacity": [100.0, 100.0],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+    resolved_activity_parameters = {
+        "work": SimpleNamespace(
+            value_of_time=10.0,
+            saturation_fun_beta=4.0,
+            saturation_fun_ref_level=1.5,
+            destination_soft_capacity_factor=1.25,
+            destination_shadow_price_sensitivity_coefficient=0.1,
+            destination_shadow_price_min_coefficient=-0.5,
+            destination_sampling_overload_gamma=1.0,
+            destination_sampling_min_attraction_factor=0.05,
+        )
+    }
+
+    result = updater.get_destination_saturation(
+        current_plan_steps=current_plan_steps,
+        opportunities=opportunities,
+        resolved_activity_parameters=resolved_activity_parameters,
+    ).sort("to")
+
+    overloaded = result.row(0, named=True)
+    below_soft_capacity = result.row(1, named=True)
+
+    assert overloaded["capacity_ratio"] == pytest.approx(2.5)
+    assert overloaded["destination_shadow_price"] == pytest.approx(-math.log(2.0))
+    assert overloaded["destination_sampling_attraction_factor"] == pytest.approx(0.5)
+    assert below_soft_capacity["destination_shadow_price"] == pytest.approx(0.0)
+    assert below_soft_capacity["destination_sampling_attraction_factor"] == pytest.approx(1.0)
+
+
+def test_add_stay_home_plan_steps_adds_neutral_shadow_price(tmp_path):
+    updater = PlanUpdater()
+    index_folder = tmp_path / "plan_index"
+    index_folder.mkdir()
+    possible_plan_steps = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "country": ["fr"],
+            "csp": ["worker"],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_seq_id": [1000],
+            "mode_seq_id": [10000],
+            "seq_step_index": [1],
+            "activity": ["work"],
+            "from": [1],
+            "to": [2],
+            "mode": ["car"],
+            "duration_per_pers": [8.0],
+            "departure_time": [8.0],
+            "arrival_time": [9.0],
+            "next_departure_time": [17.0],
+            "iteration": [2],
+            "cost": [1.0],
+            "distance": [10.0],
+            "time": [1.0],
+            "mean_duration_per_pers": [8.0],
+            "value_of_time": [1.0],
+            "k_saturation_utility": [1.0],
+            "destination_shadow_price": [-0.5],
+            "min_activity_time": [1.0],
+            "first_seen_iteration": [2],
+            "last_active_iteration": [None],
+            "utility": [5.0],
+        }
+    ).lazy()
+    stay_home_plan = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "country": ["fr"],
+            "csp": ["worker"],
+            "mean_home_night_per_pers": [10.0],
+            "iteration": [0],
+            "activity_seq_id": [0],
+            "time_seq_id": [0],
+            "mode_seq_id": [0],
+            "dest_seq_id": [0],
+            "seq_step_index": [0],
+            "activity": ["home"],
+            "from": [1],
+            "to": [1],
+            "mode": ["stay_home"],
+            "duration_per_pers": [24.0],
+            "departure_time": [0.0],
+            "arrival_time": [0.0],
+            "next_departure_time": [24.0],
+            "utility": [1.0],
+            "n_persons": [1.0],
+        }
+    )
+
+    result = updater.add_stay_home_plan_steps(
+        possible_plan_steps,
+        stay_home_plan,
+        sequence_index_folder=index_folder,
+    ).collect()
+
+    assert "destination_shadow_price" in result.columns
+    stay_home_shadow_price = (
+        result
+        .filter(pl.col("mode_seq_id") == 0)
+        .select("destination_shadow_price")
+        .item()
+    )
+    assert stay_home_shadow_price == 0.0

--- a/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
+++ b/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
@@ -158,6 +158,55 @@ def test_destination_probability_inputs_use_cost_and_sink_even_without_destinati
     assert cost_bin_to_destination.collect().height > 0
 
 
+def test_destination_probability_inputs_use_shadow_attraction_when_enabled(tmp_path):
+    destination_sequences = DestinationSequences(
+        run_key="run",
+        is_weekday=True,
+        iteration=1,
+        base_folder=_make_local_tmp_path(tmp_path, "destination_shadow_inputs"),
+        activities=[],
+        transport_zones=None,
+        destination_saturation=pl.DataFrame(),
+        demand_groups=pl.DataFrame(),
+        costs=pl.DataFrame(),
+        parameters=Parameters(use_destination_shadow_prices=True),
+        seed=123,
+        resolved_activity_parameters={},
+        current_plans=pl.DataFrame(),
+    )
+    opportunities = pl.DataFrame(
+        {
+            "to": [10, 20],
+            "activity": ["work", "work"],
+            "opportunity_capacity": [100.0, 100.0],
+            "k_saturation_utility": [1.0, 1.0],
+            "destination_sampling_attraction_factor": [1.0, 0.5],
+        }
+    ).with_columns(activity=pl.col("activity").cast(pl.Enum(["work"])))
+    costs = pl.DataFrame(
+        {
+            "from": [1, 1],
+            "to": [10, 20],
+            "cost": [3.0, 3.0],
+        }
+    )
+
+    _, cost_bin_to_destination = destination_sequences._get_destination_probability_inputs(
+        opportunities=opportunities,
+        costs=costs,
+        cost_uncertainty_sd=1.0,
+    )
+
+    probabilities = (
+        cost_bin_to_destination
+        .group_by("to")
+        .agg(p_to=pl.col("p_to").mean())
+        .sort("to")
+    ).collect()
+
+    assert probabilities["p_to"].to_list() == [2.0 / 3.0, 1.0 / 3.0]
+
+
 def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candidates(tmp_path):
     destination_sequences = DestinationSequences(
         run_key="run",

--- a/tests/back/unit/domain/group_day_trips/test_014_activity_shadow_price_parameters.py
+++ b/tests/back/unit/domain/group_day_trips/test_014_activity_shadow_price_parameters.py
@@ -1,0 +1,40 @@
+import polars as pl
+import pytest
+
+from mobility.activities.leisure.leisure import LeisureActivity
+from mobility.activities.other import OtherActivity
+from mobility.activities.shopping.shop import ShopActivity
+from mobility.activities.studies.study import StudyActivity
+from mobility.activities.work.work import WorkActivity
+
+
+@pytest.mark.parametrize(
+    "activity_cls",
+    [
+        WorkActivity,
+        StudyActivity,
+        ShopActivity,
+        LeisureActivity,
+        OtherActivity,
+    ],
+)
+def test_non_home_activities_expose_destination_shadow_price_parameters(activity_cls):
+    """Check that users can tune destination shadow prices from activity classes."""
+    opportunities = pl.DataFrame({"to": [1], "n_opp": [1.0]}).to_pandas()
+
+    activity = activity_cls(
+        opportunities=opportunities,
+        destination_soft_capacity_factor=1.5,
+        destination_shadow_price_sensitivity_coefficient=0.7,
+        destination_shadow_price_min_coefficient=-1.2,
+        destination_sampling_overload_gamma=1.8,
+        destination_sampling_min_attraction_factor=0.03,
+    )
+
+    parameters = activity.inputs["parameters"]
+
+    assert parameters.destination_soft_capacity_factor == 1.5
+    assert parameters.destination_shadow_price_sensitivity_coefficient == 0.7
+    assert parameters.destination_shadow_price_min_coefficient == -1.2
+    assert parameters.destination_sampling_overload_gamma == 1.8
+    assert parameters.destination_sampling_min_attraction_factor == 0.03


### PR DESCRIPTION
### Motivation

Destination saturation was previously handled with `k_saturation_utility`, a multiplicative factor applied to the positive activity value.

That made overloaded destinations less attractive, but the penalty was not expressed on the same scale as the rest of plan utility. Travel cost, time, and activity duration are combined as utility terms, while destination overload was applied before that as a factor on activity value.

This PR adds an optional additive destination penalty.

When enabled, an overloaded destination gets a `destination_shadow_price`. This value is added to the activity value term before plan utility is computed. It makes the saturation effect easier to compare with the other parts of utility, and easier to tune: users can control when the penalty starts, how fast it grows, and how low it can go.

The default behavior does not change. The old `k_saturation_utility` behavior is still used unless `use_destination_shadow_prices=True`.

### Changes

This PR adds destination shadow-price parameters to non-home activities:

- `destination_soft_capacity_factor`: defines when a destination starts to be penalized. A value of `1.0` starts the penalty when occupation reaches capacity. A value of `1.25` allows occupation up to 125% of capacity before the penalty starts.
- `destination_shadow_price_sensitivity_coefficient`: controls how fast the utility penalty grows after the destination is above its soft capacity. Higher values make overloaded destinations lose utility faster.
- `destination_shadow_price_min_coefficient`: sets the maximum penalty that can be applied. It is expressed as a negative multiple of the activity value of time, so `-2.0` means the shadow price cannot go below `-2 * value_of_time`.
- `destination_sampling_overload_gamma`: controls how fast overloaded destinations become less likely to be sampled as destination candidates. Higher values reduce sampling probability faster when overload increases.
- `destination_sampling_min_attraction_factor`: sets the minimum sampling attractiveness for an overloaded destination. This avoids fully removing a destination from sampling only because it is overloaded.

It also adds this group-day-trip parameter:

- `use_destination_shadow_prices`: enables the new additive destination penalty. When this is `False`, the model keeps using the old `k_saturation_utility` behavior.

Before this PR:

- destination saturation only produced `k_saturation_utility`;
- plan utility used `k_saturation_utility * value_of_time`;
- destination sampling used `k_saturation_utility` to reduce overloaded destinations.

After this PR:

- destination saturation also computes:
  - `opportunity_occupation`
  - `capacity_ratio`
  - `destination_shadow_price`
  - `destination_sampling_attraction_factor`
- when `use_destination_shadow_prices=False`, plan utility keeps the old behavior;
- when `use_destination_shadow_prices=True`, plan utility uses an additive destination penalty;
- destination sampling can use `destination_sampling_attraction_factor` instead of `k_saturation_utility`.

The PR also keeps compatibility with older/simple destination saturation tables by filling missing shadow-price columns with neutral defaults.

Tests were added or updated for:

- activity-level shadow-price parameters;
- shadow-price computation above soft capacity;
- opt-in use of shadow prices in plan-step utility;
- destination sampling using shadow-price attraction factors;
- existing country value coefficient behavior.

### Example

```python
trips = mobility.PopulationGroupDayTrips(
    population=population,
    transport_costs=transport_costs,
    activities=[
        mobility.WorkActivity(
            destination_soft_capacity_factor=1.25,
            destination_shadow_price_sensitivity_coefficient=0.7,
            destination_shadow_price_min_coefficient=-1.5,
        ),
        mobility.ShopActivity(),
        mobility.LeisureActivity(),
    ],
    use_destination_shadow_prices=True,
)
```

With the default settings, existing simulations keep using the old saturation utility.

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: helped split this change from the larger dump branch, clean the implementation, and add focused tests.
- What you reviewed or changed: reviewed the activity parameters, destination saturation calculation, plan-step utility, destination sampling inputs, and test coverage.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/domain/group_day_trips`, which passed with 76 tests.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior