### PR TITLE
Forward group day trip parameters

### DIFF
--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -31,6 +31,7 @@ class PopulationGroupDayTrips:
         k_mode_sequences: int = None,
         n_warmup_iterations: int = None,
         max_inactive_age: int = None,
+        refresh_active_mode_alternatives: bool = None,
         dest_prob_cutoff: float = None,
         n_iter_per_cost_update: int = None,
         cost_uncertainty_sd: float = None,
@@ -41,11 +42,15 @@ class PopulationGroupDayTrips:
         persist_iteration_artifacts: bool = None,
         min_activity_time_constant: float = None,
         update_plan_timings_from_modeled_travel_times: bool = None,
+        use_destination_shadow_prices: bool = None,
         transition_distance_threshold: float = None,
         enable_transition_distance_model: bool = None,
         transition_revision_probability: float = None,
         transition_logit_scale: float = None,
         transition_utility_pruning_delta: float = None,
+        min_transition_utility_gain: float = None,
+        plan_probability_pruning_retained_share: float = None,
+        plan_probability_pruning_min_iteration: int = None,
         transition_distance_friction: float = None,
         plan_embedding_dimension_weights: list[float] | None = None,
         behavior_change_phases: list[BehaviorChangePhase] | None = None,
@@ -84,6 +89,8 @@ class PopulationGroupDayTrips:
                 `Parameters.n_warmup_iterations`.
             max_inactive_age: Optional override for
                 `Parameters.max_inactive_age`.
+            refresh_active_mode_alternatives: Optional override for
+                `Parameters.refresh_active_mode_alternatives`.
             dest_prob_cutoff: Optional override for
                 `Parameters.dest_prob_cutoff`.
             n_iter_per_cost_update: Optional override for
@@ -103,6 +110,8 @@ class PopulationGroupDayTrips:
                 `Parameters.min_activity_time_constant`.
             update_plan_timings_from_modeled_travel_times: Optional override for
                 `Parameters.update_plan_timings_from_modeled_travel_times`.
+            use_destination_shadow_prices: Optional override for
+                `Parameters.use_destination_shadow_prices`.
             transition_distance_threshold: Optional override for
                 `Parameters.transition_distance_threshold`.
             enable_transition_distance_model: Optional override for
@@ -113,6 +122,12 @@ class PopulationGroupDayTrips:
                 `Parameters.transition_logit_scale`.
             transition_utility_pruning_delta: Optional override for
                 `Parameters.transition_utility_pruning_delta`.
+            min_transition_utility_gain: Optional override for
+                `Parameters.min_transition_utility_gain`.
+            plan_probability_pruning_retained_share: Optional override for
+                `Parameters.plan_probability_pruning_retained_share`.
+            plan_probability_pruning_min_iteration: Optional override for
+                `Parameters.plan_probability_pruning_min_iteration`.
             transition_distance_friction: Optional override for
                 `Parameters.transition_distance_friction`.
             plan_embedding_dimension_weights: Optional override for
@@ -143,6 +158,7 @@ class PopulationGroupDayTrips:
                 "k_mode_sequences": k_mode_sequences,
                 "n_warmup_iterations": n_warmup_iterations,
                 "max_inactive_age": max_inactive_age,
+                "refresh_active_mode_alternatives": refresh_active_mode_alternatives,
                 "dest_prob_cutoff": dest_prob_cutoff,
                 "n_iter_per_cost_update": n_iter_per_cost_update,
                 "cost_uncertainty_sd": cost_uncertainty_sd,
@@ -153,11 +169,15 @@ class PopulationGroupDayTrips:
                 "persist_iteration_artifacts": persist_iteration_artifacts,
                 "min_activity_time_constant": min_activity_time_constant,
                 "update_plan_timings_from_modeled_travel_times": update_plan_timings_from_modeled_travel_times,
+                "use_destination_shadow_prices": use_destination_shadow_prices,
                 "transition_distance_threshold": transition_distance_threshold,
                 "enable_transition_distance_model": enable_transition_distance_model,
                 "transition_revision_probability": transition_revision_probability,
                 "transition_logit_scale": transition_logit_scale,
                 "transition_utility_pruning_delta": transition_utility_pruning_delta,
+                "min_transition_utility_gain": min_transition_utility_gain,
+                "plan_probability_pruning_retained_share": plan_probability_pruning_retained_share,
+                "plan_probability_pruning_min_iteration": plan_probability_pruning_min_iteration,
                 "transition_distance_friction": transition_distance_friction,
                 "plan_embedding_dimension_weights": plan_embedding_dimension_weights,
                 "behavior_change_phases": behavior_change_phases,

--- a/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
+++ b/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
@@ -63,8 +63,13 @@ def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
         k_destination_sequences=6,
         n_warmup_iterations=2,
         max_inactive_age=3,
+        refresh_active_mode_alternatives=True,
         transition_revision_probability=0.4,
         transition_logit_scale=0.75,
+        use_destination_shadow_prices=True,
+        min_transition_utility_gain=0.1,
+        plan_probability_pruning_retained_share=0.995,
+        plan_probability_pruning_min_iteration=3,
         use_rust_mode_sequence_search=True,
         enable_transition_distance_model=True,
         transition_distance_threshold=8.0,
@@ -83,8 +88,13 @@ def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
     assert parameters.k_destination_sequences == 6
     assert parameters.n_warmup_iterations == 2
     assert parameters.max_inactive_age == 3
+    assert parameters.refresh_active_mode_alternatives is True
     assert parameters.transition_revision_probability == 0.4
     assert parameters.transition_logit_scale == 0.75
+    assert parameters.use_destination_shadow_prices is True
+    assert parameters.min_transition_utility_gain == 0.1
+    assert parameters.plan_probability_pruning_retained_share == 0.995
+    assert parameters.plan_probability_pruning_min_iteration == 3
     assert parameters.use_rust_mode_sequence_search is True
     assert parameters.enable_transition_distance_model is True
     assert parameters.transition_distance_threshold == 8.0


### PR DESCRIPTION
### Motivation

For historical reasons, `PopulationGroupDayTrips(...)` exposes many `Parameters` fields as direct keyword arguments.

For example, users can write:

```python
PopulationGroupDayTrips(
    population=population,
    modes=modes,
    activities=activities,
    surveys=surveys,
    n_iterations=10,
    k_destination_sequences=5,
    transition_logit_scale=0.8,
)
```

The newer parameters added recently existed in `Parameters`, but were not exposed through this historical convenience API. Users had to build a `Parameters` object manually for those options.

Before this PR, this worked:

```python
PopulationGroupDayTrips(
    population=population,
    modes=modes,
    activities=activities,
    surveys=surveys,
    parameters=Parameters(
        refresh_active_mode_alternatives=True,
        use_destination_shadow_prices=True,
        min_transition_utility_gain=0.1,
    ),
)
```

But this did not forward the values:

```python
PopulationGroupDayTrips(
    population=population,
    modes=modes,
    activities=activities,
    surveys=surveys,
    refresh_active_mode_alternatives=True,
    use_destination_shadow_prices=True,
    min_transition_utility_gain=0.1,
)
```

After this PR, both forms work.

This keeps the current public API consistent. Longer term, we should probably simplify the API and move toward `parameters=Parameters(...)` only, but this PR does not make that breaking change.

### Changes

This PR forwards these parameters from `PopulationGroupDayTrips(...)` to `Parameters`:

- `refresh_active_mode_alternatives`
- `use_destination_shadow_prices`
- `min_transition_utility_gain`
- `plan_probability_pruning_retained_share`
- `plan_probability_pruning_min_iteration`

The public API forwarding test now checks these parameters.

### Example

```python
group_day_trips = PopulationGroupDayTrips(
    population=population,
    modes=modes,
    activities=activities,
    surveys=surveys,
    refresh_active_mode_alternatives=True,
    use_destination_shadow_prices=True,
    min_transition_utility_gain=0.1,
)
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: implementation split from the larger dump branch, test update, and PR text.
- What you reviewed or changed: `PopulationGroupDayTrips` constructor forwarding and the public API forwarding test.
- How you validated it: ran the focused public API forwarding test, the full group-day-trip unit suite, `py_compile`, and `git diff --check`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior