### PR TITLE
Refresh active destination candidates

### DIFF
--- a/mobility/trips/group_day_trips/core/parameters.py
+++ b/mobility/trips/group_day_trips/core/parameters.py
@@ -158,9 +158,24 @@ class Parameters(BaseModel):
             title="Maximum inactive candidate-plan age",
             description=(
                 "Maximum number of iterations an inactive candidate plan is "
-                "kept in memory after it was last active. Plans that were "
-                "never active use their first-seen iteration as the age "
-                "reference."
+                "kept in memory after it was last active or last regenerated. "
+                "Plans that were never active use their last-seen iteration as "
+                "the age reference."
+            ),
+        ),
+    ]
+
+    refresh_active_mode_alternatives: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Refresh active mode alternatives",
+            description=(
+                "Whether to append currently active destination chains to the "
+                "iteration destination candidates before the top-k mode search. "
+                "This refreshes mode alternatives for occupied plans with "
+                "current travel costs, while behavior-change phases still "
+                "control which transitions are allowed."
             ),
         ),
     ]

--- a/mobility/trips/group_day_trips/plans/candidate_plan_steps.py
+++ b/mobility/trips/group_day_trips/plans/candidate_plan_steps.py
@@ -30,6 +30,7 @@ class CandidatePlanStepsAsset(FileAsset):
 
     RETENTION_COLUMNS = [
         "first_seen_iteration",
+        "last_seen_iteration",
         "last_active_iteration",
     ]
 
@@ -109,6 +110,17 @@ class CandidatePlanStepsAsset(FileAsset):
         )
 
     @classmethod
+    def _with_retention_columns(cls, frame: pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
+        """Add missing candidate-memory columns for older cached files."""
+        candidate_rows = frame.lazy() if isinstance(frame, pl.DataFrame) else frame
+        schema = frame.schema if isinstance(frame, pl.DataFrame) else frame.collect_schema()
+        if "last_seen_iteration" not in schema:
+            candidate_rows = candidate_rows.with_columns(
+                last_seen_iteration=pl.col("first_seen_iteration")
+            )
+        return candidate_rows
+
+    @classmethod
     def build_candidate_memory(
         cls,
         *,
@@ -126,14 +138,15 @@ class CandidatePlanStepsAsset(FileAsset):
 
         candidate_sets = []
         if previous_candidate_plan_steps is not None:
+            previous_candidates = cls._with_retention_columns(previous_candidate_plan_steps)
             candidate_sets.append(
-                previous_candidate_plan_steps.lazy()
+                previous_candidates
                 .filter(pl.col("mode_seq_id") != 0)
                 .select(cls.STRUCTURAL_COLUMNS + cls.RETENTION_COLUMNS)
             )
         if previous_candidate_plan_steps is not None:
             candidate_sets.append(
-                previous_candidate_plan_steps.lazy()
+                previous_candidates
                 .filter(pl.col("mode_seq_id") != 0)
                 .join(
                     current_plans.select(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id"]).lazy(),
@@ -154,6 +167,7 @@ class CandidatePlanStepsAsset(FileAsset):
             )
             .with_columns(
                 first_seen_iteration=pl.lit(current_iteration).cast(pl.UInt16),
+                last_seen_iteration=pl.lit(current_iteration).cast(pl.UInt16),
                 last_active_iteration=pl.lit(None, dtype=pl.UInt16),
             )
             .select(cls.STRUCTURAL_COLUMNS + cls.RETENTION_COLUMNS)
@@ -163,18 +177,19 @@ class CandidatePlanStepsAsset(FileAsset):
             pl.concat(candidate_sets, how="vertical_relaxed")
             .group_by(cls.DEDUPE_COLUMNS)
             .agg(
-                activity=pl.col("activity").first(),
-                from_=pl.col("from").first(),
-                to=pl.col("to").first(),
-                mode=pl.col("mode").first(),
-                duration_per_pers=pl.col("duration_per_pers").first(),
-                departure_time=pl.col("departure_time").first(),
-                arrival_time=pl.col("arrival_time").first(),
-                next_departure_time=pl.col("next_departure_time").first(),
-                iteration=pl.col("iteration").min(),
-                country=pl.col("country").first(),
-                csp=pl.col("csp").first(),
+                activity=pl.col("activity").sort_by("last_seen_iteration").last(),
+                from_=pl.col("from").sort_by("last_seen_iteration").last(),
+                to=pl.col("to").sort_by("last_seen_iteration").last(),
+                mode=pl.col("mode").sort_by("last_seen_iteration").last(),
+                duration_per_pers=pl.col("duration_per_pers").sort_by("last_seen_iteration").last(),
+                departure_time=pl.col("departure_time").sort_by("last_seen_iteration").last(),
+                arrival_time=pl.col("arrival_time").sort_by("last_seen_iteration").last(),
+                next_departure_time=pl.col("next_departure_time").sort_by("last_seen_iteration").last(),
+                iteration=pl.col("iteration").sort_by("last_seen_iteration").last(),
+                country=pl.col("country").sort_by("last_seen_iteration").last(),
+                csp=pl.col("csp").sort_by("last_seen_iteration").last(),
                 first_seen_iteration=pl.col("first_seen_iteration").min(),
+                last_seen_iteration=pl.col("last_seen_iteration").max(),
                 last_active_iteration=pl.col("last_active_iteration").max(),
             )
             .rename({"from_": "from"})
@@ -182,7 +197,11 @@ class CandidatePlanStepsAsset(FileAsset):
         if current_iteration <= n_warmup_iterations:
             return candidate_memory
 
-        age_reference = pl.coalesce([pl.col("last_active_iteration"), pl.col("first_seen_iteration")])
+        age_reference = pl.max_horizontal(
+            pl.col("first_seen_iteration"),
+            pl.col("last_seen_iteration"),
+            pl.col("last_active_iteration").fill_null(0),
+        )
         return candidate_memory.filter(
             (pl.lit(current_iteration, dtype=pl.UInt16) - age_reference) <= max_inactive_age
         )

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -16,6 +16,20 @@ from mobility.runtime.assets.file_asset import FileAsset
 class DestinationSequences(FileAsset):
     """Persist destination sequences produced for one PopulationGroupDayTrips iteration."""
 
+    OUTPUT_COLUMNS = [
+        "demand_group_id",
+        "activity_seq_id",
+        "time_seq_id",
+        "dest_seq_id",
+        "seq_step_index",
+        "from",
+        "to",
+        "departure_time",
+        "arrival_time",
+        "next_departure_time",
+        "iteration",
+    ]
+
     def __init__(
         self,
         *,
@@ -97,10 +111,14 @@ class DestinationSequences(FileAsset):
         scope = self.parameters.get_behavior_change_scope(self.iteration)
 
         if scope == BehaviorChangeScope.FULL_REPLANNING:
-            return self._sample_all_destination_sequences()
+            return self._with_refreshed_active_destination_sequences(
+                self._sample_all_destination_sequences()
+            )
 
         if scope == BehaviorChangeScope.DESTINATION_REPLANNING:
-            return self._sample_active_destination_sequences()
+            return self._with_refreshed_active_destination_sequences(
+                self._sample_active_destination_sequences()
+            )
 
         if scope == BehaviorChangeScope.MODE_REPLANNING:
             return self._reuse_current_destination_sequences()
@@ -193,6 +211,38 @@ class DestinationSequences(FileAsset):
             )
 
         return reused
+
+    def _with_refreshed_active_destination_sequences(self, sampled_sequences: pl.DataFrame) -> pl.DataFrame:
+        """Append active destination chains when active-mode refresh is enabled."""
+        if not self.parameters.refresh_active_mode_alternatives:
+            return sampled_sequences
+
+        active_sequences = self._reuse_current_destination_sequences()
+        if active_sequences.height == 0:
+            return sampled_sequences.select(self.OUTPUT_COLUMNS)
+        if sampled_sequences.height == 0:
+            return active_sequences.select(self.OUTPUT_COLUMNS)
+
+        return (
+            pl.concat(
+                [
+                    active_sequences.select(self.OUTPUT_COLUMNS),
+                    sampled_sequences.select(self.OUTPUT_COLUMNS),
+                ],
+                how="vertical_relaxed",
+            )
+            .unique(
+                subset=[
+                    "demand_group_id",
+                    "activity_seq_id",
+                    "time_seq_id",
+                    "dest_seq_id",
+                    "seq_step_index",
+                ],
+                keep="first",
+                maintain_order=True,
+            )
+        )
 
     def _get_active_non_stay_home_plans(self) -> pl.DataFrame:
         """Return the distinct currently active non-stay-home plans."""
@@ -323,7 +373,7 @@ class DestinationSequences(FileAsset):
             source_activity_sequences=source_activity_sequences,
             destination_sequences=destination_sequences,
         )
-        return destination_sequences
+        return destination_sequences.select(self.OUTPUT_COLUMNS)
 
     def _get_destination_probability_inputs(
         self,

--- a/mobility/trips/group_day_trips/plans/plan_initializer.py
+++ b/mobility/trips/group_day_trips/plans/plan_initializer.py
@@ -373,6 +373,15 @@ class PlanInitializer:
                     activity.get_opportunities(transport_zones).with_columns(
                         activity=pl.lit(activity.name),
                         sink_saturation_coeff=pl.lit(activity.inputs["parameters"].sink_saturation_coeff),
+                        destination_soft_capacity_factor=pl.lit(
+                            activity.inputs["parameters"].destination_soft_capacity_factor
+                        ),
+                        destination_sampling_overload_gamma=pl.lit(
+                            activity.inputs["parameters"].destination_sampling_overload_gamma
+                        ),
+                        destination_sampling_min_attraction_factor=pl.lit(
+                            activity.inputs["parameters"].destination_sampling_min_attraction_factor
+                        ),
                     )
                     for activity in activities
                     if activity.has_opportunities is True
@@ -390,9 +399,27 @@ class PlanInitializer:
                     * pl.col("duration")
                     * pl.col("sink_saturation_coeff")
                 ),
+                opportunity_occupation=pl.lit(0.0, dtype=pl.Float64()),
+                capacity_ratio=pl.lit(0.0, dtype=pl.Float64()),
                 k_saturation_utility=pl.lit(1.0, dtype=pl.Float64()),
+                destination_shadow_price=pl.lit(0.0, dtype=pl.Float64()),
+                destination_sampling_attraction_factor=pl.lit(1.0, dtype=pl.Float64()),
             )
-            .select(["to", "activity", "opportunity_capacity", "k_saturation_utility"])
+            .select(
+                [
+                    "to",
+                    "activity",
+                    "opportunity_capacity",
+                    "opportunity_occupation",
+                    "capacity_ratio",
+                    "destination_soft_capacity_factor",
+                    "destination_sampling_overload_gamma",
+                    "destination_sampling_min_attraction_factor",
+                    "k_saturation_utility",
+                    "destination_shadow_price",
+                    "destination_sampling_attraction_factor",
+                ]
+            )
         )
 
         return opportunities

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -250,6 +250,7 @@ class PlanUpdater:
     ) -> pl.LazyFrame:
         """Score plan-step candidates under current costs and destination saturation."""
 
+        candidates = CandidatePlanStepsAsset._with_retention_columns(candidates)
         cost_by_od_and_modes = transport_costs.get_costs_by_od_and_mode(
             ["cost", "distance", "time"],
             detail_distances=False,
@@ -314,6 +315,7 @@ class PlanUpdater:
             "iteration",
             "csp",
             "first_seen_iteration",
+            "last_seen_iteration",
             "last_active_iteration",
             "cost",
             "distance",
@@ -466,6 +468,7 @@ class PlanUpdater:
                 destination_shadow_price=pl.lit(0.0),
                 min_activity_time=pl.lit(0.0),
                 first_seen_iteration=pl.lit(None, dtype=pl.UInt16),
+                last_seen_iteration=pl.lit(None, dtype=pl.UInt16),
                 last_active_iteration=pl.lit(None, dtype=pl.UInt16),
             )
             .select(step_columns)

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -15,6 +15,7 @@ def _make_possible_plan_steps(rows: dict[str, list]) -> pl.DataFrame:
         "country": rows.get("country", ["fr"] * len(rows["demand_group_id"])),
         "time_seq_id": rows.get("time_seq_id", [0] * len(rows["demand_group_id"])),
         "first_seen_iteration": rows.get("first_seen_iteration", [None] * len(rows["demand_group_id"])),
+        "last_seen_iteration": rows.get("last_seen_iteration", [None] * len(rows["demand_group_id"])),
         "last_active_iteration": rows.get("last_active_iteration", [None] * len(rows["demand_group_id"])),
         **rows,
     }
@@ -39,6 +40,7 @@ def _make_possible_plan_steps(rows: dict[str, list]) -> pl.DataFrame:
             "iteration": pl.UInt32,
             "csp": pl.Utf8,
             "first_seen_iteration": pl.UInt32,
+            "last_seen_iteration": pl.UInt32,
             "last_active_iteration": pl.UInt32,
             "cost": pl.Float64,
             "distance": pl.Float64,
@@ -487,6 +489,153 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
     ).collect()
 
     assert result.select("activity_seq_id").sort("activity_seq_id").to_series().to_list() == [10]
+
+
+def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
+    previous_candidate_plan_steps = _make_possible_plan_steps(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [11],
+            "dest_seq_id": [101],
+            "mode_seq_id": [1001],
+            "seq_step_index": [0],
+            "activity": ["shop"],
+            "from": [1],
+            "to": [3],
+            "mode": ["bike"],
+            "duration_per_pers": [1.0],
+            "departure_time": [18.0],
+            "arrival_time": [18.5],
+            "next_departure_time": [19.0],
+            "iteration": [1],
+            "csp": ["x"],
+            "first_seen_iteration": [1],
+            "last_seen_iteration": [1],
+            "last_active_iteration": [None],
+            "cost": [1.0],
+            "distance": [3.0],
+            "time": [0.5],
+            "mean_duration_per_pers": [1.0],
+            "value_of_time": [1.0],
+            "k_saturation_utility": [1.0],
+            "min_activity_time": [1.0],
+            "utility": [1.0],
+        }
+    )
+
+    class _StubAsset:
+        def __init__(self, df):
+            self._df = df
+
+        def get_cached_asset(self):
+            return self._df
+
+    destination_sequences = _StubAsset(
+        pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "activity_seq_id": [11],
+                "time_seq_id": [0],
+                "dest_seq_id": [101],
+                "seq_step_index": [0],
+                "from": [1],
+                "to": [3],
+                "departure_time": [18.0],
+                "arrival_time": [18.6],
+                "next_departure_time": [19.0],
+                "iteration": [5],
+            },
+            schema={
+                "demand_group_id": pl.UInt32,
+                "activity_seq_id": pl.UInt32,
+                "time_seq_id": pl.UInt32,
+                "dest_seq_id": pl.UInt32,
+                "seq_step_index": pl.UInt32,
+                "from": pl.Int32,
+                "to": pl.Int32,
+                "departure_time": pl.Float64,
+                "arrival_time": pl.Float64,
+                "next_departure_time": pl.Float64,
+                "iteration": pl.UInt32,
+            },
+        )
+    )
+    mode_sequences = _StubAsset(
+        pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "activity_seq_id": [11],
+                "time_seq_id": [0],
+                "dest_seq_id": [101],
+                "mode_seq_id": [1001],
+                "seq_step_index": [0],
+                "mode": ["bike"],
+                "iteration": [5],
+            },
+            schema={
+                "demand_group_id": pl.UInt32,
+                "activity_seq_id": pl.UInt32,
+                "time_seq_id": pl.UInt32,
+                "dest_seq_id": pl.UInt32,
+                "mode_seq_id": pl.UInt32,
+                "seq_step_index": pl.UInt32,
+                "mode": pl.Utf8,
+                "iteration": pl.UInt32,
+            },
+        )
+    )
+    chains = pl.DataFrame(
+        {
+            "activity_seq_id": [11],
+            "time_seq_id": [0],
+            "seq_step_index": [0],
+            "activity": ["shop"],
+            "duration_per_pers": [1.0],
+            "departure_time": [18.0],
+            "arrival_time": [18.5],
+            "next_departure_time": [19.0],
+        },
+        schema={
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt32,
+            "activity": pl.Utf8,
+            "duration_per_pers": pl.Float64,
+            "departure_time": pl.Float64,
+            "arrival_time": pl.Float64,
+            "next_departure_time": pl.Float64,
+        },
+    )
+    demand_groups = pl.DataFrame(
+        {"demand_group_id": [1], "country": ["fr"], "csp": ["x"]},
+        schema={"demand_group_id": pl.UInt32, "country": pl.Utf8, "csp": pl.Utf8},
+    )
+
+    result = CandidatePlanStepsAsset.build_candidate_memory(
+        destination_sequences=destination_sequences,
+        mode_sequences=mode_sequences,
+        survey_plan_steps=chains,
+        demand_groups=demand_groups,
+        current_plans=pl.DataFrame(
+            schema={
+                "demand_group_id": pl.UInt32,
+                "activity_seq_id": pl.UInt32,
+                "time_seq_id": pl.UInt32,
+                "dest_seq_id": pl.UInt32,
+                "mode_seq_id": pl.UInt32,
+            }
+        ),
+        previous_candidate_plan_steps=previous_candidate_plan_steps,
+        current_iteration=5,
+        n_warmup_iterations=1,
+        max_inactive_age=2,
+    ).collect()
+
+    assert result.select("activity_seq_id").to_series().to_list() == [11]
+    assert result.select("first_seen_iteration").item() == 1
+    assert result.select("last_seen_iteration").item() == 5
+    assert result.select("arrival_time").item() == pytest.approx(18.6)
+
 
 def test_get_transition_probabilities_limits_destination_replanning_to_same_timing_profile(tmp_path):
     updater = PlanUpdater()

--- a/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
+++ b/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
@@ -106,6 +106,139 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
     assert seen["chains"].select("activity_seq_id").to_series().to_list() == [10]
 
 
+def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_path):
+    destination_sequences = DestinationSequences(
+        run_key="run",
+        is_weekday=True,
+        iteration=5,
+        base_folder=_make_local_tmp_path(tmp_path, "refresh_active_destinations"),
+        current_plans=pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "activity_seq_id": [10],
+                "time_seq_id": [20],
+                "dest_seq_id": [30],
+                "mode_seq_id": [40],
+            },
+            schema={
+                "demand_group_id": pl.UInt32,
+                "activity_seq_id": pl.UInt32,
+                "time_seq_id": pl.UInt32,
+                "dest_seq_id": pl.UInt32,
+                "mode_seq_id": pl.UInt32,
+            },
+        ),
+        current_plan_steps=pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "activity_seq_id": [10],
+                "time_seq_id": [20],
+                "dest_seq_id": [30],
+                "seq_step_index": [1],
+                "from": [100],
+                "to": [200],
+                "departure_time": [8.0],
+                "arrival_time": [9.0],
+                "next_departure_time": [17.0],
+            },
+            schema={
+                "demand_group_id": pl.UInt32,
+                "activity_seq_id": pl.UInt32,
+                "time_seq_id": pl.UInt32,
+                "dest_seq_id": pl.UInt32,
+                "seq_step_index": pl.UInt8,
+                "from": pl.UInt16,
+                "to": pl.UInt16,
+                "departure_time": pl.Float32,
+                "arrival_time": pl.Float32,
+                "next_departure_time": pl.Float32,
+            },
+        ),
+        activities=[],
+        transport_zones=None,
+        destination_saturation=pl.DataFrame(),
+        demand_groups=pl.DataFrame(),
+        costs=pl.DataFrame(),
+        parameters=Parameters(refresh_active_mode_alternatives=True),
+        seed=123,
+        resolved_activity_parameters={},
+    )
+    sampled = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [11],
+            "time_seq_id": [21],
+            "dest_seq_id": [31],
+            "seq_step_index": [1],
+            "from": [101],
+            "to": [201],
+            "departure_time": [8.0],
+            "arrival_time": [9.0],
+            "next_departure_time": [17.0],
+            "anchor_to": [201],
+            "iteration": [5],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt8,
+            "from": pl.UInt16,
+            "to": pl.UInt16,
+            "departure_time": pl.Float32,
+            "arrival_time": pl.Float32,
+            "next_departure_time": pl.Float32,
+            "anchor_to": pl.UInt16,
+            "iteration": pl.UInt16,
+        },
+    )
+
+    result = destination_sequences._with_refreshed_active_destination_sequences(sampled)
+
+    assert result.select("dest_seq_id").sort("dest_seq_id").to_series().to_list() == [30, 31]
+    assert result.filter(pl.col("dest_seq_id") == 30).select("iteration").item() == 5
+    assert result.columns == DestinationSequences.OUTPUT_COLUMNS
+
+
+def test_refresh_active_mode_alternatives_default_keeps_sampled_destinations_only(tmp_path):
+    destination_sequences = DestinationSequences(
+        run_key="run",
+        is_weekday=True,
+        iteration=5,
+        base_folder=_make_local_tmp_path(tmp_path, "refresh_active_destinations_default"),
+        current_plans=pl.DataFrame(),
+        current_plan_steps=pl.DataFrame(),
+        activities=[],
+        transport_zones=None,
+        destination_saturation=pl.DataFrame(),
+        demand_groups=pl.DataFrame(),
+        costs=pl.DataFrame(),
+        parameters=Parameters(),
+        seed=123,
+        resolved_activity_parameters={},
+    )
+    sampled = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [11],
+            "time_seq_id": [21],
+            "dest_seq_id": [31],
+            "seq_step_index": [1],
+            "from": [101],
+            "to": [201],
+            "departure_time": [8.0],
+            "arrival_time": [9.0],
+            "next_departure_time": [17.0],
+            "iteration": [5],
+        }
+    )
+
+    result = destination_sequences._with_refreshed_active_destination_sequences(sampled)
+
+    assert result is sampled
+
+
 def test_destination_probability_inputs_use_cost_and_sink_even_without_destination_utilities(tmp_path):
     destination_sequences = DestinationSequences(
         run_key="run",


### PR DESCRIPTION
### Motivation

Before this PR, full replanning and destination replanning only ran the mode search on the destination chains sampled for the current iteration. A destination chain that was already active could be missing from that sample. In that case, the model reused the old active plan, but did not necessarily rebuild its mode alternatives with the latest travel costs.

With `refresh_active_mode_alternatives=True`, currently active destination chains are added back to the destination candidates before the top-k mode search. This means the model can recompute mode alternatives for plans that people are already using, with current travel costs, without forcing those people to change destination.

This PR also improves candidate memory. Before this PR, candidate memory only tracked when a plan was first generated and when it was last selected. If the same plan was generated again later but was not selected, the pruning logic could still treat it as old and remove it too soon.

This PR adds `last_seen_iteration`, which records the last iteration where the plan was generated. Inactive pruning now uses this value too, so recently regenerated plans stay available long enough to be compared with the current plans.

### Changes

This PR adds `refresh_active_mode_alternatives`.

When enabled, full replanning and destination replanning append currently active destination chains to the destination candidates before the top-k mode search.

Candidate-plan memory now tracks:

- `first_seen_iteration`: first iteration where the candidate appeared
- `last_seen_iteration`: last iteration where the candidate was generated
- `last_active_iteration`: last iteration where the candidate was selected by people

Inactive candidate pruning now uses the latest of these values.

The change also keeps compatibility with older cached candidate-plan files that do not have `last_seen_iteration`.

Initial destination opportunities now include the same destination saturation columns that later iterations produce, including shadow price and destination sampling fields. This keeps the first iteration and later iterations easier to handle with the same schema.

### Example

```python
Parameters(
    refresh_active_mode_alternatives=True,
)
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: implementation split from the larger dump branch, tests, and PR text.
- What you reviewed or changed: candidate memory retention, active destination refresh, initial destination saturation schema, and related tests.
- How you validated it: ran the full group-day-trip unit suite, the group-day-trip integration smoke test, `py_compile`, and `git diff --check`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior