### PR TITLE
Add plan transition stability controls

### DIFF
--- a/mobility/trips/group_day_trips/core/parameters.py
+++ b/mobility/trips/group_day_trips/core/parameters.py
@@ -395,6 +395,49 @@ class Parameters(BaseModel):
         ),
     ]
 
+    min_transition_utility_gain: Annotated[
+        float,
+        Field(
+            default=0.0,
+            ge=0.0,
+            title="Minimum transition utility gain",
+            description=(
+                "Minimum utility gain needed before a person can switch from "
+                "one plan to another. The current plan is always kept. Set this "
+                "above zero to avoid switching between almost equal plans."
+            ),
+        ),
+    ]
+
+    plan_probability_pruning_retained_share: Annotated[
+        float,
+        Field(
+            default=1.0,
+            gt=0.0,
+            le=1.0,
+            title="Current-plan retained probability share",
+            description=(
+                "Share of transition mass kept as separate target plans for "
+                "each demand group. Lower-mass target plans are merged into "
+                "the largest retained target plan of the same stay-home or "
+                "mobile type. Set to 1.0 to keep all target plans."
+            ),
+        ),
+    ]
+
+    plan_probability_pruning_min_iteration: Annotated[
+        int,
+        Field(
+            default=2,
+            ge=1,
+            title="Current-plan probability pruning start iteration",
+            description=(
+                "First iteration where low-probability target plans may be "
+                "merged when plan_probability_pruning_retained_share is below 1.0."
+            ),
+        ),
+    ]
+
     transition_distance_friction: Annotated[
         float,
         Field(

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -120,6 +120,7 @@ class PlanUpdater:
             transition_revision_probability=parameters.transition_revision_probability,
             transition_logit_scale=parameters.transition_logit_scale,
             transition_utility_pruning_delta=parameters.transition_utility_pruning_delta,
+            min_transition_utility_gain=parameters.min_transition_utility_gain,
             transition_distance_friction=parameters.transition_distance_friction,
             plan_embedding_dimension_weights=parameters.plan_embedding_dimension_weights,
         )
@@ -131,6 +132,8 @@ class PlanUpdater:
             current_plans,
             transition_prob,
             iteration,
+            plan_probability_pruning_retained_share=parameters.plan_probability_pruning_retained_share,
+            plan_probability_pruning_min_iteration=parameters.plan_probability_pruning_min_iteration,
         )
         log_memory_checkpoint(
             f"plan_updater:iteration:{iteration}:after_apply_transitions",
@@ -486,6 +489,7 @@ class PlanUpdater:
         transition_revision_probability: float = 1.0,
         transition_logit_scale: float = 1.0,
         transition_utility_pruning_delta: float = 3.0,
+        min_transition_utility_gain: float = 0.0,
         transition_distance_friction: float = 0.0,
         plan_embedding_dimension_weights: list[float] | None = None,
     ) -> pl.DataFrame:
@@ -497,6 +501,7 @@ class PlanUpdater:
             behavior_change_scope,
             transition_utility_pruning_delta=transition_utility_pruning_delta,
             transition_logit_scale=transition_logit_scale,
+            min_transition_utility_gain=min_transition_utility_gain,
         )
         log_memory_checkpoint(
             "plan_updater:allowed_transitions",
@@ -543,6 +548,7 @@ class PlanUpdater:
         *,
         transition_utility_pruning_delta: float = 3.0,
         transition_logit_scale: float = 1.0,
+        min_transition_utility_gain: float = 0.0,
     ) -> pl.LazyFrame:
         """Build allowed from-to plan pairs under the active behavior scope."""
 
@@ -567,15 +573,20 @@ class PlanUpdater:
 
         scope_pair_constraint = pl.lit(True)
         if behavior_change_scope == BehaviorChangeScope.DESTINATION_REPLANNING:
-            scope_pair_constraint = pl.col("time_seq_id") == pl.col("time_seq_id_trans")
+            scope_pair_constraint = (
+                (pl.col("activity_seq_id") == pl.col("activity_seq_id_trans"))
+                & (pl.col("time_seq_id") == pl.col("time_seq_id_trans"))
+            )
         elif behavior_change_scope == BehaviorChangeScope.MODE_REPLANNING:
             scope_pair_constraint = (
-                (pl.col("time_seq_id") == pl.col("time_seq_id_trans"))
+                (pl.col("activity_seq_id") == pl.col("activity_seq_id_trans"))
+                & (pl.col("time_seq_id") == pl.col("time_seq_id_trans"))
                 & (pl.col("dest_seq_id") == pl.col("dest_seq_id_trans"))
             )
 
         is_self_transition = (
-            (pl.col("time_seq_id") == pl.col("time_seq_id_trans"))
+            (pl.col("activity_seq_id") == pl.col("activity_seq_id_trans"))
+            & (pl.col("time_seq_id") == pl.col("time_seq_id_trans"))
             & (pl.col("dest_seq_id") == pl.col("dest_seq_id_trans"))
             & (pl.col("mode_seq_id") == pl.col("mode_seq_id_trans"))
         )
@@ -586,6 +597,10 @@ class PlanUpdater:
                 is_self_transition
                 | (pl.col("utility_trans") >= pl.col("max_utility_trans") - utility_pruning_delta)
             )
+        gain_filter = (
+            is_self_transition
+            | (pl.col("utility_trans") >= pl.col("utility") + min_transition_utility_gain)
+        )
 
         return (
             current_plans_for_transitions
@@ -606,7 +621,7 @@ class PlanUpdater:
             .with_columns(
                 max_utility_trans=pl.col("utility_trans").max().over(plan_cols),
             )
-            .filter(utility_filter)
+            .filter(utility_filter & gain_filter)
             .drop(["max_utility_trans"])
         )
 
@@ -745,6 +760,9 @@ class PlanUpdater:
         current_plans: pl.DataFrame,
         transition_probabilities: pl.DataFrame,
         iteration: int,
+        *,
+        plan_probability_pruning_retained_share: float = 1.0,
+        plan_probability_pruning_min_iteration: int = 2,
     ) -> tuple[pl.DataFrame, pl.LazyFrame]:
         """Apply transition probabilities and emit transition events."""
 
@@ -767,25 +785,13 @@ class PlanUpdater:
             .with_columns(n_persons_moved=pl.col("n_persons") * pl.col("p_transition"))
         )
 
-        prev_to_lookup = (
-            current_plans.lazy()
-            .select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id", "utility"])
-            .rename(
-                {
-                    "activity_seq_id": "activity_seq_id_trans",
-                    "time_seq_id": "time_seq_id_trans",
-                    "dest_seq_id": "dest_seq_id_trans",
-                    "mode_seq_id": "mode_seq_id_trans",
-                    "utility": "utility_prev_to",
-                }
-            )
+        transitions = self.remap_low_probability_transition_targets(
+            transitions,
+            retained_share=plan_probability_pruning_retained_share,
+            min_iteration=plan_probability_pruning_min_iteration,
+            iteration=iteration,
         )
-
-        transitions = transitions.join(
-            prev_to_lookup,
-            on=["demand_group_id", "activity_seq_id_trans", "time_seq_id_trans", "dest_seq_id_trans", "mode_seq_id_trans"],
-            how="left",
-        )
+        transitions = self.attach_previous_target_utility(current_plans, transitions)
 
         transition_events = build_transition_events_lazy(
             transitions,
@@ -813,6 +819,219 @@ class PlanUpdater:
         )
 
         return new_states, transition_events
+
+    def remap_low_probability_transition_targets(
+        self,
+        transitions: pl.LazyFrame,
+        *,
+        retained_share: float,
+        min_iteration: int,
+        iteration: int,
+    ) -> pl.LazyFrame:
+        """Merge low-mass target plans into the largest retained plan per demand group."""
+        if retained_share >= 1.0 or iteration < min_iteration:
+            return transitions
+
+        target_map = self.build_low_probability_target_map(
+            transitions,
+            retained_share=retained_share,
+        )
+        if target_map is None:
+            return transitions
+
+        raw_plan_count = int(target_map["raw_plan_count"][0])
+        retained_plan_count = int(target_map["retained_plan_count"][0])
+        dropped_person_share = float(target_map["dropped_person_share"][0])
+        logging.info(
+            "Low-probability current-plan pruning check: iteration=%s retained_share=%s target_plans=%s retained_plans=%s dropped_person_share=%s",
+            str(iteration),
+            str(retained_share),
+            str(raw_plan_count),
+            str(retained_plan_count),
+            str(round(dropped_person_share, 6)),
+        )
+        if retained_plan_count == raw_plan_count:
+            return transitions
+
+        mapping = target_map.drop(["raw_plan_count", "retained_plan_count", "dropped_person_share"])
+        return (
+            transitions
+            .join(mapping.lazy(), on="plan_id_trans", how="left")
+            .with_columns(
+                plan_id_trans=pl.coalesce([pl.col("plan_id_trans_final"), pl.col("plan_id_trans")]),
+                activity_seq_id_trans=pl.coalesce(
+                    [pl.col("activity_seq_id_trans_final"), pl.col("activity_seq_id_trans")]
+                ),
+                time_seq_id_trans=pl.coalesce([pl.col("time_seq_id_trans_final"), pl.col("time_seq_id_trans")]),
+                dest_seq_id_trans=pl.coalesce([pl.col("dest_seq_id_trans_final"), pl.col("dest_seq_id_trans")]),
+                mode_seq_id_trans=pl.coalesce([pl.col("mode_seq_id_trans_final"), pl.col("mode_seq_id_trans")]),
+                utility_trans=pl.coalesce([pl.col("utility_trans_final"), pl.col("utility_trans")]),
+            )
+            .drop(
+                [
+                    "plan_id_trans_final",
+                    "activity_seq_id_trans_final",
+                    "time_seq_id_trans_final",
+                    "dest_seq_id_trans_final",
+                    "mode_seq_id_trans_final",
+                    "utility_trans_final",
+                ]
+            )
+        )
+
+    def build_low_probability_target_map(
+        self,
+        transitions: pl.LazyFrame,
+        *,
+        retained_share: float,
+    ) -> pl.DataFrame | None:
+        """Build a raw-target to retained-target map from transition mass."""
+        target_cols = [
+            "plan_id_trans",
+            "demand_group_id",
+            "activity_seq_id_trans",
+            "time_seq_id_trans",
+            "dest_seq_id_trans",
+            "mode_seq_id_trans",
+            "utility_trans",
+        ]
+        target_states = (
+            transitions
+            .group_by(target_cols)
+            .agg(n_persons=pl.col("n_persons_moved").sum())
+            .with_columns(is_stay_home_target=pl.col("mode_seq_id_trans") == 0)
+            .collect(engine="streaming")
+        )
+        if target_states.height == 0:
+            return None
+
+        ranked = (
+            target_states
+            .sort(
+                [
+                    "demand_group_id",
+                    "is_stay_home_target",
+                    "n_persons",
+                    "activity_seq_id_trans",
+                    "time_seq_id_trans",
+                    "dest_seq_id_trans",
+                    "mode_seq_id_trans",
+                ],
+                descending=[False, False, True, False, False, False, False],
+            )
+            .with_columns(
+                group_n_persons=pl.col("n_persons").sum().over(["demand_group_id", "is_stay_home_target"]),
+                cumulative_n_persons=pl.col("n_persons").cum_sum().over(["demand_group_id", "is_stay_home_target"]),
+                group_rank=pl.col("n_persons").cum_count().over(["demand_group_id", "is_stay_home_target"]),
+            )
+            .with_columns(
+                previous_cumulative_share=(
+                    (pl.col("cumulative_n_persons") - pl.col("n_persons"))
+                    / pl.col("group_n_persons").clip(1e-12)
+                )
+            )
+            .with_columns(
+                is_retained=(pl.col("group_rank") == 1) | (pl.col("previous_cumulative_share") < retained_share)
+            )
+        )
+        fallback_targets = (
+            ranked
+            .filter(pl.col("is_retained"))
+            .filter(
+                pl.col("group_rank")
+                == pl.col("group_rank").min().over(["demand_group_id", "is_stay_home_target"])
+            )
+            .select(
+                [
+                    "demand_group_id",
+                    "is_stay_home_target",
+                    pl.col("plan_id_trans").alias("fallback_plan_id_trans"),
+                    pl.col("activity_seq_id_trans").alias("fallback_activity_seq_id_trans"),
+                    pl.col("time_seq_id_trans").alias("fallback_time_seq_id_trans"),
+                    pl.col("dest_seq_id_trans").alias("fallback_dest_seq_id_trans"),
+                    pl.col("mode_seq_id_trans").alias("fallback_mode_seq_id_trans"),
+                    pl.col("utility_trans").alias("fallback_utility_trans"),
+                ]
+            )
+        )
+        mapping = (
+            ranked
+            .join(fallback_targets, on=["demand_group_id", "is_stay_home_target"], how="left")
+            .with_columns(
+                plan_id_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("plan_id_trans"))
+                .otherwise(pl.col("fallback_plan_id_trans")),
+                activity_seq_id_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("activity_seq_id_trans"))
+                .otherwise(pl.col("fallback_activity_seq_id_trans")),
+                time_seq_id_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("time_seq_id_trans"))
+                .otherwise(pl.col("fallback_time_seq_id_trans")),
+                dest_seq_id_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("dest_seq_id_trans"))
+                .otherwise(pl.col("fallback_dest_seq_id_trans")),
+                mode_seq_id_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("mode_seq_id_trans"))
+                .otherwise(pl.col("fallback_mode_seq_id_trans")),
+                utility_trans_final=pl.when(pl.col("is_retained"))
+                .then(pl.col("utility_trans"))
+                .otherwise(pl.col("fallback_utility_trans")),
+            )
+        )
+
+        raw_plan_count = target_states.height
+        retained_plan_count = mapping.filter(pl.col("is_retained")).height
+
+        dropped_persons = mapping.filter(~pl.col("is_retained")).select(pl.col("n_persons").sum()).item()
+        total_persons = mapping.select(pl.col("n_persons").sum()).item()
+
+        return mapping.select(
+            [
+                "plan_id_trans",
+                "plan_id_trans_final",
+                "activity_seq_id_trans_final",
+                "time_seq_id_trans_final",
+                "dest_seq_id_trans_final",
+                "mode_seq_id_trans_final",
+                "utility_trans_final",
+                pl.lit(raw_plan_count, dtype=pl.UInt32).alias("raw_plan_count"),
+                pl.lit(retained_plan_count, dtype=pl.UInt32).alias("retained_plan_count"),
+                pl.lit(float(dropped_persons) / max(float(total_persons), 1e-12)).alias("dropped_person_share"),
+            ]
+        )
+
+    def attach_previous_target_utility(
+        self,
+        current_plans: pl.DataFrame,
+        transitions: pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Attach previous utility for the final transition target state."""
+        prev_to_lookup = (
+            current_plans.lazy()
+            .select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id", "utility"])
+            .rename(
+                {
+                    "activity_seq_id": "activity_seq_id_trans",
+                    "time_seq_id": "time_seq_id_trans",
+                    "dest_seq_id": "dest_seq_id_trans",
+                    "mode_seq_id": "mode_seq_id_trans",
+                    "utility": "utility_prev_to",
+                }
+            )
+        )
+
+        return transitions.join(
+            prev_to_lookup,
+            on=[
+                "demand_group_id",
+                "activity_seq_id_trans",
+                "time_seq_id_trans",
+                "dest_seq_id_trans",
+                "mode_seq_id_trans",
+            ],
+            how="left",
+        )
+
     def get_current_plan_steps(self, current_plans, possible_plan_steps):
         """Expand aggregate plans to per-step rows."""
 

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -555,6 +555,7 @@ def test_get_transition_probabilities_limits_destination_replanning_to_same_timi
     )
 
     assert result.select("time_seq_id_trans").unique().to_series().to_list() == [0]
+    assert result.select("activity_seq_id_trans").unique().to_series().to_list() == [10]
 
 
 def test_get_transition_probabilities_filters_candidates_by_distance_threshold(tmp_path):
@@ -723,45 +724,45 @@ def test_get_transition_probabilities_scales_pruning_window_with_transition_logi
             "activity_seq_id": [10],
             "dest_seq_id": [100],
             "mode_seq_id": [1000],
-            "utility": [10.0],
+            "utility": [4.0],
             "n_persons": [5.0],
         }
     )
     possible_plan_utility = _make_possible_plan_utility(
         {
-            "demand_group_id": [1, 1],
-            "activity_seq_id": [10, 10],
-            "dest_seq_id": [100, 101],
-            "mode_seq_id": [1000, 1001],
-            "utility": [10.0, 4.0],
+            "demand_group_id": [1, 1, 1],
+            "activity_seq_id": [10, 10, 10],
+            "dest_seq_id": [100, 101, 102],
+            "mode_seq_id": [1000, 1001, 1002],
+            "utility": [4.0, 4.0, 10.0],
         }
     )
 
     possible_plan_steps = _make_possible_plan_steps(
         {
-            "demand_group_id": [1, 1],
-            "activity_seq_id": [10, 10],
-            "dest_seq_id": [100, 101],
-            "mode_seq_id": [1000, 1001],
-            "seq_step_index": [0, 0],
-            "activity": ["work", "work"],
-            "from": [1, 1],
-            "to": [2, 3],
-            "mode": ["car", "bike"],
-            "duration_per_pers": [8.0, 8.0],
-            "departure_time": [8.0, 8.0],
-            "arrival_time": [9.0, 9.0],
-            "next_departure_time": [17.0, 17.0],
-            "iteration": [1, 1],
-            "csp": ["x", "x"],
-            "cost": [1.0, 1.0],
-            "distance": [10.0, 12.0],
-            "time": [1.0, 1.0],
-            "mean_duration_per_pers": [8.0, 8.0],
-            "value_of_time": [1.0, 1.0],
-            "k_saturation_utility": [1.0, 1.0],
-            "min_activity_time": [1.0, 1.0],
-            "utility": [10.0, 4.0],
+            "demand_group_id": [1, 1, 1],
+            "activity_seq_id": [10, 10, 10],
+            "dest_seq_id": [100, 101, 102],
+            "mode_seq_id": [1000, 1001, 1002],
+            "seq_step_index": [0, 0, 0],
+            "activity": ["work", "work", "work"],
+            "from": [1, 1, 1],
+            "to": [2, 3, 4],
+            "mode": ["car", "bike", "walk"],
+            "duration_per_pers": [8.0, 8.0, 8.0],
+            "departure_time": [8.0, 8.0, 8.0],
+            "arrival_time": [9.0, 9.0, 9.0],
+            "next_departure_time": [17.0, 17.0, 17.0],
+            "iteration": [1, 1, 1],
+            "csp": ["x", "x", "x"],
+            "cost": [1.0, 1.0, 1.0],
+            "distance": [10.0, 12.0, 8.0],
+            "time": [1.0, 1.0, 1.0],
+            "mean_duration_per_pers": [8.0, 8.0, 8.0],
+            "value_of_time": [1.0, 1.0, 1.0],
+            "k_saturation_utility": [1.0, 1.0, 1.0],
+            "min_activity_time": [1.0, 1.0, 1.0],
+            "utility": [4.0, 4.0, 10.0],
         }
     )
 
@@ -797,8 +798,94 @@ def test_get_transition_probabilities_scales_pruning_window_with_transition_logi
         transition_logit_scale=0.25,
     )
 
-    assert result_default["mode_seq_id_trans"].to_list() == [1000]
-    assert result_scaled["mode_seq_id_trans"].sort().to_list() == [1000, 1001]
+    assert result_default["mode_seq_id_trans"].sort().to_list() == [1000, 1002]
+    assert result_scaled["mode_seq_id_trans"].sort().to_list() == [1000, 1001, 1002]
+
+
+def test_get_transition_probabilities_filters_non_self_by_minimum_utility_gain(tmp_path):
+    updater = PlanUpdater()
+    current_plans = _make_current_plans(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [10],
+            "dest_seq_id": [100],
+            "mode_seq_id": [1000],
+            "utility": [10.0],
+            "n_persons": [5.0],
+        }
+    )
+    possible_plan_utility = _make_possible_plan_utility(
+        {
+            "demand_group_id": [1, 1, 1, 1, 1],
+            "activity_seq_id": [10, 10, 10, 10, 10],
+            "dest_seq_id": [100, 101, 102, 103, 104],
+            "mode_seq_id": [1000, 1001, 1002, 1003, 1004],
+            "utility": [10.0, 9.9, 10.0, 10.05, 10.2],
+        }
+    )
+    possible_plan_steps = _make_possible_plan_steps(
+        {
+            "demand_group_id": [1, 1, 1, 1, 1],
+            "activity_seq_id": [10, 10, 10, 10, 10],
+            "dest_seq_id": [100, 101, 102, 103, 104],
+            "mode_seq_id": [1000, 1001, 1002, 1003, 1004],
+            "seq_step_index": [0, 0, 0, 0, 0],
+            "activity": ["work", "work", "work", "work", "work"],
+            "from": [1, 1, 1, 1, 1],
+            "to": [2, 3, 4, 5, 6],
+            "mode": ["car", "bike", "walk", "car", "bike"],
+            "duration_per_pers": [8.0, 8.0, 8.0, 8.0, 8.0],
+            "departure_time": [8.0, 8.0, 8.0, 8.0, 8.0],
+            "arrival_time": [9.0, 9.0, 9.0, 9.0, 9.0],
+            "next_departure_time": [17.0, 17.0, 17.0, 17.0, 17.0],
+            "iteration": [1, 1, 1, 1, 1],
+            "csp": ["x", "x", "x", "x", "x"],
+            "cost": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "distance": [10.0, 12.0, 8.0, 11.0, 9.0],
+            "time": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "mean_duration_per_pers": [8.0, 8.0, 8.0, 8.0, 8.0],
+            "value_of_time": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "k_saturation_utility": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "min_activity_time": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "utility": [10.0, 9.9, 10.0, 10.05, 10.2],
+        }
+    )
+
+    result_default = updater.get_transition_probabilities(
+        current_plans=current_plans,
+        possible_plan_utility=_with_plan_id(
+            possible_plan_utility,
+            tmp_path=tmp_path,
+            name="transition_probabilities_min_gain_default_utility",
+        ),
+        possible_plan_steps=_with_plan_id(
+            possible_plan_steps,
+            tmp_path=tmp_path,
+            name="transition_probabilities_min_gain_default_steps",
+        ),
+        behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
+        transport_zones=None,
+    )
+    result_with_gain = updater.get_transition_probabilities(
+        current_plans=current_plans,
+        possible_plan_utility=_with_plan_id(
+            possible_plan_utility,
+            tmp_path=tmp_path,
+            name="transition_probabilities_min_gain_threshold_utility",
+        ),
+        possible_plan_steps=_with_plan_id(
+            possible_plan_steps,
+            tmp_path=tmp_path,
+            name="transition_probabilities_min_gain_threshold_steps",
+        ),
+        behavior_change_scope=BehaviorChangeScope.FULL_REPLANNING,
+        transport_zones=None,
+        min_transition_utility_gain=0.1,
+    )
+
+    assert result_default["mode_seq_id_trans"].sort().to_list() == [1000, 1002, 1003, 1004]
+    assert result_with_gain["mode_seq_id_trans"].sort().to_list() == [1000, 1004]
+    assert abs(float(result_with_gain["p_transition"].sum()) - 1.0) < 1e-9
 
 
 def test_get_transition_probabilities_transition_distance_friction_penalizes_far_states(tmp_path):
@@ -883,3 +970,215 @@ def test_get_transition_probabilities_transition_distance_friction_penalizes_far
 
     assert float(q_near) > float(q_far)
     assert float(tau_far) > 0.0
+
+
+def test_apply_transitions_prunes_low_probability_targets_consistently(tmp_path):
+    updater = PlanUpdater()
+    plan_keys = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 1, 1],
+            "activity_seq_id": [10, 11, 12, 13],
+            "time_seq_id": [100, 101, 102, 103],
+            "dest_seq_id": [1000, 1001, 1002, 1003],
+            "mode_seq_id": [10000, 10001, 10002, 10003],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+        },
+    )
+    plan_keys = _with_plan_id(
+        plan_keys,
+        tmp_path=tmp_path,
+        name="apply_transitions_probability_pruning_plan_ids",
+    )
+    current_plans = plan_keys.head(1).with_columns(
+        utility=pl.lit(1.0),
+        n_persons=pl.lit(100.0),
+    )
+    from_state = current_plans.row(0, named=True)
+    targets = plan_keys.with_columns(
+        utility_trans=pl.Series([1.0, 2.0, 3.0, 4.0]),
+        p_transition=pl.Series([0.90, 0.09, 0.009, 0.001]),
+    )
+    transition_probabilities = targets.select(
+        [
+            pl.col("plan_id").alias("plan_id_trans"),
+            pl.lit(from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
+            pl.lit(from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
+            pl.lit(from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),
+            pl.lit(from_state["mode_seq_id"], dtype=pl.UInt32).alias("mode_seq_id"),
+            pl.col("activity_seq_id").alias("activity_seq_id_trans"),
+            pl.col("time_seq_id").alias("time_seq_id_trans"),
+            pl.col("dest_seq_id").alias("dest_seq_id_trans"),
+            pl.col("mode_seq_id").alias("mode_seq_id_trans"),
+            pl.lit(1.0).alias("utility_prev_from"),
+            pl.lit(1.0).alias("utility_from_updated"),
+            "utility_trans",
+            pl.lit(0.0).alias("tau_transition"),
+            pl.col("p_transition").alias("q_transition"),
+            pl.lit(1.0).alias("adjustment_factor"),
+            "p_transition",
+        ]
+    )
+
+    current_plans_after, transition_events = updater.apply_transitions(
+        current_plans,
+        transition_probabilities,
+        iteration=2,
+        plan_probability_pruning_retained_share=0.99,
+        plan_probability_pruning_min_iteration=2,
+    )
+    transition_events = transition_events.collect()
+
+    assert current_plans_after.select(pl.col("n_persons").sum()).item() == pytest.approx(100.0)
+    assert current_plans_after.height == 2
+    assert current_plans_after["n_persons"].sort(descending=True).to_list() == pytest.approx([91.0, 9.0])
+    assert set(current_plans_after["activity_seq_id"].to_list()) == {10, 11}
+
+    event_targets = (
+        transition_events
+        .group_by(["activity_seq_id_trans", "time_seq_id_trans", "dest_seq_id_trans", "mode_seq_id_trans"])
+        .agg(n_persons=pl.col("n_persons_moved").sum())
+        .sort("n_persons", descending=True)
+    )
+    assert event_targets["n_persons"].to_list() == pytest.approx([91.0, 9.0])
+    assert set(event_targets["activity_seq_id_trans"].to_list()) == {10, 11}
+
+
+def test_apply_transitions_probability_pruning_does_not_merge_mobile_targets_into_stay_home(tmp_path):
+    updater = PlanUpdater()
+    plan_keys = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 1, 1],
+            "activity_seq_id": [0, 10, 11, 12],
+            "time_seq_id": [0, 100, 101, 102],
+            "dest_seq_id": [0, 1000, 1001, 1002],
+            "mode_seq_id": [0, 10000, 10001, 10002],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+        },
+    )
+    plan_keys = _with_plan_id(
+        plan_keys,
+        tmp_path=tmp_path,
+        name="apply_transitions_probability_pruning_stay_home_plan_ids",
+    )
+    current_plans = plan_keys.head(2).with_columns(
+        utility=pl.Series([0.0, 10.0]),
+        n_persons=pl.Series([70.0, 30.0]),
+    )
+    mobile_from_state = current_plans.filter(pl.col("mode_seq_id") != 0).row(0, named=True)
+    mobile_targets = plan_keys.filter(pl.col("mode_seq_id") != 0).with_columns(
+        utility_trans=pl.Series([10.0, 11.0, 12.0]),
+        p_transition=pl.Series([20.0 / 30.0, 9.0 / 30.0, 1.0 / 30.0]),
+    )
+    transition_probabilities = mobile_targets.select(
+        [
+            pl.col("plan_id").alias("plan_id_trans"),
+            pl.lit(mobile_from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(mobile_from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
+            pl.lit(mobile_from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
+            pl.lit(mobile_from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),
+            pl.lit(mobile_from_state["mode_seq_id"], dtype=pl.UInt32).alias("mode_seq_id"),
+            pl.col("activity_seq_id").alias("activity_seq_id_trans"),
+            pl.col("time_seq_id").alias("time_seq_id_trans"),
+            pl.col("dest_seq_id").alias("dest_seq_id_trans"),
+            pl.col("mode_seq_id").alias("mode_seq_id_trans"),
+            pl.lit(10.0).alias("utility_prev_from"),
+            pl.lit(10.0).alias("utility_from_updated"),
+            "utility_trans",
+            pl.lit(0.0).alias("tau_transition"),
+            pl.col("p_transition").alias("q_transition"),
+            pl.lit(1.0).alias("adjustment_factor"),
+            "p_transition",
+        ]
+    )
+
+    current_plans_after, transition_events = updater.apply_transitions(
+        current_plans,
+        transition_probabilities,
+        iteration=2,
+        plan_probability_pruning_retained_share=0.95,
+        plan_probability_pruning_min_iteration=2,
+    )
+    transition_events = transition_events.collect()
+
+    stay_home_persons = current_plans_after.filter(pl.col("mode_seq_id") == 0)["n_persons"].sum()
+    mobile_to_stay_home = transition_events.filter(
+        (pl.col("mode_seq_id") != 0) & (pl.col("mode_seq_id_trans") == 0)
+    )
+
+    assert stay_home_persons == pytest.approx(70.0)
+    assert mobile_to_stay_home.is_empty()
+    assert current_plans_after["n_persons"].sort(descending=True).to_list() == pytest.approx([70.0, 21.0, 9.0])
+
+
+def test_apply_transitions_probability_pruning_keeps_default_behavior(tmp_path):
+    updater = PlanUpdater()
+    plan_keys = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1],
+            "activity_seq_id": [10, 11],
+            "time_seq_id": [100, 101],
+            "dest_seq_id": [1000, 1001],
+            "mode_seq_id": [10000, 10001],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+        },
+    )
+    plan_keys = _with_plan_id(
+        plan_keys,
+        tmp_path=tmp_path,
+        name="apply_transitions_probability_pruning_default_plan_ids",
+    )
+    current_plans = plan_keys.head(1).with_columns(utility=pl.lit(1.0), n_persons=pl.lit(10.0))
+    from_state = current_plans.row(0, named=True)
+    transition_probabilities = plan_keys.with_columns(
+        utility_trans=pl.Series([1.0, 2.0]),
+        p_transition=pl.Series([0.8, 0.2]),
+    ).select(
+        [
+            pl.col("plan_id").alias("plan_id_trans"),
+            pl.lit(from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
+            pl.lit(from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
+            pl.lit(from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),
+            pl.lit(from_state["mode_seq_id"], dtype=pl.UInt32).alias("mode_seq_id"),
+            pl.col("activity_seq_id").alias("activity_seq_id_trans"),
+            pl.col("time_seq_id").alias("time_seq_id_trans"),
+            pl.col("dest_seq_id").alias("dest_seq_id_trans"),
+            pl.col("mode_seq_id").alias("mode_seq_id_trans"),
+            pl.lit(1.0).alias("utility_prev_from"),
+            pl.lit(1.0).alias("utility_from_updated"),
+            "utility_trans",
+            pl.lit(0.0).alias("tau_transition"),
+            pl.col("p_transition").alias("q_transition"),
+            pl.lit(1.0).alias("adjustment_factor"),
+            "p_transition",
+        ]
+    )
+
+    current_plans_after, transition_events = updater.apply_transitions(
+        current_plans,
+        transition_probabilities,
+        iteration=2,
+    )
+
+    assert current_plans_after.height == 2
+    assert current_plans_after["n_persons"].sort(descending=True).to_list() == pytest.approx([8.0, 2.0])
+    assert transition_events.collect()["n_persons_moved"].sum() == pytest.approx(10.0)


### PR DESCRIPTION
### Motivation

During day-to-day replanning, small utility differences can create changes between very similar plans.

This PR adds two controls to make plan transitions more stable:

- a minimum utility gain before a person can switch to a different plan;
- an optional way to merge very small target-plan masses after transitions.

This helps keep the number of active plan states under control without changing the default behavior too aggressively.

### Changes

This PR adds three group-day-trip parameters:

- `min_transition_utility_gain`: minimum utility improvement required before a non-self transition is allowed. The current plan is always kept.
- `plan_probability_pruning_retained_share`: share of transition mass to keep as separate target plans for each demand group. Small target plans beyond this share are merged into the largest retained target plan of the same stay-home or mobile type.
- `plan_probability_pruning_min_iteration`: first iteration where target-plan pruning can run.

Before this PR:

- a person could switch to another plan even when the new plan had the same or slightly lower utility, as long as it was inside the transition choice set;
- all target plans created by transition probabilities were kept as separate current plans;
- restricted replanning checked timing and destination constraints, but did not always require the same activity sequence.

After this PR:

- non-self transitions can require a minimum utility gain;
- low-mass target plans can be merged after transitions when pruning is enabled;
- stay-home targets and mobile targets are never merged together;
- restricted destination and mode replanning also keep the same activity sequence;
- default pruning settings keep all target plans.

### Example

```python
trips = mobility.PopulationGroupDayTrips(
    population=population,
    transport_costs=transport_costs,
    min_transition_utility_gain=0.1,
    plan_probability_pruning_retained_share=0.99,
    plan_probability_pruning_min_iteration=2,
)
```

With default settings, all target plans are kept:

```python
plan_probability_pruning_retained_share=1.0
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: helped split this transition-stability change from the larger dump branch, clean the branch boundary, and add focused tests.
- What you reviewed or changed: reviewed transition filtering, target-plan pruning, stay-home/mobile separation, restricted replanning constraints, and defaults.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/domain/group_day_trips`, `mamba run -n mobility python -m pytest --local --use-truststore tests/back/integration/test_008_group_day_trips_can_be_computed.py::test_008_group_day_trips_can_be_computed`, and `py_compile` on the changed files.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior