### PR TITLE
Add group day trip diagnostics and metrics

### DIFF
--- a/mobility/trips/group_day_trips/core/diagnostics.py
+++ b/mobility/trips/group_day_trips/core/diagnostics.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from ..evaluation.model_entropy import ModelEntropy
 from ..evaluation.model_loss import ModelLoss
+from ..evaluation.model_trip_count_loss import ModelTripCountLoss
 
 if TYPE_CHECKING:
     from .results import RunResults
@@ -36,6 +37,16 @@ class RunDiagnostics:
         return ModelEntropy(
             expected_plan_steps=self.results.expected_entropy_plan_steps,
             observed_plan_steps=self.results.observed_entropy_plan_steps,
+            history=self.results.iteration_metrics_store,
+        )
+
+    def trip_count_loss(self) -> ModelTripCountLoss:
+        """Return the trip-count distribution loss helper for this run."""
+        return ModelTripCountLoss(
+            expected_plan_steps=self.results.population_weighted_plan_steps,
+            surveys=self.results.surveys,
+            is_weekday=self.results.is_weekday,
+            observed_plan_steps=self.results.plan_steps,
             history=self.results.iteration_metrics_store,
         )
 

--- a/mobility/trips/group_day_trips/core/metrics.py
+++ b/mobility/trips/group_day_trips/core/metrics.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Literal
+import math
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
 import geopandas as gpd
+import matplotlib.ticker as mticker
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.express as px
@@ -12,6 +18,10 @@ import plotly.graph_objects as go
 import polars as pl
 from plotly.subplots import make_subplots
 
+from mobility.reports import TransportZoneMaps
+from mobility.reports.theme import MOBILITY_COLORS, apply_report_layout
+
+from ..iterations import Iterations
 from ..evaluation.car_traffic_evaluation import CarTrafficEvaluation
 from ..evaluation.public_transport_network_evaluation import (
     PublicTransportNetworkEvaluation,
@@ -99,6 +109,12 @@ class RunMetrics:
         variable: Literal["mode", "activity", "time_bin", "distance_bin"] = None,
         normalize: bool = True,
         plot: bool = False,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        output_path: str | Path | None = None,
+        width: int = 980,
+        height: int = 560,
+        return_figure: bool = False,
     ):
         """Compare trips, travel time, and travel distance with the survey reference by one grouping variable."""
         ref_plan_steps = (
@@ -169,31 +185,369 @@ class RunMetrics:
             .select(["variable", variable, "value", "value_ref", "delta", "delta_relative"])
         )
 
-        if plot:
-            comparison_plot_df = (
-                comparison.select(["variable", variable, "value", "value_ref"])
-                .unpivot(
-                    index=["variable", variable],
-                    on=["value", "value_ref"],
-                    variable_name="value_type",
-                    value_name="value",
-                )
-                .sort(variable)
+        fig = None
+        if plot or save_to_file or output_path is not None or return_figure:
+            fig = self._plot_travel_indicators_by(
+                comparison,
+                group_variable=variable,
+                width=width,
+                height=height,
+            )
+        if save_to_file or output_path is not None:
+            svg_path = (
+                Path(output_path)
+                if output_path is not None
+                else self._svg_report_path(f"{self.results.period}-travel-indicators-by-{variable}")
+            )
+            self._save_travel_indicators_by_svg(
+                comparison,
+                group_variable=variable,
+                output_path=svg_path,
+                width=width,
+                height=height,
             )
 
-            fig = px.bar(
-                comparison_plot_df,
-                x=variable,
-                y="value",
-                color="value_type",
-                facet_col="variable",
-                barmode="group",
-                facet_col_spacing=0.05,
-            )
-            fig.update_yaxes(matches=None, showticklabels=True)
-            fig.show("browser")
+        if plot and fig is not None:
+            fig.show(plot_method)
+
+        if return_figure:
+            return comparison, fig
 
         return comparison
+
+    def _travel_indicators_plot_table(
+        self,
+        comparison: pl.DataFrame,
+        *,
+        group_variable: str,
+    ) -> pl.DataFrame:
+        """Return a long table used by travel-indicator plots."""
+        indicator_labels = self._travel_indicator_labels()
+        return (
+            comparison
+            .select(["variable", group_variable, "value", "value_ref"])
+            .unpivot(
+                index=["variable", group_variable],
+                on=["value", "value_ref"],
+                variable_name="value_type",
+                value_name="value",
+            )
+            .with_columns(
+                pl.col(group_variable).cast(pl.String),
+                source=(
+                    pl.when(pl.col("value_type") == "value_ref")
+                    .then(pl.lit("Survey"))
+                    .otherwise(pl.lit("Model"))
+                ),
+                indicator=pl.col("variable").replace(indicator_labels),
+                value=pl.col("value").fill_null(0.0),
+            )
+            .select([group_variable, "indicator", "source", "value"])
+            .sort([group_variable, "indicator", "source"])
+        )
+
+    def _plot_travel_indicators_by(
+        self,
+        comparison: pl.DataFrame,
+        *,
+        group_variable: str,
+        width: int,
+        height: int,
+    ) -> go.Figure:
+        """Render survey/model travel indicators with the report style."""
+        plot_table = self._travel_indicators_plot_table(
+            comparison,
+            group_variable=group_variable,
+        )
+        indicator_order = list(self._travel_indicator_labels().values())
+        fig = px.bar(
+            plot_table.to_pandas(),
+            x=group_variable,
+            y="value",
+            color="source",
+            facet_col="indicator",
+            barmode="group",
+            facet_col_spacing=0.06,
+            category_orders={
+                "source": ["Survey", "Model"],
+                "indicator": indicator_order,
+            },
+            color_discrete_map={
+                "Survey": MOBILITY_COLORS["survey"],
+                "Model": MOBILITY_COLORS["model"],
+            },
+            labels={
+                group_variable: group_variable.replace("_", " ").capitalize(),
+                "value": "Value",
+                "source": "",
+            },
+            width=width,
+            height=height,
+        )
+        apply_report_layout(fig)
+        fig.update_layout(
+            title_text=None,
+            paper_bgcolor=MOBILITY_COLORS["background"],
+            plot_bgcolor=MOBILITY_COLORS["background"],
+            margin={"l": 65, "r": 20, "t": 35, "b": 120},
+            legend={
+                "orientation": "h",
+                "x": 0.0,
+                "y": -0.22,
+                "xanchor": "left",
+                "yanchor": "top",
+                "bgcolor": "rgba(255,255,255,0.9)",
+            },
+        )
+        fig.for_each_annotation(lambda annotation: annotation.update(text=annotation.text.split("=")[-1], font_size=12))
+        fig.update_yaxes(matches=None, showticklabels=True, showgrid=True, gridcolor=MOBILITY_COLORS["grid"], zeroline=False)
+        fig.update_xaxes(showgrid=False, zeroline=False, tickangle=45)
+        return fig
+
+    def _save_travel_indicators_by_svg(
+        self,
+        comparison: pl.DataFrame,
+        *,
+        group_variable: str,
+        output_path: Path,
+        width: int,
+        height: int,
+    ) -> None:
+        """Save travel indicators as SVG with the same report style."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        plot_table = self._travel_indicators_plot_table(
+            comparison,
+            group_variable=group_variable,
+        ).to_pandas()
+        indicators = list(self._travel_indicator_labels().values())
+        groups = sorted(plot_table[group_variable].dropna().unique().tolist())
+        if not groups:
+            return
+
+        fig_width = max(width / 100.0, 7.0)
+        fig_height = max(height / 100.0, 4.5)
+        fig, axes = plt.subplots(
+            1,
+            len(indicators),
+            figsize=(fig_width, fig_height),
+            squeeze=False,
+        )
+        bar_width = 0.38
+        x_positions = np.arange(len(groups))
+        source_colors = {
+            "Survey": MOBILITY_COLORS["survey"],
+            "Model": MOBILITY_COLORS["model"],
+        }
+
+        for axis, indicator in zip(axes[0], indicators, strict=True):
+            panel = plot_table[plot_table["indicator"] == indicator]
+            for index, source in enumerate(["Survey", "Model"]):
+                values = (
+                    panel[panel["source"] == source]
+                    .set_index(group_variable)["value"]
+                    .reindex(groups, fill_value=0.0)
+                    .to_numpy()
+                )
+                axis.bar(
+                    x_positions + (index - 0.5) * bar_width,
+                    values,
+                    width=bar_width,
+                    color=source_colors[source],
+                    label=source,
+                )
+            axis.set_title(indicator, fontsize=12)
+            axis.set_xticks(x_positions, groups, rotation=45, ha="right")
+            axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=0.8)
+            axis.grid(axis="x", visible=False)
+            axis.set_facecolor(MOBILITY_COLORS["background"])
+
+        axes[0][0].set_ylabel("Value")
+        handles, legend_labels = axes[0][0].get_legend_handles_labels()
+        fig.legend(
+            handles,
+            legend_labels,
+            loc="lower left",
+            bbox_to_anchor=(0.06, 0.02),
+            ncol=2,
+            frameon=False,
+        )
+        fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+        fig.subplots_adjust(left=0.07, right=0.98, top=0.90, bottom=0.28, wspace=0.22)
+        fig.savefig(output_path, format="svg")
+        plt.close(fig)
+
+    @staticmethod
+    def _travel_indicator_labels() -> dict[str, str]:
+        """Return display labels for travel indicator facets."""
+        return {
+            "n_trips": "Trips",
+            "time": "Travel time",
+            "distance": "Distance",
+        }
+
+    def activity_duration_distribution(
+        self,
+        bin_width_minutes: int = 15,
+        plot: bool = True,
+        inner_zone_residents_only: bool = False,
+    ) -> pl.DataFrame:
+        """Compare weighted activity-duration distributions between model and survey."""
+        if bin_width_minutes <= 0:
+            raise ValueError("bin_width_minutes must be positive.")
+
+        model_plan_steps = self.results.plan_steps
+        survey_plan_steps = self.results.population_weighted_plan_steps
+        if inner_zone_residents_only:
+            model_plan_steps = self._filter_plan_steps_to_inner_zone_residents(model_plan_steps)
+            survey_plan_steps = self._filter_plan_steps_to_inner_zone_residents(survey_plan_steps)
+
+        durations = pl.concat(
+            [
+                self._activity_duration_samples(model_plan_steps, source="model"),
+                self._activity_duration_samples(survey_plan_steps, source="survey"),
+            ],
+            how="vertical_relaxed",
+        )
+        bin_width_hours = bin_width_minutes / 60.0
+
+        distribution = (
+            durations.lazy()
+            .with_columns(
+                duration_bin_start=(pl.col("duration") / bin_width_hours).floor() * bin_width_hours,
+            )
+            .with_columns(
+                duration_bin_end=pl.col("duration_bin_start") + bin_width_hours,
+                duration_bin_mid=pl.col("duration_bin_start") + bin_width_hours / 2.0,
+                duration_label=pl.format(
+                    "{}-{} h",
+                    pl.col("duration_bin_start").round(2),
+                    (pl.col("duration_bin_start") + bin_width_hours).round(2),
+                ),
+            )
+            .group_by(
+                [
+                    "source",
+                    "activity",
+                    "duration_bin_start",
+                    "duration_bin_end",
+                    "duration_bin_mid",
+                    "duration_label",
+                ]
+            )
+            .agg(
+                weighted_visits=pl.col("weight").sum(),
+                person_hours=(pl.col("duration") * pl.col("weight")).sum(),
+            )
+            .with_columns(
+                probability=pl.col("weighted_visits") / pl.col("weighted_visits").sum().over(["source", "activity"])
+            )
+            .sort(["activity", "source", "duration_bin_start"])
+            .collect(engine="streaming")
+        )
+
+        if plot:
+            self._plot_activity_duration_distribution(distribution)
+
+        return distribution
+
+    @staticmethod
+    def _activity_duration_samples(
+        plan_steps: pl.LazyFrame | pl.DataFrame,
+        source: str,
+    ) -> pl.DataFrame:
+        """Extract one weighted activity-duration sample table from plan steps."""
+        if isinstance(plan_steps, pl.DataFrame):
+            plan_steps = plan_steps.lazy()
+
+        column_names = set(plan_steps.collect_schema().names())
+        required_columns = {"activity", "n_persons"}
+        missing_columns = required_columns - column_names
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Plan steps are missing required duration-distribution columns: {missing}.")
+
+        if "duration_per_pers" in column_names:
+            duration_expr = pl.col("duration_per_pers").cast(pl.Float64)
+        elif {"duration", "n_persons"} <= column_names:
+            duration_expr = pl.col("duration").cast(pl.Float64) / pl.col("n_persons").cast(pl.Float64)
+        else:
+            raise ValueError("Plan steps need either duration_per_pers or duration and n_persons.")
+
+        samples = plan_steps.with_columns(
+            source=pl.lit(source),
+            activity=pl.col("activity").cast(pl.String),
+            duration=duration_expr,
+            weight=pl.col("n_persons").cast(pl.Float64),
+        )
+        samples = RunMetrics._filter_terminal_home_steps(samples, column_names)
+
+        return (
+            samples.filter(
+                pl.col("duration").is_not_null()
+                & pl.col("duration").is_finite()
+                & (pl.col("duration") >= 0.0)
+                & pl.col("weight").is_not_null()
+                & pl.col("weight").is_finite()
+                & (pl.col("weight") > 0.0)
+            )
+            .select(["source", "activity", "duration", "weight"])
+            .collect(engine="streaming")
+        )
+
+    @staticmethod
+    def _filter_terminal_home_steps(plan_steps: pl.LazyFrame, column_names: set[str]) -> pl.LazyFrame:
+        """Remove the final home stay and keep home stops reached during the day."""
+        if "seq_step_index" in column_names:
+            plan_key_candidates = [
+                "country",
+                "home_zone_id",
+                "city_category",
+                "csp",
+                "n_cars",
+                "activity_seq_id",
+                "time_seq_id",
+                "dest_seq_id",
+                "mode_seq_id",
+            ]
+            plan_keys = [column for column in plan_key_candidates if column in column_names]
+            if plan_keys:
+                return (
+                    plan_steps.with_columns(
+                        is_terminal_step=pl.col("seq_step_index") == pl.col("seq_step_index").max().over(plan_keys)
+                    )
+                    .filter(~((pl.col("activity") == "home") & pl.col("is_terminal_step")))
+                    .drop("is_terminal_step")
+                )
+
+        if "next_departure_time" in column_names:
+            return plan_steps.filter(~((pl.col("activity") == "home") & (pl.col("next_departure_time") >= 24.0)))
+
+        return plan_steps
+
+    @staticmethod
+    def _plot_activity_duration_distribution(distribution: pl.DataFrame) -> None:
+        """Plot the weighted duration distributions with one panel per activity."""
+        if distribution.is_empty():
+            return
+
+        fig = px.line(
+            distribution.to_pandas(),
+            x="duration_bin_mid",
+            y="probability",
+            color="source",
+            facet_col="activity",
+            facet_col_wrap=3,
+            markers=True,
+            labels={
+                "duration_bin_mid": "activity duration (h)",
+                "probability": "share of weighted visits",
+                "source": "source",
+                "activity": "activity",
+            },
+        )
+        fig.update_yaxes(matches=None, showticklabels=True)
+        fig.update_xaxes(matches=None, showticklabels=True)
+        fig.show("browser")
 
     def immobility(self, plot: bool = True):
         """Compute immobility by country and socio-professional category."""
@@ -280,6 +634,8 @@ class RunMetrics:
         interval_minutes: int = 15,
         plot: bool = False,
         inner_zone_residents_only: bool = False,
+        plot_mode: Literal["stacked", "activity_panels"] = "stacked",
+        save_to_file: bool = False,
     ) -> pl.DataFrame:
         """Aggregate average occupancy by activity and in-transit mode over time bins."""
         observed_time_series = self._add_residual_home_time(
@@ -304,7 +660,14 @@ class RunMetrics:
             ["source", "time_bin_start", "time_label", "label", "n_persons"]
         )
         if plot:
-            self._plot_activity_time_series(time_series)
+            if plot_mode == "stacked":
+                self._plot_activity_time_series(time_series, save_to_file=save_to_file)
+            else:
+                self._plot_activity_time_series(
+                    time_series,
+                    mode=plot_mode,
+                    save_to_file=save_to_file,
+                )
 
         return time_series
 
@@ -491,13 +854,21 @@ class RunMetrics:
         self,
         interval_minutes: int = 15,
         inner_zone_residents_only: bool = False,
+        plot_mode: Literal["stacked", "activity_panels"] = "stacked",
+        save_to_file: bool = False,
     ):
-        """Plot a stacked bar chart of average occupancy by activity and transit mode."""
+        """Plot average occupancy by time of day."""
         time_series = self.activity_time_series(
             interval_minutes=interval_minutes,
             inner_zone_residents_only=inner_zone_residents_only,
         )
-        return self._plot_activity_time_series(time_series)
+        if plot_mode == "stacked":
+            return self._plot_activity_time_series(time_series, save_to_file=save_to_file)
+        return self._plot_activity_time_series(
+            time_series,
+            mode=plot_mode,
+            save_to_file=save_to_file,
+        )
 
     def _add_residual_home_time(
         self,
@@ -536,8 +907,18 @@ class RunMetrics:
     def _plot_activity_time_series(
         self,
         time_series: pl.DataFrame,
+        mode: Literal["stacked", "activity_panels"] = "stacked",
+        save_to_file: bool = False,
     ):
         """Render stacked occupancy charts, with survey on the left when available."""
+        if mode == "activity_panels":
+            return self._plot_activity_time_series_activity_panels(
+                time_series,
+                save_to_file=save_to_file,
+            )
+        if mode != "stacked":
+            raise ValueError("mode must be 'stacked' or 'activity_panels'.")
+
         source_titles = {"survey": "Survey", "observed": "Model"}
         available_sources = [source for source in ["survey", "observed"] if source in time_series["source"].unique().to_list()]
         panel_series = [
@@ -554,6 +935,7 @@ class RunMetrics:
                 .to_list()
             )
         }
+        tick_labels = self._activity_time_tick_labels(category_orders["time_label"])
         labels = sorted({label for _, series in panel_series for label in series["label"].to_list()})
         color_map = self._activity_time_series_color_map(labels)
 
@@ -579,6 +961,7 @@ class RunMetrics:
                         x=time_labels,
                         y=values,
                         name=label,
+                        legendgroup=label,
                         marker_color=color_map[label],
                         showlegend=(col_index == 1),
                     ),
@@ -588,14 +971,356 @@ class RunMetrics:
 
         fig.update_layout(
             barmode="stack",
-            title=f"Average occupancy by activity on {self.results.period}",
-            xaxis_title="Time of day",
-            yaxis_title="Average persons in bin",
+            yaxis_title="Nombre de personnes",
+            paper_bgcolor=MOBILITY_COLORS["background"],
+            plot_bgcolor=MOBILITY_COLORS["background"],
+            width=980,
+            height=560,
+            margin={"l": 65, "r": 20, "t": 35, "b": 95},
+            legend={
+                "orientation": "h",
+                "x": 0.0,
+                "y": -0.18,
+                "xanchor": "left",
+                "yanchor": "top",
+                "bgcolor": "rgba(255,255,255,0.9)",
+            },
         )
+        apply_report_layout(fig)
+        fig.update_layout(title_text=None)
+        fig.update_annotations(font_size=13)
+        fig.update_xaxes(
+            showgrid=False,
+            zeroline=False,
+            tickmode="array",
+            tickvals=tick_labels,
+            ticktext=tick_labels,
+            title_text=None,
+        )
+        fig.update_yaxes(showgrid=True, gridcolor=MOBILITY_COLORS["grid"], zeroline=False)
         for axis_name in [f"xaxis{suffix}" for suffix in ([""] + [str(index) for index in range(2, len(panel_series) + 1)])]:
             fig.layout[axis_name].update(categoryorder="array", categoryarray=category_orders["time_label"])
+        if save_to_file:
+            self._save_activity_time_series_svg(
+                time_series,
+                mode="stacked",
+                output_path=self._svg_report_path("activity-time-series"),
+            )
         fig.show("browser")
         return fig
+
+    def _plot_activity_time_series_activity_panels(
+        self,
+        time_series: pl.DataFrame,
+        save_to_file: bool = False,
+    ):
+        """Render one panel per activity, comparing survey and model occupancy."""
+        activity_series = (
+            time_series
+            .filter(~pl.col("label").str.starts_with("in_transit:"))
+            .with_columns(
+                source=(
+                    pl.when(pl.col("source") == "observed")
+                    .then(pl.lit("Model"))
+                    .when(pl.col("source") == "survey")
+                    .then(pl.lit("Survey"))
+                    .otherwise(pl.col("source"))
+                ),
+                label=pl.col("label").cast(pl.String),
+            )
+            .sort(["label", "source", "time_bin_start"])
+        )
+        if activity_series.is_empty():
+            return None
+
+        time_labels = (
+            time_series
+            .select(["time_bin_start", "time_label"])
+            .unique()
+            .sort("time_bin_start")
+            .get_column("time_label")
+            .to_list()
+        )
+        activities = sorted(activity_series["label"].unique().to_list())
+        tick_labels = self._activity_time_tick_labels(time_labels)
+
+        fig = px.line(
+            activity_series.to_pandas(),
+            x="time_label",
+            y="n_persons",
+            color="source",
+            facet_col="label",
+            facet_col_wrap=2,
+            facet_col_spacing=0.08,
+            facet_row_spacing=0.16,
+            markers=True,
+            category_orders={"time_label": time_labels, "source": ["Survey", "Model"]},
+            color_discrete_map={
+                "Survey": MOBILITY_COLORS["survey"],
+                "Model": MOBILITY_COLORS["model"],
+            },
+            labels={
+                "time_label": "Time of day",
+                "n_persons": "Average persons in bin",
+                "source": "source",
+                "label": "activity",
+            },
+            title=f"Average occupancy by activity on {self.results.period}",
+            width=980,
+            height=max(520, 260 * math.ceil(len(activities) / 2)),
+        )
+        apply_report_layout(fig)
+        fig.update_layout(
+            paper_bgcolor=MOBILITY_COLORS["background"],
+            plot_bgcolor=MOBILITY_COLORS["background"],
+            title_text=None,
+            margin={"l": 65, "r": 20, "t": 35, "b": 95},
+            legend={
+                "orientation": "h",
+                "x": 0.0,
+                "y": -0.12,
+                "xanchor": "left",
+                "yanchor": "top",
+                "bgcolor": "rgba(255,255,255,0.9)",
+            },
+        )
+        fig.for_each_annotation(lambda annotation: annotation.update(text=annotation.text.split("=")[-1], font_size=12))
+        fig.update_yaxes(matches=None, showticklabels=True, title_text=None)
+        fig.update_xaxes(
+            matches=None,
+            showticklabels=True,
+            categoryorder="array",
+            categoryarray=time_labels,
+            showgrid=False,
+            zeroline=False,
+            tickmode="array",
+            tickvals=tick_labels,
+            ticktext=tick_labels,
+            title_text=None,
+        )
+        fig.update_yaxes(showgrid=True, gridcolor=MOBILITY_COLORS["grid"], zeroline=False)
+        if save_to_file:
+            self._save_activity_time_series_svg(
+                time_series,
+                mode="activity_panels",
+                output_path=self._svg_report_path("activity-time-series-activity-panels"),
+            )
+        fig.show("browser")
+        return fig
+
+    @staticmethod
+    def _activity_time_tick_labels(time_labels: list[str]) -> list[str]:
+        """Return a sparse set of time labels so plot axes stay readable."""
+        if len(time_labels) <= 12:
+            return time_labels
+        step = max(1, math.ceil(len(time_labels) / 12))
+        return time_labels[::step]
+
+    def _svg_report_path(self, save_name: str) -> Path:
+        """Return the standard report SVG path for this run."""
+        return self._report_folder() / f"{self.results.inputs_hash}-{save_name}.svg"
+
+    @staticmethod
+    def _report_folder() -> Path:
+        """Return the configured report output folder."""
+        project_folder = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+        if project_folder is None:
+            raise ValueError(
+                "save_to_file=True needs MOBILITY_PROJECT_DATA_FOLDER to be defined."
+            )
+        return Path(project_folder)
+
+    def _save_activity_time_series_svg(
+        self,
+        time_series: pl.DataFrame,
+        *,
+        mode: Literal["stacked", "activity_panels"],
+        output_path: Path,
+    ) -> None:
+        """Save the activity time-series plot as SVG without using a browser."""
+        if mode == "activity_panels":
+            self._save_activity_time_series_activity_panels_svg(time_series, output_path)
+        else:
+            self._save_activity_time_series_stacked_svg(time_series, output_path)
+
+    def _save_activity_time_series_stacked_svg(
+        self,
+        time_series: pl.DataFrame,
+        output_path: Path,
+    ) -> None:
+        """Save the stacked activity time-series plot as SVG."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        source_titles = {"survey": "Survey", "observed": "Model"}
+        available_sources = [
+            source
+            for source in ["survey", "observed"]
+            if source in time_series["source"].unique().to_list()
+        ]
+        time_labels = (
+            time_series
+            .select(["time_bin_start", "time_label"])
+            .unique()
+            .sort("time_bin_start")
+            .get_column("time_label")
+            .to_list()
+        )
+        labels = sorted(time_series["label"].unique().to_list())
+        color_map = self._activity_time_series_color_map(labels)
+        tick_labels = self._activity_time_tick_labels(time_labels)
+        tick_positions = [time_labels.index(label) for label in tick_labels]
+
+        fig, axes = plt.subplots(
+            1,
+            len(available_sources),
+            sharey=True,
+            figsize=(9.8, 5.6),
+            squeeze=False,
+        )
+        for axis, source in zip(axes[0], available_sources, strict=True):
+            source_series = (
+                time_series
+                .filter(pl.col("source") == source)
+                .pivot(index="time_label", on="label", values="n_persons", aggregate_function="sum")
+                .sort("time_label")
+                .fill_null(0.0)
+            )
+            source_series = (
+                source_series
+                .to_pandas()
+                .set_index("time_label")
+                .reindex(time_labels, fill_value=0.0)
+            )
+            bottom = np.zeros(len(time_labels))
+            for label in labels:
+                values = (
+                    source_series[label].to_numpy()
+                    if label in source_series
+                    else np.zeros(len(time_labels))
+                )
+                axis.bar(
+                    np.arange(len(time_labels)),
+                    values,
+                    bottom=bottom,
+                    color=color_map[label],
+                    width=0.9,
+                    label=label,
+                )
+                bottom += values
+            axis.set_title(source_titles[source], fontsize=13)
+            axis.set_xticks(tick_positions, tick_labels, rotation=0)
+            axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=0.8)
+            axis.grid(axis="x", visible=False)
+            axis.set_facecolor(MOBILITY_COLORS["background"])
+
+        axes[0][0].set_ylabel("Nombre de personnes")
+        handles, legend_labels = axes[0][0].get_legend_handles_labels()
+        fig.legend(
+            handles,
+            legend_labels,
+            loc="lower left",
+            bbox_to_anchor=(0.06, 0.02),
+            ncol=min(4, max(1, len(legend_labels))),
+            frameon=False,
+        )
+        fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+        fig.subplots_adjust(left=0.07, right=0.98, top=0.92, bottom=0.18, wspace=0.08)
+        fig.savefig(output_path, format="svg")
+        plt.close(fig)
+
+    def _save_activity_time_series_activity_panels_svg(
+        self,
+        time_series: pl.DataFrame,
+        output_path: Path,
+    ) -> None:
+        """Save the activity-panel time-series plot as SVG."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        activity_series = (
+            time_series
+            .filter(~pl.col("label").str.starts_with("in_transit:"))
+            .with_columns(
+                source=(
+                    pl.when(pl.col("source") == "observed")
+                    .then(pl.lit("Model"))
+                    .when(pl.col("source") == "survey")
+                    .then(pl.lit("Survey"))
+                    .otherwise(pl.col("source"))
+                )
+            )
+        )
+        if activity_series.is_empty():
+            return
+
+        time_labels = (
+            time_series
+            .select(["time_bin_start", "time_label"])
+            .unique()
+            .sort("time_bin_start")
+            .get_column("time_label")
+            .to_list()
+        )
+        activities = sorted(activity_series["label"].unique().to_list())
+        tick_labels = self._activity_time_tick_labels(time_labels)
+        tick_positions = [time_labels.index(label) for label in tick_labels]
+        n_cols = 2
+        n_rows = math.ceil(len(activities) / n_cols)
+        fig, axes = plt.subplots(
+            n_rows,
+            n_cols,
+            sharex=True,
+            figsize=(9.8, max(5.2, 2.6 * n_rows)),
+            squeeze=False,
+        )
+        colors = {"Survey": MOBILITY_COLORS["survey"], "Model": MOBILITY_COLORS["model"]}
+
+        for axis, activity in zip(axes.ravel(), activities, strict=False):
+            panel = (
+                activity_series
+                .filter(pl.col("label") == activity)
+                .pivot(index="time_label", on="source", values="n_persons", aggregate_function="sum")
+                .sort("time_label")
+                .fill_null(0.0)
+                .to_pandas()
+                .set_index("time_label")
+                .reindex(time_labels, fill_value=0.0)
+            )
+            for source in ["Survey", "Model"]:
+                if source in panel:
+                    axis.plot(
+                        np.arange(len(time_labels)),
+                        panel[source].to_numpy(),
+                        color=colors[source],
+                        linewidth=1.8,
+                        label=source,
+                    )
+            axis.set_title(activity, fontsize=12)
+            axis.set_xticks(tick_positions, tick_labels, rotation=0)
+            axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=0.8)
+            axis.grid(axis="x", visible=False)
+            axis.set_facecolor(MOBILITY_COLORS["background"])
+
+        for axis in axes.ravel()[len(activities):]:
+            axis.set_axis_off()
+
+        handles, legend_labels = axes[0][0].get_legend_handles_labels()
+        fig.legend(
+            handles,
+            legend_labels,
+            loc="lower left",
+            bbox_to_anchor=(0.06, 0.02),
+            ncol=2,
+            frameon=False,
+        )
+        fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+        fig.subplots_adjust(
+            left=0.07,
+            right=0.98,
+            top=0.92,
+            bottom=0.18,
+            hspace=0.35,
+            wspace=0.12,
+        )
+        fig.savefig(output_path, format="svg")
+        plt.close(fig)
 
     @staticmethod
     def _activity_time_series_color_map(labels: list[str]) -> dict[str, str]:
@@ -607,11 +1332,15 @@ class RunMetrics:
             "shopping": "#E88AF2",
             "other": "#B8E986",
             "leisure": "#FF5C8A",
-            "in_transit:car": "#00C389",
-            "in_transit:walk": "#FFA15A",
-            "in_transit:bicycle": "#EF553B",
-            "in_transit:other": "#AB63FA",
-            "in_transit:walk/public_transport/walk": "#19D3F3",
+            "in_transit:car": "#4D4D4D",
+            "in_transit:carpool": "#8C8C8C",
+            "in_transit:walk": "#5F7F73",
+            "in_transit:bicycle": "#0B5A66",
+            "in_transit:public_transport": "#EF4B3E",
+            "in_transit:car/public_transport/walk": "#EF4B3E",
+            "in_transit:bicycle/public_transport/walk": "#D7191C",
+            "in_transit:walk/public_transport/walk": "#F06A5A",
+            "in_transit:other": "#7E6F9A",
         }
         fallback_palette = (
             px.colors.qualitative.Safe
@@ -862,6 +1591,2848 @@ class RunMetrics:
 
     def cost_per_person(self, *args, **kwargs):
         return self.metric_per_person("cost", *args, **kwargs)
+
+    def modal_share_evolution_by_iteration(
+        self,
+        iterations: list[int] | range | None = None,
+        modes: list[str] | None = None,
+        aggregate_public_transport: bool = True,
+        inner_zones_only: bool = False,
+        chart_type: Literal["stacked_bar", "line"] = "stacked_bar",
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        output_path: str | Path | None = None,
+        width: int = 980,
+        height: int = 560,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Plot modal-share evolution as stacked bars over saved iterations."""
+        iterations = self._modal_share_evolution_iterations(iterations)
+        if modes is not None and not modes:
+            raise ValueError("modes should contain at least one mode.")
+        if chart_type not in {"stacked_bar", "line"}:
+            raise ValueError("chart_type should be one of: stacked_bar, line.")
+
+        evolution = self._modal_share_evolution_table(
+            iterations=iterations,
+            modes=modes,
+            aggregate_public_transport=aggregate_public_transport,
+            inner_zones_only=inner_zones_only,
+        )
+
+        fig = None
+        if plot or save_to_file or output_path is not None or return_figure:
+            fig = self._plot_modal_share_evolution(
+                evolution,
+                width=width,
+                height=height,
+                chart_type=chart_type,
+            )
+
+        if save_to_file or output_path is not None:
+            svg_path = (
+                Path(output_path)
+                if output_path is not None
+                else self._svg_report_path(f"{self.results.period}-modal-share-evolution-by-iteration")
+            )
+            self._save_modal_share_evolution_svg(
+                evolution,
+                output_path=svg_path,
+                width=width,
+                height=height,
+                chart_type=chart_type,
+            )
+
+        if plot and fig is not None:
+            fig.show(plot_method)
+
+        if return_figure:
+            return evolution, fig
+        return evolution
+
+    def modal_share_delta_evolution_by_iteration(
+        self,
+        compare_with: Any,
+        iterations: list[int] | range | None = None,
+        modes: list[str] | None = None,
+        aggregate_public_transport: bool = True,
+        inner_zones_only: bool = False,
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        output_path: str | Path | None = None,
+        width: int = 980,
+        height: int = 560,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Plot modal-share deltas over iterations against another scenario."""
+        iterations = self._modal_share_evolution_iterations(iterations)
+        if modes is not None and not modes:
+            raise ValueError("modes should contain at least one mode.")
+
+        reference_run = self._resolve_comparison_run(compare_with)
+        reference_demand_groups = self._resolve_comparison_demand_groups(
+            compare_with=compare_with,
+            reference_run=reference_run,
+        )
+        current_raw = self._modal_share_evolution_raw_table(
+            iterations=iterations,
+            run=self.results.run,
+            demand_groups=self.results.demand_groups,
+            aggregate_public_transport=aggregate_public_transport,
+            inner_zones_only=inner_zones_only,
+        )
+        reference_raw = self._modal_share_evolution_raw_table(
+            iterations=iterations,
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            aggregate_public_transport=aggregate_public_transport,
+            inner_zones_only=inner_zones_only,
+        )
+        if modes is None:
+            modes = self._ordered_modes(
+                list(dict.fromkeys(current_raw["mode"].to_list() + reference_raw["mode"].to_list()))
+            )
+        else:
+            modes = [
+                self._modal_share_mode_key(
+                    mode,
+                    aggregate_public_transport=aggregate_public_transport,
+                )
+                for mode in modes
+            ]
+            modes = self._ordered_modes(list(dict.fromkeys(modes)))
+
+        current = self._complete_modal_share_evolution_table(
+            current_raw,
+            iterations=iterations,
+            modes=modes,
+        )
+        reference = self._complete_modal_share_evolution_table(
+            reference_raw,
+            iterations=iterations,
+            modes=modes,
+        )
+        delta = (
+            current
+            .join(
+                reference.rename(
+                    {
+                        "n_trips": "n_trips_reference",
+                        "modal_share": "modal_share_reference",
+                    }
+                ),
+                on=["iteration", "mode", "mode_label"],
+                how="inner",
+            )
+            .with_columns(
+                n_trips_delta=pl.col("n_trips") - pl.col("n_trips_reference"),
+                modal_share_delta=pl.col("modal_share") - pl.col("modal_share_reference"),
+            )
+            .select(
+                [
+                    "iteration",
+                    "mode",
+                    "mode_label",
+                    "n_trips",
+                    "n_trips_reference",
+                    "n_trips_delta",
+                    "modal_share",
+                    "modal_share_reference",
+                    "modal_share_delta",
+                ]
+            )
+        )
+
+        fig = None
+        if plot or save_to_file or output_path is not None or return_figure:
+            fig = self._plot_modal_share_delta_evolution(
+                delta,
+                width=width,
+                height=height,
+            )
+
+        if save_to_file or output_path is not None:
+            svg_path = (
+                Path(output_path)
+                if output_path is not None
+                else self._svg_report_path(f"{self.results.period}-modal-share-delta-evolution-by-iteration")
+            )
+            self._save_modal_share_delta_evolution_svg(
+                delta,
+                output_path=svg_path,
+                width=width,
+                height=height,
+            )
+
+        if plot and fig is not None:
+            fig.show(plot_method)
+
+        if return_figure:
+            return delta, fig
+        return delta
+
+    def _modal_share_evolution_iterations(
+        self,
+        iterations: list[int] | range | None,
+    ) -> list[int]:
+        """Return the iterations used by modal-share evolution plots."""
+        if iterations is None:
+            n_iterations = getattr(self.results.parameters, "n_iterations", None)
+            if n_iterations is None:
+                raise ValueError(
+                    "iterations should be provided when results.parameters has no n_iterations."
+                )
+            iterations = range(1, int(n_iterations) + 1)
+
+        iterations = [int(iteration) for iteration in iterations]
+        if not iterations:
+            raise ValueError("iterations should contain at least one iteration.")
+        if any(iteration < 1 for iteration in iterations):
+            raise ValueError("iterations should be greater than or equal to 1.")
+        return iterations
+
+    def _modal_share_evolution_table(
+        self,
+        *,
+        iterations: list[int],
+        modes: list[str] | None,
+        aggregate_public_transport: bool,
+        inner_zones_only: bool,
+    ) -> pl.DataFrame:
+        """Return one modal-share row per iteration and mode."""
+        modal_share = self._modal_share_evolution_raw_table(
+            iterations=iterations,
+            run=self.results.run,
+            demand_groups=self.results.demand_groups,
+            aggregate_public_transport=aggregate_public_transport,
+            inner_zones_only=inner_zones_only,
+        )
+        if modes is None:
+            modes = self._ordered_modes(modal_share["mode"].unique().to_list())
+        else:
+            modes = [
+                self._modal_share_mode_key(mode, aggregate_public_transport=aggregate_public_transport)
+                for mode in modes
+            ]
+            modes = self._ordered_modes(list(dict.fromkeys(modes)))
+
+        return self._complete_modal_share_evolution_table(
+            modal_share,
+            iterations=iterations,
+            modes=modes,
+        )
+
+    def _modal_share_evolution_raw_table(
+        self,
+        *,
+        iterations: list[int],
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        aggregate_public_transport: bool,
+        inner_zones_only: bool,
+    ) -> pl.DataFrame:
+        """Return observed modal shares without adding missing mode rows."""
+        iteration_tables = [
+            self._modal_share_for_iteration(
+                iteration,
+                run=run,
+                demand_groups=demand_groups,
+                aggregate_public_transport=aggregate_public_transport,
+                inner_zones_only=inner_zones_only,
+            ).with_columns(iteration=pl.lit(iteration))
+            for iteration in iterations
+        ]
+        return pl.concat(iteration_tables, how="vertical_relaxed")
+
+    def _complete_modal_share_evolution_table(
+        self,
+        modal_share: pl.DataFrame,
+        *,
+        iterations: list[int],
+        modes: list[str],
+    ) -> pl.DataFrame:
+        """Add missing iteration-mode rows with zero shares."""
+        iteration_mode_grid = pl.DataFrame(
+            {
+                "iteration": [
+                    iteration
+                    for iteration in iterations
+                    for _mode in modes
+                ],
+                "mode": [
+                    mode
+                    for _iteration in iterations
+                    for mode in modes
+                ],
+                "mode_order": [
+                    mode_order
+                    for _iteration in iterations
+                    for mode_order, _mode in enumerate(modes)
+                ],
+            }
+        )
+        return (
+            iteration_mode_grid
+            .join(modal_share, on=["iteration", "mode"], how="left")
+            .with_columns(
+                pl.col("n_trips").fill_null(0.0),
+                pl.col("modal_share").fill_null(0.0),
+                mode_label=pl.col("mode").map_elements(
+                    self._mode_label,
+                    return_dtype=pl.String,
+                ),
+            )
+            .sort(["iteration", "mode_order"])
+            .select(["iteration", "mode", "mode_label", "n_trips", "modal_share"])
+        )
+
+    def _modal_share_for_iteration(
+        self,
+        iteration: int,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        aggregate_public_transport: bool,
+        inner_zones_only: bool,
+    ) -> pl.DataFrame:
+        """Compute modal shares over mobile trips in one saved iteration."""
+        plan_steps = self._saved_iteration_plan_steps(run, iteration).lazy()
+        if inner_zones_only:
+            plan_steps = self._join_home_zone(plan_steps, demand_groups)
+
+        required_columns = {"activity_seq_id", "mode", "n_persons"}
+        if inner_zones_only:
+            required_columns.add("home_zone_id")
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration plan steps are missing: {missing}.")
+
+        mobile_steps = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .with_columns(pl.col("mode").cast(pl.String))
+        )
+        if inner_zones_only:
+            mobile_steps = mobile_steps.filter(
+                pl.col("home_zone_id").is_in(self._inner_transport_zone_ids())
+            )
+        if aggregate_public_transport:
+            mobile_steps = mobile_steps.with_columns(
+                mode=pl.when(pl.col("mode").str.contains("public_transport"))
+                .then(pl.lit("public_transport"))
+                .otherwise(pl.col("mode"))
+            )
+
+        return (
+            mobile_steps
+            .group_by("mode")
+            .agg(n_trips=pl.col("n_persons").sum())
+            .with_columns(total_trips=pl.col("n_trips").sum())
+            .with_columns(
+                modal_share=pl.when(pl.col("total_trips") > 0.0)
+                .then(pl.col("n_trips") / pl.col("total_trips"))
+                .otherwise(0.0)
+            )
+            .select(["mode", "n_trips", "modal_share"])
+            .collect(engine="streaming")
+        )
+
+    def _plot_modal_share_evolution(
+        self,
+        modal_share: pl.DataFrame,
+        *,
+        width: int,
+        height: int,
+        chart_type: Literal["stacked_bar", "line"],
+    ) -> go.Figure:
+        """Render a modal-share evolution chart."""
+        mode_labels = modal_share["mode_label"].unique(maintain_order=True).to_list()
+        color_map = self._mode_label_color_map(mode_labels)
+        figure_kwargs = {
+            "data_frame": modal_share.to_pandas(),
+            "x": "iteration",
+            "y": "modal_share",
+            "color": "mode_label",
+            "color_discrete_map": color_map,
+            "category_orders": {"mode_label": mode_labels},
+            "labels": {
+                "iteration": "Iteration",
+                "modal_share": "Modal share",
+                "mode_label": "Mode",
+            },
+            "width": width,
+            "height": height,
+        }
+        if chart_type == "line":
+            fig = px.line(**figure_kwargs, markers=True)
+        else:
+            fig = px.bar(**figure_kwargs)
+        apply_report_layout(fig)
+        fig.update_layout(
+            title_text=None,
+            xaxis_title="Iteration",
+            yaxis_title="Modal share",
+            legend_title_text=None,
+            margin={"l": 65, "r": 20, "t": 35, "b": 95},
+        )
+        if chart_type == "stacked_bar":
+            fig.update_layout(barmode="stack")
+        fig.update_xaxes(dtick=1, showgrid=False, zeroline=False)
+        fig.update_yaxes(
+            range=[0.0, 1.0],
+            tickformat=".0%",
+            showgrid=True,
+            gridcolor=MOBILITY_COLORS["grid"],
+            zeroline=False,
+        )
+        return fig
+
+    def _plot_modal_share_delta_evolution(
+        self,
+        modal_share_delta: pl.DataFrame,
+        *,
+        width: int,
+        height: int,
+    ) -> go.Figure:
+        """Render modal-share deltas over iterations as a line chart."""
+        mode_labels = modal_share_delta["mode_label"].unique(maintain_order=True).to_list()
+        color_map = self._mode_label_color_map(mode_labels)
+        fig = px.line(
+            modal_share_delta.to_pandas(),
+            x="iteration",
+            y="modal_share_delta",
+            color="mode_label",
+            markers=True,
+            color_discrete_map=color_map,
+            category_orders={"mode_label": mode_labels},
+            labels={
+                "iteration": "Iteration",
+                "modal_share_delta": "Modal share difference",
+                "mode_label": "Mode",
+            },
+            width=width,
+            height=height,
+        )
+        apply_report_layout(fig)
+        fig.update_layout(
+            title_text=None,
+            xaxis_title="Iteration",
+            yaxis_title="Modal share difference",
+            legend_title_text=None,
+            margin={"l": 65, "r": 20, "t": 35, "b": 95},
+        )
+        fig.update_xaxes(dtick=1, showgrid=False, zeroline=False)
+        fig.update_yaxes(
+            tickformat=".1%",
+            showgrid=True,
+            gridcolor=MOBILITY_COLORS["grid"],
+            zeroline=True,
+            zerolinecolor=MOBILITY_COLORS["label"],
+            zerolinewidth=1,
+        )
+        fig.add_hline(
+            y=0.0,
+            line_color=MOBILITY_COLORS["label"],
+            line_width=1,
+        )
+        return fig
+
+    def _save_modal_share_evolution_svg(
+        self,
+        modal_share: pl.DataFrame,
+        *,
+        output_path: Path,
+        width: int,
+        height: int,
+        chart_type: Literal["stacked_bar", "line"],
+    ) -> None:
+        """Save a modal-share evolution chart as SVG."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        share_df = modal_share.to_pandas()
+        iterations = sorted(share_df["iteration"].unique().tolist())
+        mode_labels = share_df["mode_label"].drop_duplicates().tolist()
+        color_map = self._mode_label_color_map(mode_labels)
+        pivot = (
+            share_df
+            .pivot_table(
+                index="iteration",
+                columns="mode_label",
+                values="modal_share",
+                aggfunc="sum",
+                fill_value=0.0,
+            )
+            .reindex(iterations, fill_value=0.0)
+        )
+
+        fig, axis = plt.subplots(figsize=(width / 100.0, height / 100.0))
+        x = np.arange(len(iterations))
+        if chart_type == "line":
+            for mode_label in mode_labels:
+                values = (
+                    pivot[mode_label].to_numpy()
+                    if mode_label in pivot
+                    else np.zeros(len(iterations))
+                )
+                axis.plot(
+                    x,
+                    values,
+                    color=color_map[mode_label],
+                    label=mode_label,
+                    linewidth=1.9,
+                    marker="o",
+                    markersize=4.0,
+                )
+        else:
+            bottom = np.zeros(len(iterations))
+            for mode_label in mode_labels:
+                values = (
+                    pivot[mode_label].to_numpy()
+                    if mode_label in pivot
+                    else np.zeros(len(iterations))
+                )
+                axis.bar(
+                    x,
+                    values,
+                    bottom=bottom,
+                    color=color_map[mode_label],
+                    label=mode_label,
+                    width=0.75,
+                )
+                bottom += values
+
+        axis.set_ylim(0.0, 1.0)
+        axis.set_ylabel("Modal share")
+        axis.set_xlabel("Iteration")
+        axis.set_xticks(x, [str(iteration) for iteration in iterations])
+        tick_values = np.linspace(0.0, 1.0, 6)
+        axis.set_yticks(tick_values, [f"{int(value * 100)}%" for value in tick_values])
+        axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=0.8)
+        axis.grid(axis="x", visible=False)
+        axis.set_facecolor(MOBILITY_COLORS["background"])
+        axis.legend(
+            loc="lower left",
+            bbox_to_anchor=(0.0, -0.23),
+            ncol=min(4, max(1, len(mode_labels))),
+            frameon=False,
+        )
+        fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+        fig.subplots_adjust(left=0.08, right=0.98, top=0.94, bottom=0.24)
+        fig.savefig(output_path, format="svg")
+        plt.close(fig)
+
+    def _save_modal_share_delta_evolution_svg(
+        self,
+        modal_share_delta: pl.DataFrame,
+        *,
+        output_path: Path,
+        width: int,
+        height: int,
+    ) -> None:
+        """Save a modal-share-delta line chart as SVG."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        delta_df = modal_share_delta.to_pandas()
+        iterations = sorted(delta_df["iteration"].unique().tolist())
+        mode_labels = delta_df["mode_label"].drop_duplicates().tolist()
+        color_map = self._mode_label_color_map(mode_labels)
+        pivot = (
+            delta_df
+            .pivot_table(
+                index="iteration",
+                columns="mode_label",
+                values="modal_share_delta",
+                aggfunc="sum",
+                fill_value=0.0,
+            )
+            .reindex(iterations, fill_value=0.0)
+        )
+
+        fig, axis = plt.subplots(figsize=(width / 100.0, height / 100.0))
+        x = np.arange(len(iterations))
+        for mode_label in mode_labels:
+            values = (
+                pivot[mode_label].to_numpy()
+                if mode_label in pivot
+                else np.zeros(len(iterations))
+            )
+            axis.plot(
+                x,
+                values,
+                color=color_map[mode_label],
+                label=mode_label,
+                linewidth=1.9,
+                marker="o",
+                markersize=4.0,
+            )
+
+        axis.axhline(0.0, color=MOBILITY_COLORS["label"], linewidth=1.0)
+        axis.set_ylabel("Modal share difference")
+        axis.set_xlabel("Iteration")
+        axis.set_xticks(x, [str(iteration) for iteration in iterations])
+        axis.yaxis.set_major_formatter(mticker.PercentFormatter(xmax=1.0))
+        axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=0.8)
+        axis.grid(axis="x", visible=False)
+        axis.set_facecolor(MOBILITY_COLORS["background"])
+        axis.legend(
+            loc="lower left",
+            bbox_to_anchor=(0.0, -0.23),
+            ncol=min(4, max(1, len(mode_labels))),
+            frameon=False,
+        )
+        fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+        fig.subplots_adjust(left=0.08, right=0.98, top=0.94, bottom=0.24)
+        fig.savefig(output_path, format="svg")
+        plt.close(fig)
+
+    def plot_delta_by_iteration(
+        self,
+        compare_with: Any | None,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str = "car",
+        zone: Literal["home", "origin", "destination"] = "home",
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        inner_zones_only: bool = False,
+        relative_delta: bool = False,
+        paired_runs: list[tuple[Any, Any]] | None = None,
+        color_range: float | tuple[float, float] | None = None,
+        auto_cap_outliers: bool = False,
+        outlier_quantile: float = 0.98,
+        labels: bool = True,
+        width: int = 1200,
+        height: int = 850,
+        max_labels: int = 30,
+        simplify_tolerance: float | None = 50.0,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Plot a transport-zone delta map for one saved iteration."""
+        if iteration < 1:
+            raise ValueError("iteration must be greater than or equal to 1.")
+        if zone not in {"home", "origin", "destination"}:
+            raise ValueError("zone should be one of: home, origin, destination.")
+        if value not in {"modal_share", "n_trips", "mean_utility", "ghg_emissions"}:
+            raise ValueError(
+                "value should be one of: modal_share, n_trips, mean_utility, ghg_emissions."
+            )
+        if value == "mean_utility" and zone != "home":
+            raise ValueError("mean_utility can only be mapped by home zone.")
+        if value == "modal_share" and relative_delta:
+            raise ValueError("relative_delta=True is not available for modal_share.")
+        if not 0.0 < outlier_quantile <= 1.0:
+            raise ValueError("outlier_quantile should be greater than 0 and at most 1.")
+
+        if paired_runs is None:
+            if compare_with is None:
+                raise ValueError("compare_with should be provided when paired_runs is not used.")
+            reference_run = self._resolve_comparison_run(compare_with)
+            reference_demand_groups = self._resolve_comparison_demand_groups(
+                compare_with=compare_with,
+                reference_run=reference_run,
+            )
+            current_costs = self.results.costs if value == "ghg_emissions" else pl.DataFrame()
+            reference_costs = (
+                self._resolve_comparison_costs(
+                    compare_with=compare_with,
+                    reference_run=reference_run,
+                )
+                if value == "ghg_emissions"
+                else pl.DataFrame()
+            )
+            delta = self._delta_value_by_iteration(
+                reference_run=reference_run,
+                reference_demand_groups=reference_demand_groups,
+                current_costs=current_costs,
+                reference_costs=reference_costs,
+                iteration=iteration,
+                value=value,
+                mode=mode,
+                zone=zone,
+                relative_delta=relative_delta,
+            )
+            global_delta = None
+        else:
+            delta, global_delta = self._paired_delta_by_iteration(
+                paired_runs=paired_runs,
+                iteration=iteration,
+                value=value,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+                relative_delta=relative_delta,
+            )
+        value_settings = self._plot_delta_value_settings(
+            value=value,
+            mode=mode,
+            relative_delta=relative_delta,
+        )
+
+        fig = None
+        if plot or save_to_file or return_figure:
+            if global_delta is None:
+                global_delta = self._global_plot_delta_by_iteration(
+                    reference_run=reference_run,
+                    reference_demand_groups=reference_demand_groups,
+                    current_costs=current_costs,
+                    reference_costs=reference_costs,
+                    iteration=iteration,
+                    value=value,
+                    mode=mode,
+                    zone=zone,
+                    inner_zones_only=inner_zones_only,
+                    relative_delta=relative_delta,
+                )
+            range_color = self._modal_share_delta_color_range(
+                delta,
+                self._automatic_delta_color_range(
+                    delta,
+                    color_range=color_range,
+                    auto_cap_outliers=auto_cap_outliers,
+                    outlier_quantile=outlier_quantile,
+                ),
+                value_column="value_delta",
+            )
+            fig = TransportZoneMaps(
+                self.results.transport_zones,
+                population=getattr(self.results.run, "population", None),
+                max_labels=max_labels,
+                simplify_tolerance=simplify_tolerance,
+            ).metric(
+                delta,
+                value_column="value_delta",
+                save_name=(
+                    f"{self.results.period}-{value_settings['save_name']}"
+                    f"-iteration-{iteration}-map"
+                ),
+                save_to_file=save_to_file,
+                inner_zones_only=inner_zones_only,
+                labels=labels,
+                width=width,
+                height=height,
+                hover_columns=[
+                    column
+                    for column in ["value", "value_reference", "value_delta_std", "n_pairs"]
+                    if column in delta.columns
+                ],
+                legend_label=value_settings["legend_label"],
+                frame_title=self._plot_delta_frame_title(
+                    iteration=iteration,
+                    global_delta=global_delta,
+                    value=value,
+                    relative_delta=relative_delta,
+                ),
+                classify=False,
+                color_continuous_scale=[
+                    [0.0, "#44546A"],
+                    [0.5, "#FFFFFF"],
+                    [1.0, "#D71A1C"],
+                ],
+                color_continuous_midpoint=0.0,
+                range_color=range_color,
+                colorbar_tickformat=value_settings["colorbar_tickformat"],
+            )
+            if plot:
+                fig.show(plot_method)
+
+        if return_figure:
+            return delta, fig
+        return delta
+
+    def _delta_value_by_iteration(
+        self,
+        *,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        current_costs: pl.DataFrame | pl.LazyFrame,
+        reference_costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        relative_delta: bool,
+    ) -> pl.DataFrame:
+        """Return current, reference and delta values by transport zone."""
+        return self._delta_value_between_runs_by_iteration(
+            current_run=self.results.run,
+            current_demand_groups=self.results.demand_groups,
+            reference_run=reference_run,
+            reference_demand_groups=reference_demand_groups,
+            current_costs=current_costs,
+            reference_costs=reference_costs,
+            iteration=iteration,
+            value=value,
+            mode=mode,
+            zone=zone,
+            relative_delta=relative_delta,
+        )
+
+    def _delta_value_between_runs_by_iteration(
+        self,
+        *,
+        current_run: Any,
+        current_demand_groups: pl.DataFrame | pl.LazyFrame,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        current_costs: pl.DataFrame | pl.LazyFrame,
+        reference_costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        relative_delta: bool,
+    ) -> pl.DataFrame:
+        """Return current, reference and delta values between two run contexts."""
+        current = self._value_by_zone_for_saved_iteration(
+            run=current_run,
+            demand_groups=current_demand_groups,
+            costs=current_costs,
+            iteration=iteration,
+            value=value,
+            mode=mode,
+            zone=zone,
+        )
+        reference = self._value_by_zone_for_saved_iteration(
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            costs=reference_costs,
+            iteration=iteration,
+            value=value,
+            mode=mode,
+            zone=zone,
+        )
+
+        return (
+            self._transport_zone_ids()
+            .join(current, on="transport_zone_id", how="left")
+            .join(
+                reference.rename({"value": "value_reference"}),
+                on="transport_zone_id",
+                how="left",
+            )
+            .with_columns(
+                pl.col("value").fill_null(0.0),
+                pl.col("value_reference").fill_null(0.0),
+            )
+            .with_columns(
+                value_delta=self._plot_delta_expression(relative_delta=relative_delta),
+                value_name=pl.lit(value),
+            )
+            .sort("transport_zone_id")
+        )
+
+    def _value_by_zone_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+    ) -> pl.DataFrame:
+        """Compute one selected value by transport zone for a saved iteration."""
+        if value in {"modal_share", "n_trips"}:
+            column = "modal_share" if value == "modal_share" else "n_trips"
+            return self._modal_share_for_saved_iteration(
+                run=run,
+                demand_groups=demand_groups,
+                iteration=iteration,
+                zone=zone,
+                mode=mode,
+            ).select(["transport_zone_id", pl.col(column).alias("value")])
+        if value == "mean_utility":
+            return self._mean_utility_by_home_zone_for_saved_iteration(
+                run=run,
+                demand_groups=demand_groups,
+                iteration=iteration,
+            )
+        return self._ghg_emissions_by_zone_for_saved_iteration(
+            run=run,
+            demand_groups=demand_groups,
+            costs=costs,
+            iteration=iteration,
+            zone=zone,
+        )
+
+    def _metric_by_zone_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        quantity: Literal["trip_count", "distance", "travel_time", "modal_share"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+    ) -> pl.DataFrame:
+        """Compute one plotted metric by transport zone for a saved iteration."""
+        if quantity == "modal_share":
+            return (
+                self._transport_zone_ids()
+                .join(
+                    self._modal_share_for_saved_iteration(
+                        run=run,
+                        demand_groups=demand_groups,
+                        iteration=iteration,
+                        zone=zone,
+                        mode=mode,
+                    ),
+                    on="transport_zone_id",
+                    how="left",
+                )
+                .with_columns(
+                    pl.col("modal_share").fill_null(0.0),
+                    pl.col("n_trips").fill_null(0.0),
+                    mode=pl.lit(mode),
+                    quantity=pl.lit(quantity),
+                )
+                .rename({"modal_share": "value"})
+                .select(["transport_zone_id", "value", "n_trips", "mode", "quantity"])
+                .sort("transport_zone_id")
+            )
+
+        return self._average_trip_metric_by_home_zone_for_saved_iteration(
+            run=run,
+            demand_groups=demand_groups,
+            iteration=iteration,
+            quantity=quantity,
+        )
+
+    def _average_trip_metric_by_home_zone_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        quantity: Literal["trip_count", "distance", "travel_time"],
+    ) -> pl.DataFrame:
+        """Compute a trip metric average per resident by home transport zone."""
+        plan_steps = self._saved_iteration_plan_steps(run, iteration).lazy()
+        plan_steps = self._join_home_zone(plan_steps, demand_groups)
+        schema_names = plan_steps.collect_schema().names()
+        metric_column = self._saved_iteration_metric_column(quantity, schema_names)
+
+        required_columns = {"activity_seq_id", "home_zone_id", "n_persons", metric_column}
+        missing_columns = required_columns.difference(schema_names)
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration plan steps are missing: {missing}.")
+
+        if quantity == "trip_count":
+            total_expr = pl.col("n_persons").sum()
+        else:
+            total_expr = (pl.col(metric_column).fill_null(0.0) * pl.col("n_persons")).sum()
+
+        totals_by_zone = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by("home_zone_id")
+            .agg(total=total_expr)
+            .rename({"home_zone_id": "transport_zone_id"})
+        )
+        population_by_zone = self._population_by_home_zone(demand_groups)
+
+        return (
+            self._transport_zone_ids()
+            .lazy()
+            .join(totals_by_zone, on="transport_zone_id", how="left")
+            .join(population_by_zone, on="transport_zone_id", how="left")
+            .with_columns(
+                pl.col("total").fill_null(0.0),
+                pl.col("population").fill_null(0.0),
+            )
+            .with_columns(
+                value=pl.when(pl.col("population") > 0.0)
+                .then(pl.col("total") / pl.col("population"))
+                .otherwise(0.0),
+                quantity=pl.lit(quantity),
+            )
+            .select(["transport_zone_id", "value", "total", "population", "quantity"])
+            .sort("transport_zone_id")
+            .collect(engine="streaming")
+        )
+
+    @staticmethod
+    def _saved_iteration_metric_column(
+        quantity: Literal["trip_count", "distance", "travel_time"],
+        schema_names: list[str],
+    ) -> str:
+        """Return the saved plan-step column used for one plotted quantity."""
+        if quantity == "trip_count":
+            return "n_persons"
+        if quantity == "travel_time" and "time" in schema_names:
+            return "time"
+        return quantity
+
+    @staticmethod
+    def _plot_delta_expression(*, relative_delta: bool) -> pl.Expr:
+        """Return the map delta expression."""
+        absolute_delta = pl.col("value") - pl.col("value_reference")
+        if relative_delta:
+            return (
+                pl.when(pl.col("value_reference") != 0.0)
+                .then(absolute_delta / pl.col("value_reference"))
+                .otherwise(0.0)
+            )
+        return absolute_delta
+
+    @staticmethod
+    def _automatic_delta_color_range(
+        delta: pl.DataFrame,
+        *,
+        color_range: float | tuple[float, float] | None,
+        auto_cap_outliers: bool,
+        outlier_quantile: float,
+    ) -> float | tuple[float, float] | None:
+        """Return an optional symmetric color cap for a delta map."""
+        if color_range is not None or not auto_cap_outliers:
+            return color_range
+
+        cap = (
+            delta
+            .select(pl.col("value_delta").abs().quantile(outlier_quantile))
+            .item()
+        )
+        if cap is None or cap <= 0.0:
+            return None
+        return float(cap)
+
+    def _mean_utility_by_home_zone_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+    ) -> pl.DataFrame:
+        """Compute weighted mean plan utility by home transport zone."""
+        current_plans = self._saved_iteration_state(run, iteration).current_plans.lazy()
+        current_plans = self._join_home_zone(current_plans, demand_groups)
+        required_columns = {"home_zone_id", "utility", "n_persons"}
+        missing_columns = required_columns.difference(current_plans.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration current plans are missing: {missing}.")
+
+        return (
+            current_plans
+            .group_by("home_zone_id")
+            .agg(
+                weighted_utility=(pl.col("utility") * pl.col("n_persons")).sum(),
+                n_persons=pl.col("n_persons").sum(),
+            )
+            .with_columns(
+                value=pl.when(pl.col("n_persons") > 0.0)
+                .then(pl.col("weighted_utility") / pl.col("n_persons"))
+                .otherwise(0.0)
+            )
+            .rename({"home_zone_id": "transport_zone_id"})
+            .select(["transport_zone_id", "value"])
+            .collect(engine="streaming")
+        )
+
+    def _ghg_emissions_by_zone_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        zone: Literal["home", "origin", "destination"],
+    ) -> pl.DataFrame:
+        """Compute total weighted GHG emissions by transport zone."""
+        plan_steps = self._saved_iteration_plan_steps(run, iteration).lazy()
+        if zone == "home":
+            plan_steps = self._join_home_zone(plan_steps, demand_groups)
+            zone_column = "home_zone_id"
+        elif zone == "origin":
+            zone_column = "from"
+        else:
+            zone_column = "to"
+
+        required_columns = {"activity_seq_id", zone_column, "from", "to", "mode", "n_persons"}
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration plan steps are missing: {missing}.")
+
+        costs_lazy = costs.lazy() if isinstance(costs, pl.DataFrame) else costs
+        cost_columns = set(costs_lazy.collect_schema().names())
+        missing_cost_columns = {"from", "to", "mode", "ghg_emissions_per_trip"}.difference(cost_columns)
+        if missing_cost_columns:
+            missing = ", ".join(sorted(missing_cost_columns))
+            raise ValueError(f"Costs are missing: {missing}.")
+
+        emissions_by_zone = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .with_columns(pl.col("mode").cast(pl.String))
+            .join(
+                costs_lazy
+                .select(["from", "to", "mode", "ghg_emissions_per_trip"])
+                .with_columns(pl.col("mode").cast(pl.String)),
+                on=["from", "to", "mode"],
+                how="left",
+            )
+            .with_columns(pl.col("ghg_emissions_per_trip").fill_null(0.0))
+            .group_by(zone_column)
+            .agg(total_emissions=(pl.col("ghg_emissions_per_trip") * pl.col("n_persons")).sum())
+            .rename({zone_column: "transport_zone_id"})
+        )
+        population_by_zone = self._population_by_home_zone(demand_groups)
+        return (
+            emissions_by_zone
+            .join(population_by_zone, on="transport_zone_id", how="left")
+            .with_columns(pl.col("population").fill_null(0.0))
+            .with_columns(
+                value=pl.when(pl.col("population") > 0.0)
+                .then(pl.col("total_emissions") / pl.col("population"))
+                .otherwise(0.0)
+            )
+            .select(["transport_zone_id", "value"])
+            .collect(engine="streaming")
+        )
+
+    def _population_by_home_zone(
+        self,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Return total resident population by home transport zone."""
+        demand_groups_lazy = demand_groups.lazy() if isinstance(demand_groups, pl.DataFrame) else demand_groups
+        required_columns = {"home_zone_id", "n_persons"}
+        missing_columns = required_columns.difference(demand_groups_lazy.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Demand groups are missing: {missing}.")
+
+        return (
+            demand_groups_lazy
+            .group_by("home_zone_id")
+            .agg(population=pl.col("n_persons").sum())
+            .rename({"home_zone_id": "transport_zone_id"})
+        )
+
+    def _global_plot_delta_by_iteration(
+        self,
+        *,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        current_costs: pl.DataFrame | pl.LazyFrame,
+        reference_costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+        relative_delta: bool,
+    ) -> float:
+        """Return the global delta shown on a generic delta map."""
+        return self._global_plot_delta_between_runs_by_iteration(
+            current_run=self.results.run,
+            current_demand_groups=self.results.demand_groups,
+            reference_run=reference_run,
+            reference_demand_groups=reference_demand_groups,
+            current_costs=current_costs,
+            reference_costs=reference_costs,
+            iteration=iteration,
+            value=value,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+            relative_delta=relative_delta,
+        )
+
+    def _global_plot_delta_between_runs_by_iteration(
+        self,
+        *,
+        current_run: Any,
+        current_demand_groups: pl.DataFrame | pl.LazyFrame,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        current_costs: pl.DataFrame | pl.LazyFrame,
+        reference_costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+        relative_delta: bool,
+    ) -> float:
+        """Return a global delta between two run contexts."""
+        if value in {"modal_share", "n_trips"}:
+            value_type = "modal_share_delta" if value == "modal_share" else "n_trips_delta"
+            absolute_delta = self._global_delta_between_runs_by_iteration(
+                current_run=current_run,
+                current_demand_groups=current_demand_groups,
+                reference_run=reference_run,
+                reference_demand_groups=reference_demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+                value_type=value_type,
+            )
+            if not relative_delta:
+                return absolute_delta
+            reference_value = self._global_mode_trip_count_for_saved_iteration(
+                run=reference_run,
+                demand_groups=reference_demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+            )
+            return absolute_delta / reference_value if reference_value != 0.0 else 0.0
+
+        current_value = self._global_value_for_saved_iteration(
+            run=current_run,
+            demand_groups=current_demand_groups,
+            costs=current_costs,
+            iteration=iteration,
+            value=value,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        reference_value = self._global_value_for_saved_iteration(
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            costs=reference_costs,
+            iteration=iteration,
+            value=value,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        absolute_delta = current_value - reference_value
+        if relative_delta:
+            return absolute_delta / reference_value if reference_value != 0.0 else 0.0
+        return absolute_delta
+
+    def _global_value_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        costs: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        value: Literal["mean_utility", "ghg_emissions"],
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Compute a global value for one saved iteration."""
+        if value == "mean_utility":
+            current_plans = self._saved_iteration_state(run, iteration).current_plans.lazy()
+            current_plans = self._join_home_zone(current_plans, demand_groups)
+            required_columns = {"home_zone_id", "utility", "n_persons"}
+            missing_columns = required_columns.difference(current_plans.collect_schema().names())
+            if missing_columns:
+                missing = ", ".join(sorted(missing_columns))
+                raise ValueError(f"Saved iteration current plans are missing: {missing}.")
+            if inner_zones_only:
+                current_plans = current_plans.filter(
+                    pl.col("home_zone_id").is_in(self._inner_transport_zone_ids())
+                )
+            summary = (
+                current_plans
+                .select(
+                    weighted_utility=(pl.col("utility") * pl.col("n_persons")).sum(),
+                    n_persons=pl.col("n_persons").sum(),
+                )
+                .collect(engine="streaming")
+            )
+            n_persons = float(summary["n_persons"][0] or 0.0)
+            if n_persons == 0.0:
+                return 0.0
+            return float(summary["weighted_utility"][0] or 0.0) / n_persons
+
+        emissions_by_zone = self._ghg_emissions_by_zone_for_saved_iteration(
+            run=run,
+            demand_groups=demand_groups,
+            costs=costs,
+            iteration=iteration,
+            zone=zone,
+        )
+        if inner_zones_only:
+            emissions_by_zone = emissions_by_zone.filter(
+                pl.col("transport_zone_id").is_in(self._inner_transport_zone_ids())
+            )
+        population_by_zone = self._population_by_home_zone(demand_groups).collect(engine="streaming")
+        if inner_zones_only:
+            population_by_zone = population_by_zone.filter(
+                pl.col("transport_zone_id").is_in(self._inner_transport_zone_ids())
+            )
+        total_population = float(population_by_zone["population"].sum() or 0.0)
+        if total_population == 0.0:
+            return 0.0
+        total_emissions = (
+            emissions_by_zone
+            .join(population_by_zone, on="transport_zone_id", how="left")
+            .select((pl.col("value") * pl.col("population").fill_null(0.0)).sum())
+            .item()
+            or 0.0
+        )
+        return float(total_emissions) / total_population
+
+    @staticmethod
+    def _plot_delta_value_settings(
+        *,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        relative_delta: bool,
+    ) -> dict[str, str | None]:
+        """Return map settings for a generic delta value."""
+        if value == "modal_share":
+            return {
+                "save_name": f"{RunMetrics._safe_mode_name(mode)}-modal-share-delta",
+                "legend_label": f"{RunMetrics._mode_label(mode)} modal share difference",
+                "colorbar_tickformat": ".0%",
+            }
+        if value == "n_trips":
+            return {
+                "save_name": f"{RunMetrics._safe_mode_name(mode)}-n-trips"
+                f"{'-relative' if relative_delta else ''}-delta",
+                "legend_label": f"{RunMetrics._mode_label(mode)} "
+                f"{'relative ' if relative_delta else ''}trip count difference",
+                "colorbar_tickformat": ".0%" if relative_delta else None,
+            }
+        if value == "mean_utility":
+            return {
+                "save_name": f"mean-utility{'-relative' if relative_delta else ''}-delta",
+                "legend_label": "Relative mean utility difference"
+                if relative_delta
+                else "Mean utility difference",
+                "colorbar_tickformat": ".0%" if relative_delta else None,
+            }
+        return {
+            "save_name": f"ghg-emissions{'-relative' if relative_delta else ''}-delta",
+            "legend_label": (
+                "Relative GHG emissions difference (kgCO2e/person)"
+                if relative_delta
+                else "GHG emissions difference (kgCO2e/person)"
+            ),
+            "colorbar_tickformat": ".0%" if relative_delta else None,
+        }
+
+    def _plot_metric_settings(
+        self,
+        *,
+        quantity: Literal["trip_count", "distance", "travel_time", "modal_share"],
+        mode: str,
+    ) -> dict[str, Any]:
+        """Return map settings for a one-scenario metric."""
+        if quantity == "modal_share":
+            safe_mode_name = self._safe_mode_name(mode)
+            mode_label = self._mode_label(mode)
+            return {
+                "save_name": f"{safe_mode_name}-modal-share",
+                "legend_label": f"{mode_label} modal share",
+                "hover_columns": ["n_trips", "mode"],
+                "colorbar_tickformat": ".0%",
+                "color_continuous_scale": [
+                    [0.0, "#FFFFFF"],
+                    [1.0, self._mode_color(mode)],
+                ],
+            }
+        if quantity == "trip_count":
+            return {
+                "save_name": "average-trip-count",
+                "legend_label": "Average trip count (trips/pers.)",
+                "hover_columns": ["total", "population", "quantity"],
+                "colorbar_tickformat": None,
+                "color_continuous_scale": self._ylorrd_color_scale(),
+            }
+        if quantity == "distance":
+            return {
+                "save_name": "average-travel-distance",
+                "legend_label": "Average travel distance (km/pers.)",
+                "hover_columns": ["total", "population", "quantity"],
+                "colorbar_tickformat": None,
+                "color_continuous_scale": self._ylorrd_color_scale(),
+            }
+        return {
+            "save_name": "average-travel-time",
+            "legend_label": "Average travel time (h/pers.)",
+            "hover_columns": ["total", "population", "quantity"],
+            "colorbar_tickformat": None,
+            "color_continuous_scale": self._ylorrd_color_scale(),
+        }
+
+    def _plot_delta_frame_title(
+        self,
+        *,
+        iteration: int,
+        global_delta: float,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        relative_delta: bool,
+    ) -> str:
+        """Return the top-left text shown on generic delta maps."""
+        scope_label = self._behavior_change_scope_label(iteration)
+        if relative_delta:
+            global_delta_label = f"Global relative delta: {global_delta:+.2%}"
+        elif value == "modal_share":
+            global_delta_label = f"Global delta: {global_delta:+.2%}"
+        elif value == "n_trips":
+            global_delta_label = f"Global delta: {global_delta:+,.0f} trips"
+        elif value == "ghg_emissions":
+            global_delta_label = f"Global delta: {global_delta:+,.2f} kgCO2e/person"
+        else:
+            global_delta_label = f"Global delta: {global_delta:+.3f}"
+        return f"Iteration {iteration}\n{scope_label}\n{global_delta_label}"
+
+    def _plot_metric_frame_title(
+        self,
+        *,
+        iteration: int,
+        global_value: float,
+        quantity: Literal["trip_count", "distance", "travel_time", "modal_share"],
+    ) -> str:
+        """Return the top-left text shown on one-scenario metric maps."""
+        scope_label = self._behavior_change_scope_label(iteration)
+        if quantity == "modal_share":
+            value_label = f"Global share: {global_value:.2%}"
+        elif quantity == "trip_count":
+            value_label = f"Global average: {global_value:.2f} trips/pers."
+        elif quantity == "travel_time":
+            value_label = f"Global average: {global_value:.2f} h/pers."
+        else:
+            value_label = f"Global average: {global_value:.2f} km/pers."
+        return f"Iteration {iteration}\n{scope_label}\n{value_label}"
+
+    def plot_metric_by_iteration(
+        self,
+        iteration: int,
+        quantity: Literal[
+            "trip_count",
+            "distance",
+            "travel_time",
+            "modal_share",
+            "mode_share",
+        ],
+        mode: str = "car",
+        zone: Literal["home", "origin", "destination"] = "home",
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        inner_zones_only: bool = False,
+        color_range: float | tuple[float, float] | None = None,
+        clamp_outliers: bool = False,
+        outlier_quantile: float = 0.98,
+        labels: bool = True,
+        width: int = 1200,
+        height: int = 850,
+        max_labels: int = 30,
+        simplify_tolerance: float | None = 50.0,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Plot one saved-iteration metric by transport zone for this run."""
+        if iteration < 1:
+            raise ValueError("iteration must be greater than or equal to 1.")
+        if quantity == "mode_share":
+            quantity = "modal_share"
+        if quantity not in {"trip_count", "distance", "travel_time", "modal_share"}:
+            raise ValueError(
+                "quantity should be one of: trip_count, distance, travel_time, modal_share."
+            )
+        if zone not in {"home", "origin", "destination"}:
+            raise ValueError("zone should be one of: home, origin, destination.")
+        if quantity != "modal_share" and zone != "home":
+            raise ValueError(
+                "trip_count, distance and travel_time are averaged by home zone only."
+            )
+        if not 0.5 < outlier_quantile <= 1.0:
+            raise ValueError("outlier_quantile should be greater than 0.5 and at most 1.")
+
+        metric = self._metric_by_zone_for_saved_iteration(
+            run=self.results.run,
+            demand_groups=self.results.demand_groups,
+            iteration=iteration,
+            quantity=quantity,
+            mode=mode,
+            zone=zone,
+        )
+        settings = self._plot_metric_settings(quantity=quantity, mode=mode)
+
+        frame_title = None
+        if plot or save_to_file or return_figure:
+            global_value = self._global_metric_by_iteration(
+                run=self.results.run,
+                demand_groups=self.results.demand_groups,
+                iteration=iteration,
+                quantity=quantity,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+            )
+            frame_title = self._plot_metric_frame_title(
+                iteration=iteration,
+                global_value=global_value,
+                quantity=quantity,
+            )
+
+        fig = None
+        if plot or save_to_file or return_figure:
+            fig = TransportZoneMaps(
+                self.results.transport_zones,
+                population=getattr(self.results.run, "population", None),
+                max_labels=max_labels,
+                simplify_tolerance=simplify_tolerance,
+            ).metric(
+                metric,
+                value_column="value",
+                save_name=(
+                    f"{self.results.period}-{settings['save_name']}"
+                    f"-iteration-{iteration}-map"
+                ),
+                save_to_file=save_to_file,
+                inner_zones_only=inner_zones_only,
+                labels=labels,
+                width=width,
+                height=height,
+                hover_columns=settings["hover_columns"],
+                legend_label=settings["legend_label"],
+                frame_title=frame_title,
+                classify=False,
+                color_continuous_scale=settings["color_continuous_scale"],
+                range_color=self._positive_metric_color_range(
+                    self._map_metric_for_color_range(
+                        metric,
+                        inner_zones_only=inner_zones_only,
+                    ),
+                    color_range,
+                    value_column="value",
+                    clamp_outliers=clamp_outliers,
+                    outlier_quantile=outlier_quantile,
+                ),
+                colorbar_tickformat=settings["colorbar_tickformat"],
+            )
+            if plot:
+                fig.show(plot_method)
+
+        if return_figure:
+            return metric, fig
+        return metric
+
+    def modal_share_by_iteration(
+        self,
+        iteration: int,
+        mode: str = "car",
+        zone: Literal["home", "origin", "destination"] = "home",
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        inner_zones_only: bool = False,
+        color_range: float | tuple[float, float] | None = None,
+        labels: bool = True,
+        width: int = 1200,
+        height: int = 850,
+        max_labels: int = 30,
+        simplify_tolerance: float | None = 50.0,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Plot one mode modal share by transport zone for one saved iteration."""
+        if iteration < 1:
+            raise ValueError("iteration must be greater than or equal to 1.")
+        if zone not in {"home", "origin", "destination"}:
+            raise ValueError("zone should be one of: home, origin, destination.")
+
+        modal_share = (
+            self._transport_zone_ids()
+            .join(
+                self._modal_share_for_saved_iteration(
+                    run=self.results.run,
+                    demand_groups=self.results.demand_groups,
+                    iteration=iteration,
+                    zone=zone,
+                    mode=mode,
+                ),
+                on="transport_zone_id",
+                how="left",
+            )
+            .with_columns(
+                pl.col("modal_share").fill_null(0.0),
+                pl.col("n_trips").fill_null(0.0),
+                mode=pl.lit(mode),
+            )
+            .sort("transport_zone_id")
+        )
+
+        safe_mode_name = self._safe_mode_name(mode)
+        mode_label = self._mode_label(mode)
+        frame_title = None
+        if plot or save_to_file or return_figure:
+            global_share = self._global_modal_share_for_saved_iteration(
+                run=self.results.run,
+                demand_groups=self.results.demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+            )
+            frame_title = self._modal_share_frame_title(
+                iteration=iteration,
+                global_share=global_share,
+            )
+
+        fig = None
+        if plot or save_to_file or return_figure:
+            fig = TransportZoneMaps(
+                self.results.transport_zones,
+                population=getattr(self.results.run, "population", None),
+                max_labels=max_labels,
+                simplify_tolerance=simplify_tolerance,
+            ).metric(
+                modal_share,
+                value_column="modal_share",
+                save_name=(
+                    f"{self.results.period}-{safe_mode_name}"
+                    f"-modal-share-iteration-{iteration}-map"
+                ),
+                save_to_file=save_to_file,
+                inner_zones_only=inner_zones_only,
+                labels=labels,
+                width=width,
+                height=height,
+                hover_columns=["n_trips", "mode"],
+                legend_label=f"{mode_label} modal share",
+                frame_title=frame_title,
+                classify=False,
+                color_continuous_scale=[
+                    [0.0, "#FFFFFF"],
+                    [1.0, self._mode_color(mode)],
+                ],
+                range_color=self._modal_share_color_range(color_range),
+                colorbar_tickformat=".0%",
+            )
+            if plot:
+                fig.show(plot_method)
+
+        if return_figure:
+            return modal_share, fig
+        return modal_share
+
+    def _paired_delta_by_iteration(
+        self,
+        *,
+        paired_runs: list[tuple[Any, Any]],
+        iteration: int,
+        value: Literal["modal_share", "n_trips", "mean_utility", "ghg_emissions"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+        relative_delta: bool,
+    ) -> tuple[pl.DataFrame, float]:
+        """Return the average of paired run deltas for one saved iteration."""
+        if not paired_runs:
+            raise ValueError("paired_runs should contain at least one scenario/reference pair.")
+
+        pair_deltas = []
+        global_deltas = []
+        for pair_id, (current_like, reference_like) in enumerate(paired_runs):
+            current_context = self._resolve_run_context(
+                current_like,
+                include_costs=value == "ghg_emissions",
+            )
+            reference_context = self._resolve_run_context(
+                reference_like,
+                include_costs=value == "ghg_emissions",
+            )
+            current_costs = (
+                current_context["costs"]
+                if value == "ghg_emissions"
+                else pl.DataFrame()
+            )
+            reference_costs = (
+                reference_context["costs"]
+                if value == "ghg_emissions"
+                else pl.DataFrame()
+            )
+            pair_deltas.append(
+                self._delta_value_between_runs_by_iteration(
+                    current_run=current_context["run"],
+                    current_demand_groups=current_context["demand_groups"],
+                    reference_run=reference_context["run"],
+                    reference_demand_groups=reference_context["demand_groups"],
+                    current_costs=current_costs,
+                    reference_costs=reference_costs,
+                    iteration=iteration,
+                    value=value,
+                    mode=mode,
+                    zone=zone,
+                    relative_delta=relative_delta,
+                ).with_columns(pair_id=pl.lit(pair_id))
+            )
+            global_deltas.append(
+                self._global_plot_delta_between_runs_by_iteration(
+                    current_run=current_context["run"],
+                    current_demand_groups=current_context["demand_groups"],
+                    reference_run=reference_context["run"],
+                    reference_demand_groups=reference_context["demand_groups"],
+                    current_costs=current_costs,
+                    reference_costs=reference_costs,
+                    iteration=iteration,
+                    value=value,
+                    mode=mode,
+                    zone=zone,
+                    inner_zones_only=inner_zones_only,
+                    relative_delta=relative_delta,
+                )
+            )
+
+        paired_delta = (
+            pl.concat(pair_deltas, how="vertical_relaxed")
+            .group_by("transport_zone_id")
+            .agg(
+                value=pl.col("value").mean(),
+                value_reference=pl.col("value_reference").mean(),
+                value_delta=pl.col("value_delta").mean(),
+                value_delta_std=pl.col("value_delta").std(),
+                n_pairs=pl.col("pair_id").n_unique(),
+                value_name=pl.col("value_name").first(),
+            )
+            .with_columns(pl.col("value_delta_std").fill_null(0.0))
+            .sort("transport_zone_id")
+        )
+        return paired_delta, float(sum(global_deltas) / len(global_deltas))
+
+    def modal_share_delta_by_iteration(
+        self,
+        compare_with: Any,
+        iteration: int,
+        mode: str = "car",
+        zone: Literal["home", "origin", "destination"] = "home",
+        value_type: Literal["modal_share_delta", "n_trips_delta"] = "modal_share_delta",
+        plot: bool = True,
+        plot_method: str = "browser",
+        save_to_file: bool = False,
+        inner_zones_only: bool = False,
+        color_range: float | tuple[float, float] | None = None,
+        labels: bool = True,
+        width: int = 1200,
+        height: int = 850,
+        max_labels: int = 30,
+        simplify_tolerance: float | None = 50.0,
+        return_figure: bool = False,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Compare one mode with another scenario for one saved iteration.
+
+        The returned ``modal_share_delta`` is this run minus ``compare_with``.
+        If ``value_type`` is ``n_trips_delta``, the map shows the signed
+        difference in weighted trips instead of the modal-share difference.
+        By default the share is computed by home transport zone, matching the
+        saved iteration state.
+        ``color_range`` can be a positive number for a symmetric scale or a
+        ``(min, max)`` tuple to share one scale across several iterations.
+        """
+        if iteration < 1:
+            raise ValueError("iteration must be greater than or equal to 1.")
+        if zone not in {"home", "origin", "destination"}:
+            raise ValueError("zone should be one of: home, origin, destination.")
+        if value_type not in {"modal_share_delta", "n_trips_delta"}:
+            raise ValueError("value_type should be one of: modal_share_delta, n_trips_delta.")
+
+        reference_run = self._resolve_comparison_run(compare_with)
+        reference_demand_groups = self._resolve_comparison_demand_groups(
+            compare_with=compare_with,
+            reference_run=reference_run,
+        )
+        current_share = self._modal_share_for_saved_iteration(
+            run=self.results.run,
+            demand_groups=self.results.demand_groups,
+            iteration=iteration,
+            zone=zone,
+            mode=mode,
+        )
+        reference_share = self._modal_share_for_saved_iteration(
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            iteration=iteration,
+            zone=zone,
+            mode=mode,
+        )
+
+        modal_share_delta = (
+            self._transport_zone_ids()
+            .join(
+                current_share,
+                on="transport_zone_id",
+                how="left",
+            )
+            .join(
+                reference_share.rename(
+                    {
+                        "modal_share": "modal_share_reference",
+                        "n_trips": "n_trips_reference",
+                    }
+                ),
+                on="transport_zone_id",
+                how="left",
+            )
+            .with_columns(
+                pl.col("modal_share").fill_null(0.0),
+                pl.col("modal_share_reference").fill_null(0.0),
+                pl.col("n_trips").fill_null(0.0),
+                pl.col("n_trips_reference").fill_null(0.0),
+            )
+            .with_columns(
+                modal_share_delta=pl.col("modal_share") - pl.col("modal_share_reference"),
+                n_trips_delta=pl.col("n_trips") - pl.col("n_trips_reference"),
+                mode=pl.lit(mode),
+            )
+            .sort("transport_zone_id")
+        )
+        safe_mode_name = self._safe_mode_name(mode)
+        mode_label = self._mode_label(mode)
+        value_settings = self._modal_share_delta_value_settings(
+            value_type=value_type,
+            mode_label=mode_label,
+        )
+        frame_title = None
+        if plot or save_to_file or return_figure:
+            global_delta = self._global_delta_by_iteration(
+                reference_run=reference_run,
+                reference_demand_groups=reference_demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+                value_type=value_type,
+            )
+            frame_title = self._modal_share_delta_frame_title(
+                iteration=iteration,
+                global_delta=global_delta,
+                value_type=value_type,
+            )
+
+        fig = None
+        if plot or save_to_file:
+            range_color = self._modal_share_delta_color_range(
+                modal_share_delta,
+                color_range,
+                value_column=value_settings["value_column"],
+            )
+            fig = TransportZoneMaps(
+                self.results.transport_zones,
+                population=getattr(self.results.run, "population", None),
+                max_labels=max_labels,
+                simplify_tolerance=simplify_tolerance,
+            ).metric(
+                modal_share_delta,
+                value_column=value_settings["value_column"],
+                save_name=(
+                    f"{self.results.period}-{safe_mode_name}-"
+                    f"{value_settings['save_name']}-iteration-{iteration}-map"
+                ),
+                save_to_file=save_to_file,
+                inner_zones_only=inner_zones_only,
+                labels=labels,
+                width=width,
+                height=height,
+                hover_columns=[
+                    "modal_share",
+                    "modal_share_reference",
+                    "n_trips",
+                    "n_trips_reference",
+                ],
+                legend_label=value_settings["legend_label"],
+                frame_title=frame_title,
+                classify=False,
+                color_continuous_scale=[
+                    [0.0, "#44546A"],
+                    [0.5, "#FFFFFF"],
+                    [1.0, "#D71A1C"],
+                ],
+                color_continuous_midpoint=0.0,
+                range_color=range_color,
+                colorbar_tickformat=value_settings["colorbar_tickformat"],
+            )
+            if plot:
+                fig.show(plot_method)
+
+        if return_figure:
+            if fig is None:
+                range_color = self._modal_share_delta_color_range(
+                    modal_share_delta,
+                    color_range,
+                    value_column=value_settings["value_column"],
+                )
+                fig = TransportZoneMaps(
+                    self.results.transport_zones,
+                    population=getattr(self.results.run, "population", None),
+                    max_labels=max_labels,
+                    simplify_tolerance=simplify_tolerance,
+                ).metric(
+                    modal_share_delta,
+                    value_column=value_settings["value_column"],
+                    save_name=(
+                        f"{self.results.period}-{safe_mode_name}-"
+                        f"{value_settings['save_name']}-iteration-{iteration}-map"
+                    ),
+                    save_to_file=save_to_file,
+                    inner_zones_only=inner_zones_only,
+                    labels=labels,
+                    width=width,
+                    height=height,
+                    hover_columns=[
+                        "modal_share",
+                        "modal_share_reference",
+                        "n_trips",
+                        "n_trips_reference",
+                    ],
+                    legend_label=value_settings["legend_label"],
+                    frame_title=frame_title,
+                    classify=False,
+                    color_continuous_scale=[
+                        [0.0, "#44546A"],
+                        [0.5, "#FFFFFF"],
+                        [1.0, "#D71A1C"],
+                    ],
+                    color_continuous_midpoint=0.0,
+                    range_color=range_color,
+                    colorbar_tickformat=value_settings["colorbar_tickformat"],
+                )
+            return modal_share_delta, fig
+
+        return modal_share_delta
+
+    def car_modal_share_delta_by_iteration(
+        self,
+        compare_with: Any,
+        iteration: int,
+        **kwargs,
+    ) -> pl.DataFrame | tuple[pl.DataFrame, go.Figure]:
+        """Compare car modal share with another scenario for one saved iteration."""
+        result = self.modal_share_delta_by_iteration(
+            compare_with,
+            iteration,
+            mode="car",
+            **kwargs,
+        )
+        if isinstance(result, tuple):
+            modal_share_delta, fig = result
+            return self._car_modal_share_delta_columns(modal_share_delta), fig
+        return self._car_modal_share_delta_columns(result)
+
+    def modal_share_delta_gifs_by_iteration(
+        self,
+        compare_with: Any,
+        modes: list[str],
+        iterations: list[int] | range,
+        zone: Literal["home", "origin", "destination"] = "home",
+        value_type: Literal["modal_share_delta", "n_trips_delta"] = "modal_share_delta",
+        inner_zones_only: bool = False,
+        color_range: float | tuple[float, float] | None = None,
+        labels: bool = True,
+        width: int = 1200,
+        height: int = 850,
+        max_labels: int = 30,
+        simplify_tolerance: float | None = 50.0,
+        duration_ms: int = 500,
+        output_folder: str | Path | None = None,
+    ) -> dict[str, Path]:
+        """Create one modal-share-delta GIF per mode across saved iterations.
+
+        Temporary PNG frames are written in a temporary folder and removed after
+        the GIF is created. The returned dictionary maps each mode to its GIF
+        file path.
+        """
+        if not modes:
+            raise ValueError("modes should contain at least one mode.")
+        iterations = [int(iteration) for iteration in iterations]
+        if not iterations:
+            raise ValueError("iterations should contain at least one iteration.")
+        if any(iteration < 1 for iteration in iterations):
+            raise ValueError("iterations should be greater than or equal to 1.")
+        if duration_ms <= 0:
+            raise ValueError("duration_ms should be positive.")
+        if value_type not in {"modal_share_delta", "n_trips_delta"}:
+            raise ValueError("value_type should be one of: modal_share_delta, n_trips_delta.")
+
+        reference_run = self._resolve_comparison_run(compare_with)
+        reference_demand_groups = self._resolve_comparison_demand_groups(
+            compare_with=compare_with,
+            reference_run=reference_run,
+        )
+        output_folder = Path(output_folder) if output_folder is not None else self._report_folder()
+        output_folder.mkdir(parents=True, exist_ok=True)
+
+        gif_paths = {}
+        for mode in modes:
+            safe_mode_name = self._safe_mode_name(mode)
+            value_settings = self._modal_share_delta_value_settings(
+                value_type=value_type,
+                mode_label=self._mode_label(mode),
+            )
+            gif_path = output_folder / (
+                f"{self.results.inputs_hash}-{self.results.period}-"
+                f"{safe_mode_name}-{value_settings['save_name']}-iterations-"
+                f"{min(iterations)}-{max(iterations)}-map.gif"
+            )
+            with tempfile.TemporaryDirectory(prefix=f"{safe_mode_name}-modal-share-delta-") as temporary_folder:
+                frame_paths = []
+                for frame_index, iteration in enumerate(iterations):
+                    modal_share_delta = self.modal_share_delta_by_iteration(
+                        compare_with,
+                        iteration=iteration,
+                        mode=mode,
+                        zone=zone,
+                        value_type=value_type,
+                        plot=False,
+                    )
+                    global_delta = self._global_delta_by_iteration(
+                        reference_run=reference_run,
+                        reference_demand_groups=reference_demand_groups,
+                        iteration=iteration,
+                        mode=mode,
+                        zone=zone,
+                        inner_zones_only=inner_zones_only,
+                        value_type=value_type,
+                    )
+                    frame_path = Path(temporary_folder) / f"frame-{frame_index:04d}.png"
+                    self._save_modal_share_delta_frame(
+                        modal_share_delta=modal_share_delta,
+                        mode=mode,
+                        iteration=iteration,
+                        value_type=value_type,
+                        global_delta=global_delta,
+                        output_path=frame_path,
+                        inner_zones_only=inner_zones_only,
+                        color_range=color_range,
+                        labels=labels,
+                        width=width,
+                        height=height,
+                        max_labels=max_labels,
+                        simplify_tolerance=simplify_tolerance,
+                    )
+                    frame_paths.append(frame_path)
+                self._write_gif(frame_paths, gif_path, duration_ms=duration_ms)
+            gif_paths[mode] = gif_path
+
+        return gif_paths
+
+    def _save_modal_share_delta_frame(
+        self,
+        *,
+        modal_share_delta: pl.DataFrame,
+        mode: str,
+        iteration: int,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+        global_delta: float,
+        output_path: Path,
+        inner_zones_only: bool,
+        color_range: float | tuple[float, float] | None,
+        labels: bool,
+        width: int,
+        height: int,
+        max_labels: int,
+        simplify_tolerance: float | None,
+    ) -> None:
+        """Write one temporary image frame for a modal-share-delta GIF."""
+        safe_mode_name = self._safe_mode_name(mode)
+        mode_label = self._mode_label(mode)
+        value_settings = self._modal_share_delta_value_settings(
+            value_type=value_type,
+            mode_label=mode_label,
+        )
+        range_color = self._modal_share_delta_color_range(
+            modal_share_delta,
+            color_range,
+            value_column=value_settings["value_column"],
+        )
+        TransportZoneMaps(
+            self.results.transport_zones,
+            population=getattr(self.results.run, "population", None),
+            max_labels=max_labels,
+            simplify_tolerance=simplify_tolerance,
+        ).metric(
+            modal_share_delta,
+            value_column=value_settings["value_column"],
+            save_name=(
+                f"{self.results.period}-{safe_mode_name}-"
+                f"{value_settings['save_name']}-iteration-{iteration}-map"
+            ),
+            output_path=output_path,
+            inner_zones_only=inner_zones_only,
+            labels=labels,
+            width=width,
+            height=height,
+            hover_columns=[
+                "modal_share",
+                "modal_share_reference",
+                "n_trips",
+                "n_trips_reference",
+            ],
+            legend_label=value_settings["legend_label"],
+            frame_title=self._modal_share_delta_frame_title(
+                iteration=iteration,
+                global_delta=global_delta,
+                value_type=value_type,
+            ),
+            classify=False,
+            color_continuous_scale=[
+                [0.0, "#44546A"],
+                [0.5, "#FFFFFF"],
+                [1.0, "#D71A1C"],
+            ],
+            color_continuous_midpoint=0.0,
+            range_color=range_color,
+            colorbar_tickformat=value_settings["colorbar_tickformat"],
+        )
+
+    @staticmethod
+    def _write_gif(frame_paths: list[Path], output_path: Path, duration_ms: int) -> None:
+        """Combine PNG frames into one GIF."""
+        from PIL import Image
+
+        images = [Image.open(frame_path).convert("P", palette=Image.ADAPTIVE) for frame_path in frame_paths]
+        try:
+            images[0].save(
+                output_path,
+                save_all=True,
+                append_images=images[1:],
+                duration=duration_ms,
+                loop=0,
+            )
+        finally:
+            for image in images:
+                image.close()
+
+    def _modal_share_delta_frame_title(
+        self,
+        *,
+        iteration: int,
+        global_delta: float,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+    ) -> str:
+        """Return the top-left text shown on modal-delta maps."""
+        scope_label = self._behavior_change_scope_label(iteration)
+        global_delta_label = self._global_delta_label(global_delta, value_type=value_type)
+        return f"Iteration {iteration}\n{scope_label}\n{global_delta_label}"
+
+    def _modal_share_frame_title(self, *, iteration: int, global_share: float) -> str:
+        """Return the top-left text shown on modal-share maps."""
+        scope_label = self._behavior_change_scope_label(iteration)
+        return f"Iteration {iteration}\n{scope_label}\nGlobal share: {global_share:.2%}"
+
+    def _behavior_change_scope_label(self, iteration: int) -> str:
+        """Return the behavior-change scope label shown on GIF frames."""
+        if not callable(getattr(self.results.parameters, "get_behavior_change_scope", None)):
+            return "Full replanning"
+        scope = self.results.parameters.get_behavior_change_scope(iteration)
+        scope_value = getattr(scope, "value", str(scope))
+        return scope_value.replace("_", " ").capitalize()
+
+    def _global_modal_share_delta_by_iteration(
+        self,
+        *,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Return the global modal-share delta for one mode."""
+        return self._global_modal_share_delta_between_runs_by_iteration(
+            current_run=self.results.run,
+            current_demand_groups=self.results.demand_groups,
+            reference_run=reference_run,
+            reference_demand_groups=reference_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+
+    def _global_modal_share_delta_between_runs_by_iteration(
+        self,
+        *,
+        current_run: Any,
+        current_demand_groups: pl.DataFrame | pl.LazyFrame,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Return a global modal-share delta between two run contexts."""
+        current_share = self._global_modal_share_for_saved_iteration(
+            run=current_run,
+            demand_groups=current_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        reference_share = self._global_modal_share_for_saved_iteration(
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        return current_share - reference_share
+
+    def _global_delta_by_iteration(
+        self,
+        *,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+    ) -> float:
+        """Return the global delta shown on one GIF frame."""
+        return self._global_delta_between_runs_by_iteration(
+            current_run=self.results.run,
+            current_demand_groups=self.results.demand_groups,
+            reference_run=reference_run,
+            reference_demand_groups=reference_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+            value_type=value_type,
+        )
+
+    def _global_delta_between_runs_by_iteration(
+        self,
+        *,
+        current_run: Any,
+        current_demand_groups: pl.DataFrame | pl.LazyFrame,
+        reference_run: Any,
+        reference_demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+    ) -> float:
+        """Return a modal-share or trip-count delta between two run contexts."""
+        if value_type == "modal_share_delta":
+            return self._global_modal_share_delta_between_runs_by_iteration(
+                current_run=current_run,
+                current_demand_groups=current_demand_groups,
+                reference_run=reference_run,
+                reference_demand_groups=reference_demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+            )
+
+        current_n_trips = self._global_mode_trip_count_for_saved_iteration(
+            run=current_run,
+            demand_groups=current_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        reference_n_trips = self._global_mode_trip_count_for_saved_iteration(
+            run=reference_run,
+            demand_groups=reference_demand_groups,
+            iteration=iteration,
+            mode=mode,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+        return current_n_trips - reference_n_trips
+
+    def _global_metric_by_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        quantity: Literal["trip_count", "distance", "travel_time", "modal_share"],
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Return the global value shown on one-scenario metric maps."""
+        if quantity == "modal_share":
+            return self._global_modal_share_for_saved_iteration(
+                run=run,
+                demand_groups=demand_groups,
+                iteration=iteration,
+                mode=mode,
+                zone=zone,
+                inner_zones_only=inner_zones_only,
+            )
+
+        metric_by_zone = self._average_trip_metric_by_home_zone_for_saved_iteration(
+            run=run,
+            demand_groups=demand_groups,
+            iteration=iteration,
+            quantity=quantity,
+        )
+        if inner_zones_only:
+            metric_by_zone = metric_by_zone.filter(
+                pl.col("transport_zone_id").is_in(self._inner_transport_zone_ids())
+            )
+
+        population = float(metric_by_zone["population"].sum() or 0.0)
+        if population == 0.0:
+            return 0.0
+        return float(metric_by_zone["total"].sum() or 0.0) / population
+
+    def _global_modal_share_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Compute one mode share over the selected trip geography."""
+        mobile_steps = self._global_delta_mobile_steps(
+            run=run,
+            demand_groups=demand_groups,
+            iteration=iteration,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+
+        summary = (
+            mobile_steps.select(
+                total_trips=pl.col("n_persons").sum(),
+                mode_trips=pl.col("n_persons").filter(pl.col("mode") == mode).sum(),
+            )
+            .collect(engine="streaming")
+        )
+        total_trips = float(summary["total_trips"][0] or 0.0)
+        if total_trips == 0.0:
+            return 0.0
+        return float(summary["mode_trips"][0] or 0.0) / total_trips
+
+    def _global_mode_trip_count_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        mode: str,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> float:
+        """Compute the weighted trip count for one mode in the selected geography."""
+        mobile_steps = self._global_delta_mobile_steps(
+            run=run,
+            demand_groups=demand_groups,
+            iteration=iteration,
+            zone=zone,
+            inner_zones_only=inner_zones_only,
+        )
+
+        return float(
+            mobile_steps
+            .filter(pl.col("mode") == mode)
+            .select(pl.col("n_persons").sum())
+            .collect(engine="streaming")
+            .item()
+            or 0.0
+        )
+
+    def _global_delta_mobile_steps(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        zone: Literal["home", "origin", "destination"],
+        inner_zones_only: bool,
+    ) -> pl.LazyFrame:
+        """Return mobile steps used by the GIF global delta."""
+        plan_steps = self._saved_iteration_plan_steps(run, iteration).lazy()
+        zone_column = None
+        if inner_zones_only:
+            if zone == "home":
+                plan_steps = self._join_home_zone(plan_steps, demand_groups)
+                zone_column = "home_zone_id"
+            elif zone == "origin":
+                zone_column = "from"
+            else:
+                zone_column = "to"
+
+        required_columns = {"activity_seq_id", "mode", "n_persons"}
+        if zone_column is not None:
+            required_columns.add(zone_column)
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration plan steps are missing: {missing}.")
+
+        mobile_steps = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .with_columns(pl.col("mode").cast(pl.String))
+        )
+        if zone_column is None:
+            return mobile_steps
+
+        return mobile_steps.filter(pl.col(zone_column).is_in(self._inner_transport_zone_ids()))
+
+    @staticmethod
+    def _global_delta_label(
+        delta: float,
+        *,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+    ) -> str:
+        """Return the GIF label for the global delta."""
+        if value_type == "modal_share_delta":
+            return f"Global delta: {delta:+.2%}"
+        return f"Global delta: {delta:+,.0f} trips"
+
+    @staticmethod
+    def _car_modal_share_delta_columns(modal_share_delta: pl.DataFrame) -> pl.DataFrame:
+        """Return the legacy car-specific column names."""
+        return modal_share_delta.rename(
+            {
+                "modal_share": "car_modal_share",
+                "modal_share_reference": "car_modal_share_reference",
+                "modal_share_delta": "car_modal_share_delta",
+            }
+        ).select(
+            [
+                "transport_zone_id",
+                "car_modal_share",
+                "car_modal_share_reference",
+                "car_modal_share_delta",
+            ]
+        )
+
+    @staticmethod
+    def _modal_share_delta_color_range(
+        modal_share_delta: pl.DataFrame,
+        color_range: float | tuple[float, float] | None,
+        *,
+        value_column: str = "modal_share_delta",
+    ) -> tuple[float, float]:
+        """Return the color scale range for a modal-share-delta map."""
+        if isinstance(color_range, tuple):
+            if len(color_range) != 2:
+                raise ValueError("color_range tuple should have two values: (min, max).")
+            lower, upper = float(color_range[0]), float(color_range[1])
+            if lower >= upper:
+                raise ValueError("color_range minimum should be smaller than maximum.")
+            return lower, upper
+
+        if color_range is not None:
+            color_range = float(color_range)
+            if color_range <= 0.0:
+                raise ValueError("color_range should be positive.")
+            return -color_range, color_range
+
+        max_abs_delta = modal_share_delta[value_column].abs().max()
+        automatic_range = max(float(max_abs_delta or 0.0), 0.01)
+        return -automatic_range, automatic_range
+
+    @staticmethod
+    def _modal_share_color_range(
+        color_range: float | tuple[float, float] | None,
+    ) -> tuple[float, float]:
+        """Return the color scale range for a modal-share map."""
+        if isinstance(color_range, tuple):
+            if len(color_range) != 2:
+                raise ValueError("color_range tuple should have two values: (min, max).")
+            lower, upper = float(color_range[0]), float(color_range[1])
+            if lower >= upper:
+                raise ValueError("color_range minimum should be smaller than maximum.")
+            return lower, upper
+
+        if color_range is not None:
+            color_range = float(color_range)
+            if color_range <= 0.0:
+                raise ValueError("color_range should be positive.")
+            return 0.0, color_range
+
+        return 0.0, 1.0
+
+    @staticmethod
+    def _positive_metric_color_range(
+        metric: pl.DataFrame,
+        color_range: float | tuple[float, float] | None,
+        *,
+        value_column: str,
+        clamp_outliers: bool = False,
+        outlier_quantile: float = 0.98,
+    ) -> tuple[float, float]:
+        """Return the color scale range for a positive metric map."""
+        if isinstance(color_range, tuple):
+            if len(color_range) != 2:
+                raise ValueError("color_range tuple should have two values: (min, max).")
+            lower, upper = float(color_range[0]), float(color_range[1])
+            if lower >= upper:
+                raise ValueError("color_range minimum should be smaller than maximum.")
+            return lower, upper
+
+        if color_range is not None:
+            color_range = float(color_range)
+            if color_range <= 0.0:
+                raise ValueError("color_range should be positive.")
+            return 0.0, color_range
+
+        if clamp_outliers:
+            lower_quantile = 1.0 - outlier_quantile
+            lower_value, max_value = metric.select(
+                pl.col(value_column).quantile(lower_quantile).alias("lower"),
+                pl.col(value_column).quantile(outlier_quantile).alias("upper"),
+            ).row(0)
+            min_value = lower_value
+        else:
+            min_value = metric[value_column].min()
+            max_value = metric[value_column].max()
+
+        lower = float(min_value or 0.0)
+        upper = float(max_value or 0.0)
+        if lower < upper:
+            return lower, upper
+        if upper == 0.0:
+            return 0.0, 0.01
+        margin = max(abs(upper) * 0.05, 0.01)
+        return upper - margin, upper + margin
+
+    def _map_metric_for_color_range(
+        self,
+        metric: pl.DataFrame,
+        *,
+        inner_zones_only: bool,
+    ) -> pl.DataFrame:
+        """Return the metric rows visible on the map color scale."""
+        if not inner_zones_only:
+            return metric
+        return metric.filter(
+            pl.col("transport_zone_id").is_in(self._inner_transport_zone_ids())
+        )
+
+    @staticmethod
+    def _modal_share_delta_value_settings(
+        *,
+        value_type: Literal["modal_share_delta", "n_trips_delta"],
+        mode_label: str,
+    ) -> dict[str, str | None]:
+        """Return plot settings for the selected delta value."""
+        if value_type == "modal_share_delta":
+            return {
+                "value_column": "modal_share_delta",
+                "save_name": "modal-share-delta",
+                "legend_label": f"{mode_label} modal share difference",
+                "colorbar_tickformat": ".0%",
+            }
+        if value_type == "n_trips_delta":
+            return {
+                "value_column": "n_trips_delta",
+                "save_name": "n-trips-delta",
+                "legend_label": f"{mode_label} trip count difference",
+                "colorbar_tickformat": None,
+            }
+        raise ValueError("value_type should be one of: modal_share_delta, n_trips_delta.")
+
+    @staticmethod
+    def _safe_mode_name(mode: str) -> str:
+        """Return a file-name-safe label for one transport mode."""
+        safe_name = re.sub(r"[^A-Za-z0-9]+", "-", mode.lower()).strip("-")
+        return safe_name or "mode"
+
+    @staticmethod
+    def _mode_label(mode: str) -> str:
+        """Return a readable transport mode label."""
+        if mode == "car":
+            return "Car"
+        if mode == "public_transport":
+            return "Public transport"
+        return mode.replace("_", " ").replace("/", " / ").capitalize()
+
+    @classmethod
+    def _mode_color(cls, mode: str) -> str:
+        """Return the report color used for one transport mode."""
+        return cls._mode_label_color_map([cls._mode_label(mode)])[cls._mode_label(mode)]
+
+    @staticmethod
+    def _ylorrd_color_scale() -> list[list[float | str]]:
+        """Return a Plotly-style YlOrRd scale that also works for SVG export."""
+        return [
+            [0.0, "#ffffcc"],
+            [0.125, "#ffeda0"],
+            [0.25, "#fed976"],
+            [0.375, "#feb24c"],
+            [0.5, "#fd8d3c"],
+            [0.625, "#fc4e2a"],
+            [0.75, "#e31a1c"],
+            [0.875, "#bd0026"],
+            [1.0, "#800026"],
+        ]
+
+    @staticmethod
+    def _modal_share_mode_key(
+        mode: str,
+        *,
+        aggregate_public_transport: bool,
+    ) -> str:
+        """Return the mode key used by modal-share evolution charts."""
+        if aggregate_public_transport and "public_transport" in mode:
+            return "public_transport"
+        return mode
+
+    @staticmethod
+    def _ordered_modes(modes: list[str]) -> list[str]:
+        """Return modes in a stable report order."""
+        preferred_modes = [
+            "walk",
+            "bicycle",
+            "public_transport",
+            "walk/public_transport/walk",
+            "car",
+            "other",
+        ]
+        unique_modes = list(dict.fromkeys(modes))
+        ordered_modes = [mode for mode in preferred_modes if mode in unique_modes]
+        ordered_modes.extend(sorted(mode for mode in unique_modes if mode not in preferred_modes))
+        return ordered_modes
+
+    @staticmethod
+    def _mode_label_color_map(mode_labels: list[str]) -> dict[str, str]:
+        """Return stable report colors for readable mode labels."""
+        fixed_colors = {
+            "Walk": "#5F7F73",
+            "Bicycle": "#0B5A66",
+            "Public transport": "#EF4B3E",
+            "Walk / public transport / walk": "#F06A5A",
+            "Car / public transport / walk": "#EF4B3E",
+            "Bicycle / public transport / walk": "#D7191C",
+            "Car": "#4D4D4D",
+            "Carpool": "#8C8C8C",
+            "Other": "#7E6F9A",
+        }
+        fallback_palette = (
+            px.colors.qualitative.Safe
+            + px.colors.qualitative.Bold
+            + px.colors.qualitative.Set3
+        )
+
+        color_map: dict[str, str] = {}
+        fallback_index = 0
+        for mode_label in mode_labels:
+            if mode_label in fixed_colors:
+                color_map[mode_label] = fixed_colors[mode_label]
+                continue
+
+            while fallback_index < len(fallback_palette) and fallback_palette[fallback_index] in color_map.values():
+                fallback_index += 1
+            if fallback_index >= len(fallback_palette):
+                fallback_index = 0
+            color_map[mode_label] = fallback_palette[fallback_index]
+            fallback_index += 1
+
+        return color_map
+
+    def _modal_share_for_saved_iteration(
+        self,
+        *,
+        run: Any,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+        iteration: int,
+        zone: Literal["home", "origin", "destination"],
+        mode: str,
+    ) -> pl.DataFrame:
+        """Compute one mode share by zone from a saved iteration state."""
+        plan_steps = self._saved_iteration_plan_steps(run, iteration).lazy()
+        if zone == "home":
+            plan_steps = self._join_home_zone(plan_steps, demand_groups)
+            zone_column = "home_zone_id"
+        elif zone == "origin":
+            zone_column = "from"
+        else:
+            zone_column = "to"
+
+        required_columns = {"activity_seq_id", zone_column, "mode", "n_persons"}
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Saved iteration plan steps are missing: {missing}.")
+
+        mobile_steps = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .with_columns(pl.col("mode").cast(pl.String))
+        )
+        total_by_zone = mobile_steps.group_by(zone_column).agg(
+            total_trips=pl.col("n_persons").sum()
+        )
+        mode_by_zone = (
+            mobile_steps
+            .filter(pl.col("mode") == mode)
+            .group_by(zone_column)
+            .agg(mode_trips=pl.col("n_persons").sum())
+        )
+
+        return (
+            total_by_zone
+            .join(mode_by_zone, on=zone_column, how="left")
+            .with_columns(pl.col("mode_trips").fill_null(0.0))
+            .with_columns(
+                modal_share=pl.when(pl.col("total_trips") > 0.0)
+                .then(pl.col("mode_trips") / pl.col("total_trips"))
+                .otherwise(0.0)
+            )
+            .rename({zone_column: "transport_zone_id"})
+            .rename({"mode_trips": "n_trips"})
+            .select(["transport_zone_id", "modal_share", "n_trips"])
+            .collect(engine="streaming")
+        )
+
+    def _saved_iteration_plan_steps(self, run: Any, iteration: int) -> pl.DataFrame:
+        """Load current plan steps saved for one run iteration."""
+        return self._saved_iteration_state(run, iteration).current_plan_steps
+
+    def _saved_iteration_state(self, run: Any, iteration: int) -> Any:
+        """Load the full saved state for one run iteration."""
+        if not hasattr(run, "cache_path") or "plan_steps" not in run.cache_path:
+            raise TypeError("Iteration metrics need a group-day-trips run.")
+        if not hasattr(run, "inputs_hash"):
+            raise TypeError("Iteration metrics need a run with an input hash.")
+
+        return Iterations(
+            run_inputs_hash=run.inputs_hash,
+            is_weekday=getattr(run, "is_weekday", self.results.is_weekday),
+            base_folder=Path(run.cache_path["plan_steps"]).parent,
+        ).iteration(iteration).load_state()
+
+    def _join_home_zone(
+        self,
+        plan_steps: pl.LazyFrame,
+        demand_groups: pl.DataFrame | pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Attach the home transport zone when saved steps only have demand group ids."""
+        plan_columns = set(plan_steps.collect_schema().names())
+        if "home_zone_id" in plan_columns:
+            return plan_steps
+        if "demand_group_id" not in plan_columns:
+            raise ValueError(
+                "Saved iteration plan steps need `home_zone_id` or `demand_group_id` "
+                "to compute shares by home zone."
+            )
+
+        demand_groups_lazy = demand_groups.lazy() if isinstance(demand_groups, pl.DataFrame) else demand_groups
+        demand_group_columns = set(demand_groups_lazy.collect_schema().names())
+        missing_columns = {"demand_group_id", "home_zone_id"}.difference(demand_group_columns)
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Demand groups are missing: {missing}.")
+
+        return plan_steps.join(
+            demand_groups_lazy.select(["demand_group_id", "home_zone_id"]),
+            on="demand_group_id",
+            how="left",
+        )
+
+    def _resolve_run_context(self, run_like: Any, *, include_costs: bool) -> dict[str, Any]:
+        """Return run, demand groups, and costs for one run-like object."""
+        run = self._resolve_comparison_run(run_like)
+        demand_groups = self._resolve_comparison_demand_groups(
+            compare_with=run_like,
+            reference_run=run,
+        )
+        costs = (
+            self._resolve_comparison_costs(
+                compare_with=run_like,
+                reference_run=run,
+            )
+            if include_costs
+            else pl.DataFrame()
+        )
+        return {
+            "run": run,
+            "demand_groups": demand_groups,
+            "costs": costs,
+        }
+
+    def _resolve_comparison_run(self, compare_with: Any) -> Any:
+        """Return the day-type run used as the reference scenario."""
+        if hasattr(compare_with, "weekday_run") and hasattr(compare_with, "weekend_run"):
+            reference_run = compare_with.weekday_run if self.results.is_weekday else compare_with.weekend_run
+        elif hasattr(compare_with, "run") and hasattr(compare_with.run, "cache_path"):
+            reference_run = compare_with.run
+        else:
+            reference_run = compare_with
+
+        if not hasattr(reference_run, "cache_path"):
+            raise TypeError(
+                "compare_with should be a group-day-trips run, results object, "
+                "or PopulationGroupDayTrips object."
+            )
+        if getattr(reference_run, "is_weekday", self.results.is_weekday) != self.results.is_weekday:
+            raise ValueError("compare_with should use the same day type as these results.")
+
+        return reference_run
+
+    def _resolve_comparison_demand_groups(
+        self,
+        *,
+        compare_with: Any,
+        reference_run: Any,
+    ) -> pl.DataFrame | pl.LazyFrame:
+        """Return demand groups for the reference scenario."""
+        if hasattr(compare_with, "demand_groups"):
+            return compare_with.demand_groups
+
+        demand_groups_path = reference_run.cache_path.get("demand_groups")
+        if demand_groups_path is None:
+            raise TypeError("compare_with run needs `cache_path['demand_groups']`.")
+        demand_groups_path = Path(demand_groups_path)
+        if demand_groups_path.exists() is False and callable(getattr(reference_run, "get", None)):
+            reference_run.get()
+        if demand_groups_path.exists() is False:
+            raise FileNotFoundError(f"Could not find reference demand groups: {demand_groups_path}.")
+        return pl.scan_parquet(demand_groups_path)
+
+    def _resolve_comparison_costs(
+        self,
+        *,
+        compare_with: Any,
+        reference_run: Any,
+    ) -> pl.DataFrame | pl.LazyFrame:
+        """Return costs for the reference scenario."""
+        if hasattr(compare_with, "costs"):
+            return compare_with.costs
+
+        costs_path = reference_run.cache_path.get("costs")
+        if costs_path is None:
+            prefix = "weekday" if self.results.is_weekday else "weekend"
+            costs_path = reference_run.cache_path.get(f"{prefix}_costs")
+        if costs_path is None:
+            raise TypeError("compare_with run needs `cache_path['costs']`.")
+
+        costs_path = Path(costs_path)
+        if costs_path.exists() is False and callable(getattr(reference_run, "get", None)):
+            reference_run.get()
+        if costs_path.exists() is False:
+            raise FileNotFoundError(f"Could not find reference costs: {costs_path}.")
+        return pl.scan_parquet(costs_path)
+
+    def _transport_zone_ids(self) -> pl.DataFrame:
+        """Return all transport-zone ids from the results geography."""
+        zones = self.results.transport_zones.get()
+        if "transport_zone_id" not in zones.columns:
+            raise ValueError("Transport zones need a `transport_zone_id` column.")
+        return pl.DataFrame({"transport_zone_id": zones["transport_zone_id"].to_list()})
+
+    def _inner_transport_zone_ids(self) -> list[Any]:
+        """Return ids of transport zones marked as inner zones."""
+        zones = self.results.transport_zones.get()
+        missing_columns = {"transport_zone_id", "is_inner_zone"}.difference(zones.columns)
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"Transport zones are missing: {missing}.")
+
+        return zones.loc[zones["is_inner_zone"], "transport_zone_id"].to_list()
 
     def plot_map(
         self,

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -16,6 +16,7 @@ from ..evaluation.calibration_plan_steps import (
 from ..evaluation.iteration_metrics import IterationMetricsBuilder, IterationMetricsHistory
 from ..evaluation.model_entropy import ModelEntropy
 from ..evaluation.model_loss import ModelLoss
+from ..evaluation.model_trip_count_loss import ModelTripCountLoss
 from ..evaluation.trip_pattern_distribution import (
     ObservedTripPatternDistribution,
     PopulationWeightedTripPatternDistribution,
@@ -66,7 +67,7 @@ class Run(FileAsset):
     ) -> None:
         """Initialize a single weekday or weekend PopulationGroupDayTrips run."""
         inputs = {
-            "version": 10,
+            "version": 17,
             "population": population,
             "activities": activities,
             "modes": modes,
@@ -124,6 +125,7 @@ class Run(FileAsset):
                     iteration=iteration.iteration,
                     current_plans=state.current_plans,
                     current_plan_steps=state.current_plan_steps,
+                    destination_saturation=state.destination_saturation,
                 )
             )
             if self.parameters.persist_iteration_artifacts:
@@ -198,6 +200,11 @@ class Run(FileAsset):
         expected_inputs = self._get_expected_diagnostics_inputs()
         return IterationMetricsBuilder(
             model_loss=ModelLoss(expected_plan_steps=expected_inputs.calibration_plan_steps),
+            model_trip_count_loss=ModelTripCountLoss(
+                expected_plan_steps=expected_inputs.population_weighted_plan_steps,
+                surveys=self.surveys,
+                is_weekday=self.is_weekday,
+            ),
             model_entropy=ModelEntropy(expected_plan_steps=expected_inputs.trip_pattern_distribution),
         )
 

--- a/mobility/trips/group_day_trips/evaluation/__init__.py
+++ b/mobility/trips/group_day_trips/evaluation/__init__.py
@@ -5,6 +5,7 @@ from .calibration_plan_steps import (
 )
 from .iteration_metrics import IterationMetricsBuilder, IterationMetricsHistory
 from .model_loss import ModelLoss
+from .model_trip_count_loss import ModelTripCountLoss
 from .model_entropy import ModelEntropy
 from .observed_plan_steps import ObservedPlanSteps
 from .public_transport_network_evaluation import PublicTransportNetworkEvaluation
@@ -22,6 +23,7 @@ __all__ = [
     "IterationMetricsHistory",
     "ModelEntropy",
     "ModelLoss",
+    "ModelTripCountLoss",
     "ObservedPlanSteps",
     "ObservedTripPatternDistribution",
     "ObservedCalibrationPlanSteps",

--- a/mobility/trips/group_day_trips/evaluation/calibration_plan_steps.py
+++ b/mobility/trips/group_day_trips/evaluation/calibration_plan_steps.py
@@ -8,7 +8,8 @@ import polars as pl
 from mobility.runtime.assets.file_asset import FileAsset
 
 DISTANCE_BIN_BREAKS = [0.0, 1.0, 5.0, 10.0, 20.0, 40.0, 80.0, 1e6]
-CALIBRATION_PLAN_STEP_COLUMNS = ["activity", "distance_bin", "mode", "distance", "time", "n_persons"]
+TIME_BIN_BREAKS_MINUTES = [0.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 1e9]
+CALIBRATION_PLAN_STEP_COLUMNS = ["activity", "distance_bin", "time_bin", "mode", "distance", "time", "n_persons"]
 
 
 def _as_lazyframe(plan_steps: pl.LazyFrame | pl.DataFrame) -> pl.LazyFrame:
@@ -23,22 +24,41 @@ def distance_bin_expr(column: str = "distance") -> pl.Expr:
     return pl.col(column).cast(pl.Float64).cut(DISTANCE_BIN_BREAKS, left_closed=True).cast(pl.String)
 
 
+def time_bin_expr(column: str = "time") -> pl.Expr:
+    """Return the canonical travel-time-bin expression shared by calibration diagnostics."""
+    return (pl.col(column).cast(pl.Float64) * 60.0).cut(TIME_BIN_BREAKS_MINUTES, left_closed=True).cast(pl.String)
+
+
 def to_calibration_plan_steps(
     plan_steps: pl.LazyFrame | pl.DataFrame,
 ) -> pl.LazyFrame:
     """Convert raw plan steps to the canonical calibration-step schema."""
     plan_steps = _as_lazyframe(plan_steps)
+    is_stay_home = pl.col("mode").cast(pl.String) == "stay_home"
     return (
         plan_steps
-        .filter(pl.col("activity_seq_id") != 0)
-        .select(["activity", "mode", "distance", "time", "n_persons"])
+        .filter((pl.col("activity_seq_id") != 0) | is_stay_home)
+        .select(["activity_seq_id", "activity", "mode", "distance", "time", "n_persons"])
         .with_columns(
-            activity=pl.col("activity").cast(pl.String),
+            activity=pl.when(is_stay_home)
+            .then(pl.lit("stay_home", dtype=pl.String))
+            .otherwise(pl.col("activity").cast(pl.String)),
             mode=pl.col("mode").cast(pl.String),
-            distance=pl.col("distance").cast(pl.Float64),
-            time=pl.col("time").cast(pl.Float64),
+            distance=pl.when(is_stay_home)
+            .then(pl.lit(0.0))
+            .otherwise(pl.col("distance"))
+            .cast(pl.Float64),
+            time=pl.when(is_stay_home)
+            .then(pl.lit(0.0))
+            .otherwise(pl.col("time"))
+            .cast(pl.Float64),
             n_persons=pl.col("n_persons").cast(pl.Float64),
-            distance_bin=distance_bin_expr("distance"),
+            distance_bin=pl.when(is_stay_home)
+            .then(pl.lit("stay_home"))
+            .otherwise(distance_bin_expr("distance")),
+            time_bin=pl.when(is_stay_home)
+            .then(pl.lit("stay_home"))
+            .otherwise(time_bin_expr("time")),
         )
         .select(CALIBRATION_PLAN_STEP_COLUMNS)
     )
@@ -60,7 +80,7 @@ class PopulationWeightedCalibrationPlanSteps(FileAsset):
             / f"calibration_expected_plan_steps_{'weekday' if is_weekday else 'weekend'}.parquet"
         )
         inputs = {
-            "version": 1,
+            "version": 3,
             "population_weighted_plan_steps": population_weighted_plan_steps,
             "is_weekday": is_weekday,
         }
@@ -95,7 +115,7 @@ class ObservedCalibrationPlanSteps(FileAsset):
             / f"calibration_observed_plan_steps_{'weekday' if is_weekday else 'weekend'}.parquet"
         )
         inputs = {
-            "version": 1,
+            "version": 3,
             "run": run,
             "is_weekday": is_weekday,
         }

--- a/mobility/trips/group_day_trips/evaluation/iteration_metrics.py
+++ b/mobility/trips/group_day_trips/evaluation/iteration_metrics.py
@@ -23,14 +23,17 @@ class IterationMetricsHistory:
         return {
             "iteration": pl.UInt16,
             "total_loss": pl.Float64,
-            "distance_loss": pl.Float64,
-            "n_trips_loss": pl.Float64,
-            "time_loss": pl.Float64,
+            "trip_count_loss": pl.Float64,
+            "activity_loss": pl.Float64,
+            "distance_bin_loss": pl.Float64,
+            "time_bin_loss": pl.Float64,
+            "mode_loss": pl.Float64,
             "observed_entropy": pl.Float64,
             "mean_utility": pl.Float64,
             "mean_trip_count": pl.Float64,
             "mean_travel_time": pl.Float64,
             "mean_travel_distance": pl.Float64,
+            "excess_occupation_share": pl.Float64,
         }
 
     @staticmethod
@@ -44,18 +47,25 @@ class IterationMetricsHistory:
         if not records:
             return IterationMetricsHistory.empty()
 
-        return pl.DataFrame(records).select(
+        frame = pl.DataFrame(records)
+        if "excess_occupation_share" not in frame.columns:
+            frame = frame.with_columns(excess_occupation_share=pl.lit(0.0))
+
+        return frame.select(
             [
                 pl.col("iteration").cast(pl.UInt16),
                 pl.col("total_loss").cast(pl.Float64),
-                pl.col("distance_loss").cast(pl.Float64),
-                pl.col("n_trips_loss").cast(pl.Float64),
-                pl.col("time_loss").cast(pl.Float64),
+                pl.col("trip_count_loss").cast(pl.Float64),
+                pl.col("activity_loss").cast(pl.Float64),
+                pl.col("distance_bin_loss").cast(pl.Float64),
+                pl.col("time_bin_loss").cast(pl.Float64),
+                pl.col("mode_loss").cast(pl.Float64),
                 pl.col("observed_entropy").cast(pl.Float64),
                 pl.col("mean_utility").cast(pl.Float64),
                 pl.col("mean_trip_count").cast(pl.Float64),
                 pl.col("mean_travel_time").cast(pl.Float64),
                 pl.col("mean_travel_distance").cast(pl.Float64),
+                pl.col("excess_occupation_share").cast(pl.Float64),
             ]
         )
 
@@ -72,9 +82,10 @@ class IterationMetricsBuilder:
     time, and travel distance.
     """
 
-    def __init__(self, *, model_loss, model_entropy) -> None:
+    def __init__(self, *, model_loss, model_trip_count_loss, model_entropy) -> None:
         """Attach the detailed diagnostic helpers used to score each iteration."""
         self.model_loss = model_loss
+        self.model_trip_count_loss = model_trip_count_loss
         self.model_entropy = model_entropy
 
     def history_row(
@@ -83,23 +94,32 @@ class IterationMetricsBuilder:
         iteration: int,
         current_plans: pl.DataFrame,
         current_plan_steps: pl.DataFrame,
+        destination_saturation: pl.DataFrame | None = None,
     ) -> dict[str, float]:
         """Compute one persisted diagnostics row for a single model iteration."""
         loss_row = self.model_loss.history_row(
             iteration=iteration,
             plan_steps=to_calibration_plan_steps(current_plan_steps),
         )
+        trip_count_loss_row = self.model_trip_count_loss.history_row(
+            iteration=iteration,
+            plan_steps=current_plan_steps,
+        )
         entropy_row = self.model_entropy.history_row(
             iteration=iteration,
             plan_steps=current_plan_steps,
         )
+        total_loss = float(loss_row["total_loss"]) + float(trip_count_loss_row["trip_count_loss"])
         return {
             **loss_row,
+            "total_loss": total_loss,
+            "trip_count_loss": float(trip_count_loss_row["trip_count_loss"]),
             "observed_entropy": float(entropy_row["observed_entropy"]),
             "mean_utility": self._mean_plan_utility(current_plans),
             "mean_trip_count": self._mean_trip_count(current_plans, current_plan_steps),
             "mean_travel_time": self._mean_travel_metric(current_plans, current_plan_steps, "time"),
             "mean_travel_distance": self._mean_travel_metric(current_plans, current_plan_steps, "distance"),
+            "excess_occupation_share": self._excess_occupation_share(destination_saturation),
         }
 
     def rebuild_history(
@@ -120,6 +140,7 @@ class IterationMetricsBuilder:
                     iteration=iteration_index,
                     current_plans=saved_state.current_plans,
                     current_plan_steps=saved_state.current_plan_steps,
+                    destination_saturation=saved_state.destination_saturation,
                 )
             )
 
@@ -136,6 +157,36 @@ class IterationMetricsBuilder:
                 (pl.col("utility") * pl.col("n_persons")).sum()
                 / pl.col("n_persons").sum().clip(1e-12)
             ).alias("mean_utility")
+        ).item()
+        return float(value or 0.0)
+
+    @staticmethod
+    def _excess_occupation_share(destination_saturation: pl.DataFrame | None) -> float:
+        """Return the share of occupied activity duration above soft capacity."""
+        if destination_saturation is None or destination_saturation.height == 0:
+            return 0.0
+        required = {
+            "opportunity_occupation",
+            "opportunity_capacity",
+        }
+        if required.issubset(set(destination_saturation.columns)) is False:
+            return 0.0
+
+        soft_capacity_factor = (
+            pl.col("destination_soft_capacity_factor")
+            if "destination_soft_capacity_factor" in destination_saturation.columns
+            else pl.lit(1.25)
+        )
+        value = destination_saturation.select(
+            (
+                (
+                    pl.col("opportunity_occupation")
+                    - soft_capacity_factor * pl.col("opportunity_capacity")
+                )
+                .clip(0.0)
+                .sum()
+                / pl.col("opportunity_occupation").sum().clip(1e-12)
+            ).alias("excess_occupation_share")
         ).item()
         return float(value or 0.0)
 

--- a/mobility/trips/group_day_trips/evaluation/model_loss.py
+++ b/mobility/trips/group_day_trips/evaluation/model_loss.py
@@ -4,13 +4,21 @@ import polars as pl
 
 from .calibration_plan_steps import CALIBRATION_PLAN_STEP_COLUMNS
 
+LOSS_GROUP_COLUMNS = ["activity", "distance_bin", "time_bin", "mode"]
+MARGINAL_LOSS_GROUPS = {
+    "activity_loss": ["activity"],
+    "distance_bin_loss": ["distance_bin"],
+    "time_bin_loss": ["time_bin"],
+    "mode_loss": ["mode"],
+}
+
 
 class ModelLoss:
-    """Compare observed and expected calibration marginals for one run.
+    """Compare observed and expected calibration distributions for one run.
 
-    The loss is built from aggregated trip-count, distance, and travel-time
-    marginals over canonical calibration plan steps. It can be used either on
-    the final observed run outputs or on any intermediate plan-step table.
+    The loss is built from the trip-count shares of each canonical calibration
+    step group. Distance and time enter the comparison through their bins, so
+    the loss stays a single, plain distribution over modelled trip states.
     """
 
     def __init__(
@@ -40,14 +48,17 @@ class ModelLoss:
             raise ValueError("No observed calibration plan steps are attached to this ModelLoss instance.")
         return self._aggregate(self.observed_plan_steps.get())
 
-    def comparison(self, plan_steps=None) -> pl.DataFrame:
-        """Return observed-versus-expected marginal comparisons for one plan-step table."""
+    def comparison(self, plan_steps=None, group_columns: list[str] | None = None) -> pl.DataFrame:
+        """Return observed-versus-expected distribution comparisons for one plan-step table."""
         observed = self._aggregate(plan_steps) if plan_steps is not None else self.observed_marginals()
         expected = self.expected_marginals()
+        group_columns = group_columns or LOSS_GROUP_COLUMNS
+        observed = self._collapse_to_group(observed, group_columns)
+        expected = self._collapse_to_group(expected, group_columns)
         return (
             observed.join(
                 expected,
-                on=["activity", "distance_bin", "mode", "metric"],
+                on=[*group_columns, "metric"],
                 how="full",
                 coalesce=True,
                 suffix="_expected",
@@ -57,13 +68,18 @@ class ModelLoss:
                 value_expected=pl.col("value_expected").fill_null(0.0),
             )
             .with_columns(
+                observed_total=pl.col("value").sum().over("metric"),
+                expected_total=pl.col("value_expected").sum().over("metric"),
                 delta=pl.col("value") - pl.col("value_expected"),
                 relative_error=(pl.col("value") - pl.col("value_expected")) / pl.col("value_expected").clip(self.epsilon),
-                squared_error=(pl.col("value") - pl.col("value_expected")).pow(2),
-                metric_scale=pl.col("value_expected").sum().over("metric").clip(self.epsilon),
             )
             .with_columns(
-                normalized_squared_error=pl.col("squared_error") / pl.col("metric_scale").pow(2)
+                observed_share=pl.col("value") / pl.col("observed_total").clip(self.epsilon),
+                expected_share=pl.col("value_expected") / pl.col("expected_total").clip(self.epsilon),
+            )
+            .with_columns(
+                share_delta=pl.col("observed_share") - pl.col("expected_share"),
+                normalized_squared_error=(pl.col("observed_share") - pl.col("expected_share")).pow(2),
             )
             .rename(
                 {
@@ -71,18 +87,18 @@ class ModelLoss:
                     "value_expected": "expected_value",
                 }
             )
-            .sort(["metric", "activity", "distance_bin", "mode"])
+            .sort(["metric", *group_columns])
         )
 
-    def metric_losses(self, plan_steps=None) -> pl.DataFrame:
-        """Summarize normalized loss separately for trip count, distance, and time."""
+    def metric_losses(self, plan_steps=None, group_columns: list[str] | None = None) -> pl.DataFrame:
+        """Summarize the trip-state distribution loss."""
         return (
-            self.comparison(plan_steps=plan_steps)
+            self.comparison(plan_steps=plan_steps, group_columns=group_columns)
             .group_by("metric")
             .agg(
                 loss=pl.col("normalized_squared_error").sum(),
-                observed_total=pl.col("observed_value").sum(),
-                expected_total=pl.col("expected_value").sum(),
+                observed_total=pl.col("observed_total").first(),
+                expected_total=pl.col("expected_total").first(),
             )
             .sort("metric")
         )
@@ -90,6 +106,20 @@ class ModelLoss:
     def total_loss(self, plan_steps=None) -> float:
         """Return the total calibration loss across all component metrics."""
         metric_losses = self.metric_losses(plan_steps=plan_steps)
+        if metric_losses.height == 0:
+            return 0.0
+        return float(metric_losses["loss"].sum())
+
+    def marginal_losses(self, plan_steps=None) -> dict[str, float]:
+        """Return one distribution loss per calibration dimension."""
+        return {
+            loss_name: self.total_loss_for_group(plan_steps=plan_steps, group_columns=group_columns)
+            for loss_name, group_columns in MARGINAL_LOSS_GROUPS.items()
+        }
+
+    def total_loss_for_group(self, *, plan_steps=None, group_columns: list[str]) -> float:
+        """Return the distribution loss after collapsing to one set of columns."""
+        metric_losses = self.metric_losses(plan_steps=plan_steps, group_columns=group_columns)
         if metric_losses.height == 0:
             return 0.0
         return float(metric_losses["loss"].sum())
@@ -104,24 +134,29 @@ class ModelLoss:
         """Return the persisted loss history extracted from iteration diagnostics."""
         if self.history_store is None:
             raise ValueError("No model loss history is attached to this ModelLoss instance.")
-        return self.history_store.get().select(
-            ["iteration", "total_loss", "distance_loss", "n_trips_loss", "time_loss"]
-        )
+        history = self.history_store.get()
+        columns = ["iteration", "total_loss", "activity_loss", "distance_bin_loss", "time_bin_loss", "mode_loss"]
+        if "trip_count_loss" in history.columns:
+            columns.insert(2, "trip_count_loss")
+        return history.select(columns)
 
     def history_row(self, *, iteration: int, plan_steps) -> dict[str, float]:
         """Build one persisted loss-history row for a given iteration state."""
         metric_losses = self.metric_losses(plan_steps=plan_steps)
-        metric_loss_map = {
-            row["metric"]: row["loss"]
-            for row in metric_losses.select(["metric", "loss"]).to_dicts()
-        }
         return {
             "iteration": iteration,
             "total_loss": float(metric_losses["loss"].sum()) if metric_losses.height > 0 else 0.0,
-            "distance_loss": float(metric_loss_map.get("distance", 0.0)),
-            "n_trips_loss": float(metric_loss_map.get("n_trips", 0.0)),
-            "time_loss": float(metric_loss_map.get("time", 0.0)),
+            **self.marginal_losses(plan_steps=plan_steps),
         }
+
+    @staticmethod
+    def _collapse_to_group(marginals: pl.DataFrame, group_columns: list[str]) -> pl.DataFrame:
+        """Collapse full trip-state marginals to one diagnostic grouping."""
+        return (
+            marginals
+            .group_by([*group_columns, "metric"])
+            .agg(value=pl.col("value").sum())
+        )
 
     def _aggregate(self, plan_steps: pl.LazyFrame | pl.DataFrame) -> pl.DataFrame:
         """Aggregate canonical calibration plan steps into loss marginals."""
@@ -136,15 +171,14 @@ class ModelLoss:
             )
         aggregated = (
             plan_steps
-            .group_by(["activity", "distance_bin", "mode"])
+            .filter(pl.col("mode") != "stay_home")
+            .group_by(["activity", "distance_bin", "time_bin", "mode"])
             .agg(
                 n_trips=pl.col("n_persons").sum(),
-                distance=(pl.col("distance") * pl.col("n_persons")).sum(),
-                time=(pl.col("time") * pl.col("n_persons")).sum(),
             )
             .unpivot(
-                index=["activity", "distance_bin", "mode"],
-                on=["n_trips", "distance", "time"],
+                index=["activity", "distance_bin", "time_bin", "mode"],
+                on=["n_trips"],
                 variable_name="metric",
                 value_name="value",
             )

--- a/mobility/trips/group_day_trips/evaluation/model_trip_count_loss.py
+++ b/mobility/trips/group_day_trips/evaluation/model_trip_count_loss.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import polars as pl
+
+from .calibration_plan_steps import _as_lazyframe
+from .trip_pattern_distribution import get_survey_immobility_probabilities
+
+TRIP_COUNT_BINS = ["0", "1", "2", "3", "4", "5+"]
+
+
+def build_trip_count_distribution(
+    plan_steps: pl.LazyFrame | pl.DataFrame,
+    *,
+    immobility_probabilities: pl.DataFrame | None = None,
+    epsilon: float = 1e-12,
+) -> pl.DataFrame:
+    """Build a weighted distribution of the number of trips per person.
+
+    When survey immobility probabilities are given, the input is treated as the
+    cleaned mobile survey plans. Mobile weights are scaled by the mobile share,
+    and a zero-trip mass is added by country and socio-professional group.
+    """
+    plan_steps = _as_lazyframe(plan_steps)
+    available_columns = set(plan_steps.collect_schema().names())
+    required_columns = {"activity_seq_id", "n_persons"}
+    if not required_columns.issubset(available_columns):
+        missing = sorted(required_columns - available_columns)
+        raise ValueError(
+            "Trip-count loss expects raw ordered plan steps. "
+            f"Missing columns: {missing}."
+        )
+
+    candidate_columns = [
+        "country",
+        "demand_group_id",
+        "home_zone_id",
+        "city_category",
+        "csp",
+        "n_cars",
+        "activity_seq_id",
+        "time_seq_id",
+        "dest_seq_id",
+        "mode_seq_id",
+    ]
+    plan_key_cols = [col for col in candidate_columns if col in available_columns]
+
+    mobile_counts = (
+        plan_steps
+        .filter(pl.col("activity_seq_id") != 0)
+        .select(plan_key_cols + ["n_persons"])
+        .group_by(plan_key_cols)
+        .agg(
+            n_persons=pl.col("n_persons").first(),
+            trip_count=pl.len(),
+        )
+    )
+
+    if immobility_probabilities is not None:
+        if not {"country", "csp"}.issubset(set(plan_key_cols)):
+            raise ValueError(
+                "Survey-side immobility rescaling requires plan steps with 'country' and 'csp' columns."
+            )
+        segment_cols = ["country", "csp"]
+        mobile_counts = mobile_counts.with_columns(
+            country=pl.col("country").cast(pl.String),
+            csp=pl.col("csp").cast(pl.String),
+        )
+        segment_totals = (
+            mobile_counts
+            .group_by(segment_cols)
+            .agg(n_persons_segment=pl.col("n_persons").sum())
+            .join(
+                immobility_probabilities.lazy().with_columns(
+                    country=pl.col("country").cast(pl.String),
+                    csp=pl.col("csp").cast(pl.String),
+                ),
+                on=segment_cols,
+                how="left",
+            )
+            .with_columns(p_immobility=pl.col("p_immobility").fill_null(0.0))
+        )
+        mobile_counts = (
+            mobile_counts
+            .join(segment_totals, on=segment_cols, how="left")
+            .with_columns(n_persons=pl.col("n_persons") * (1.0 - pl.col("p_immobility")))
+            .select(["trip_count", "n_persons"])
+        )
+        stay_home_counts = (
+            segment_totals
+            .with_columns(
+                trip_count=pl.lit(0, dtype=pl.UInt32),
+                n_persons=pl.col("n_persons_segment") * pl.col("p_immobility"),
+            )
+            .select(["trip_count", "n_persons"])
+        )
+        all_counts = pl.concat([mobile_counts, stay_home_counts], how="vertical_relaxed")
+    else:
+        stay_home_counts = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") == 0)
+            .select(plan_key_cols + ["n_persons"])
+            .group_by(plan_key_cols)
+            .agg(n_persons=pl.col("n_persons").first())
+            .with_columns(trip_count=pl.lit(0, dtype=pl.UInt32))
+            .select(["trip_count", "n_persons"])
+        )
+        all_counts = pl.concat(
+            [
+                mobile_counts.select(["trip_count", "n_persons"]),
+                stay_home_counts,
+            ],
+            how="vertical_relaxed",
+        )
+
+    distribution = (
+        all_counts
+        .with_columns(trip_count_bin=_trip_count_bin_expr("trip_count"))
+        .group_by("trip_count_bin")
+        .agg(n_persons=pl.col("n_persons").sum())
+        .with_columns(probability=pl.col("n_persons") / pl.col("n_persons").sum().clip(epsilon))
+        .collect(engine="streaming")
+    )
+    return (
+        _all_trip_count_bins()
+        .join(distribution, on="trip_count_bin", how="left")
+        .with_columns(
+            n_persons=pl.col("n_persons").fill_null(0.0).cast(pl.Float64),
+            probability=pl.col("probability").fill_null(0.0).cast(pl.Float64),
+        )
+    )
+
+
+class ModelTripCountLoss:
+    """Compare the observed and expected distributions of trips per person."""
+
+    def __init__(
+        self,
+        *,
+        expected_plan_steps,
+        surveys=None,
+        is_weekday: bool = True,
+        observed_plan_steps=None,
+        history=None,
+        epsilon: float = 1e-9,
+    ) -> None:
+        """Attach expected data, optional observed data, and optional history storage."""
+        self.expected_plan_steps = expected_plan_steps
+        self.surveys = surveys
+        self.is_weekday = is_weekday
+        self.observed_plan_steps = observed_plan_steps
+        self.history_store = history
+        self.epsilon = epsilon
+        self._expected_distribution = None
+
+    def expected_distribution(self) -> pl.DataFrame:
+        """Return the survey-derived trip-count distribution."""
+        if self._expected_distribution is None:
+            immobility = (
+                get_survey_immobility_probabilities(self.surveys, is_weekday=self.is_weekday)
+                if self.surveys is not None
+                else None
+            )
+            self._expected_distribution = build_trip_count_distribution(
+                _get_plan_steps(self.expected_plan_steps),
+                immobility_probabilities=immobility,
+            )
+        return self._expected_distribution
+
+    def observed_distribution(self) -> pl.DataFrame:
+        """Return the observed trip-count distribution for the attached run."""
+        if self.observed_plan_steps is None:
+            raise ValueError("No observed plan steps are attached to this ModelTripCountLoss instance.")
+        return build_trip_count_distribution(_get_plan_steps(self.observed_plan_steps))
+
+    def comparison(self, plan_steps=None) -> pl.DataFrame:
+        """Return observed-versus-expected trip-count distribution comparisons."""
+        observed = (
+            build_trip_count_distribution(plan_steps)
+            if plan_steps is not None
+            else self.observed_distribution()
+        )
+        expected = self.expected_distribution()
+        return (
+            observed
+            .select(["trip_count_bin", pl.col("n_persons").alias("observed_value")])
+            .join(
+                expected.select(["trip_count_bin", pl.col("n_persons").alias("expected_value")]),
+                on="trip_count_bin",
+                how="full",
+                coalesce=True,
+            )
+            .with_columns(
+                observed_value=pl.col("observed_value").fill_null(0.0),
+                expected_value=pl.col("expected_value").fill_null(0.0),
+            )
+            .with_columns(
+                observed_total=pl.col("observed_value").sum(),
+                expected_total=pl.col("expected_value").sum(),
+                delta=pl.col("observed_value") - pl.col("expected_value"),
+                relative_error=(pl.col("observed_value") - pl.col("expected_value"))
+                / pl.col("expected_value").clip(self.epsilon),
+            )
+            .with_columns(
+                observed_share=pl.col("observed_value") / pl.col("observed_total").clip(self.epsilon),
+                expected_share=pl.col("expected_value") / pl.col("expected_total").clip(self.epsilon),
+            )
+            .with_columns(
+                share_delta=pl.col("observed_share") - pl.col("expected_share"),
+                normalized_squared_error=(pl.col("observed_share") - pl.col("expected_share")).pow(2),
+            )
+            .sort("trip_count_bin")
+        )
+
+    def total_loss(self, plan_steps=None) -> float:
+        """Return the trip-count distribution loss."""
+        comparison = self.comparison(plan_steps=plan_steps)
+        if comparison.height == 0:
+            return 0.0
+        return float(comparison["normalized_squared_error"].sum())
+
+    def summary(self, plan_steps=None) -> pl.DataFrame:
+        """Return the trip-count loss and population totals."""
+        comparison = self.comparison(plan_steps=plan_steps)
+        return pl.DataFrame(
+            {
+                "trip_count_loss": [float(comparison["normalized_squared_error"].sum())],
+                "observed_total": [float(comparison["observed_total"].max() or 0.0)],
+                "expected_total": [float(comparison["expected_total"].max() or 0.0)],
+            }
+        )
+
+    def history(self) -> pl.DataFrame:
+        """Return the persisted trip-count loss history."""
+        if self.history_store is None:
+            raise ValueError("No model trip-count loss history is attached to this instance.")
+        return self.history_store.get().select(["iteration", "trip_count_loss"])
+
+    def history_row(self, *, iteration: int, plan_steps) -> dict[str, float]:
+        """Build one persisted trip-count loss row for a given iteration state."""
+        return {
+            "iteration": iteration,
+            "trip_count_loss": self.total_loss(plan_steps=plan_steps),
+        }
+
+
+def _trip_count_bin_expr(column: str) -> pl.Expr:
+    """Return the small set of trip-count classes used by diagnostics."""
+    return (
+        pl.when(pl.col(column) >= 5)
+        .then(pl.lit("5+"))
+        .otherwise(pl.col(column).cast(pl.UInt32).cast(pl.String))
+    )
+
+
+def _all_trip_count_bins() -> pl.DataFrame:
+    """Return all trip-count bins so missing classes get explicit zero mass."""
+    return pl.DataFrame({"trip_count_bin": TRIP_COUNT_BINS})
+
+
+def _get_plan_steps(plan_steps):
+    """Return a plan-step frame from either a frame or a small asset wrapper."""
+    return plan_steps.get() if hasattr(plan_steps, "get") else plan_steps

--- a/mobility/trips/group_day_trips/evaluation/travel_costs_evaluation.py
+++ b/mobility/trips/group_day_trips/evaluation/travel_costs_evaluation.py
@@ -1,9 +1,14 @@
-import re
 import itertools
+import os
+from pathlib import Path
 
-import polars as pl
 import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
 import plotly.express as px
+import polars as pl
+
+from mobility.reports.theme import MOBILITY_COLORS, apply_report_layout
 
 from urllib.parse import unquote
 from typing import Dict, List
@@ -33,6 +38,11 @@ class TravelCostsEvaluation:
             variable: str = "time",
             plot: bool = True,
             iteration: int | None = None,
+            plot_method: str = "browser",
+            save_to_file: bool = False,
+            output_path: str | Path | None = None,
+            width: int = 760,
+            height: int = 560,
         ):
         """
         Compares the travel costs (time, distance) of the model with reference 
@@ -100,7 +110,7 @@ class TravelCostsEvaluation:
                 x=variable,
                 y=variable + "_model",
                 color="mode",
-                title=f"Travel costs comparison at iteration {iteration}",
+                color_discrete_map=_mode_color_map(ref_costs["mode"].unique().to_list()),
                 hover_data={
                     "origin": True,
                     "destination": True,
@@ -111,11 +121,65 @@ class TravelCostsEvaluation:
                     "distance_model": True
                 }
             )
+            apply_report_layout(fig)
+            fig.update_layout(
+                title_text=None,
+                paper_bgcolor=MOBILITY_COLORS["background"],
+                plot_bgcolor=MOBILITY_COLORS["background"],
+                width=width,
+                height=height,
+                margin={"l": 65, "r": 20, "t": 35, "b": 80},
+                legend={
+                    "orientation": "h",
+                    "x": 0.0,
+                    "y": -0.18,
+                    "xanchor": "left",
+                    "yanchor": "top",
+                    "bgcolor": "rgba(255,255,255,0.9)",
+                },
+            )
+            fig.update_xaxes(
+                title_text=_travel_cost_axis_label(variable, source="reference"),
+                showgrid=False,
+                zeroline=False,
+            )
+            fig.update_yaxes(
+                title_text=_travel_cost_axis_label(variable, source="model"),
+                showgrid=True,
+                gridcolor=MOBILITY_COLORS["grid"],
+                zeroline=False,
+            )
             
-            fig.show("browser")
+            fig.show(plot_method)
+
+        if save_to_file or output_path is not None:
+            _save_travel_costs_svg(
+                ref_costs,
+                variable=variable,
+                output_path=(
+                    Path(output_path)
+                    if output_path is not None
+                    else self._travel_costs_svg_path(variable, iteration)
+                ),
+                width=width,
+                height=height,
+            )
         
         return ref_costs
-    
+
+    def _travel_costs_svg_path(self, variable: str, iteration: int) -> Path:
+        """Return the default SVG output path for a travel-cost plot."""
+        project_folder = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+        if project_folder is None:
+            raise ValueError(
+                "save_to_file=True needs MOBILITY_PROJECT_DATA_FOLDER to be defined."
+            )
+        inputs_hash = getattr(self.results, "inputs_hash", "travel-costs")
+        return (
+            Path(project_folder)
+            / f"{inputs_hash}-travel-costs-{variable}-iteration-{iteration}.svg"
+        )
+
     
     def convert_to_dataframe(self, ref_costs):
         """
@@ -251,3 +315,128 @@ class TravelCostsEvaluation:
         )
         
         return ref_costs
+
+
+def _travel_cost_axis_label(variable: str, *, source: str) -> str:
+    """Return a plain axis label for a travel-cost comparison plot."""
+    label = {
+        "time": "Travel time (h)",
+        "distance": "Distance (km)",
+    }.get(variable, variable.replace("_", " ").capitalize())
+    if source == "model":
+        return f"Model {label.lower()}"
+    return f"Reference {label.lower()}"
+
+
+def _mode_color_map(modes: list[str]) -> dict[str, str]:
+    """Return report colors for raw mode names."""
+    fixed_colors = {
+        "walk": "#5F7F73",
+        "bicycle": "#0B5A66",
+        "public_transport": "#EF4B3E",
+        "walk/public_transport/walk": "#F06A5A",
+        "car/public_transport/walk": "#EF4B3E",
+        "bicycle/public_transport/walk": "#D7191C",
+        "car": "#4D4D4D",
+        "carpool": "#8C8C8C",
+        "other": "#7E6F9A",
+    }
+    fallback_palette = (
+        px.colors.qualitative.Safe
+        + px.colors.qualitative.Bold
+        + px.colors.qualitative.Set3
+    )
+
+    color_map: dict[str, str] = {}
+    fallback_index = 0
+    for mode in modes:
+        if mode in fixed_colors:
+            color_map[mode] = fixed_colors[mode]
+            continue
+
+        while fallback_index < len(fallback_palette) and fallback_palette[fallback_index] in color_map.values():
+            fallback_index += 1
+        if fallback_index >= len(fallback_palette):
+            fallback_index = 0
+        color_map[mode] = fallback_palette[fallback_index]
+        fallback_index += 1
+
+    return color_map
+
+
+def _mode_label(mode: str) -> str:
+    """Return a readable transport mode label."""
+    return mode.replace("_", " ").replace("/", " / ").capitalize()
+
+
+def _save_travel_costs_svg(
+    costs: pl.DataFrame,
+    *,
+    variable: str,
+    output_path: Path,
+    width: int,
+    height: int,
+) -> None:
+    """Save a travel-cost comparison scatter plot as SVG."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame = costs.to_pandas()
+    model_variable = f"{variable}_model"
+    frame[variable] = frame[variable].astype(float)
+    frame[model_variable] = frame[model_variable].astype(float)
+
+    modes = sorted(frame["mode"].dropna().unique().tolist())
+    color_map = _mode_color_map(modes)
+    fig, axis = plt.subplots(
+        figsize=(max(width / 100.0, 7.6), max(height / 100.0, 5.6)),
+    )
+    for mode in modes:
+        panel = frame[frame["mode"] == mode]
+        axis.scatter(
+            panel[variable],
+            panel[model_variable],
+            color=color_map[mode],
+            label=mode,
+            s=28,
+            alpha=0.9,
+            edgecolors="none",
+        )
+
+    values = np.concatenate(
+        [
+            frame[variable].dropna().to_numpy(),
+            frame[model_variable].dropna().to_numpy(),
+        ]
+    )
+    if values.size > 0:
+        lower = float(values.min())
+        upper = float(values.max())
+        if lower == upper:
+            margin = max(abs(upper) * 0.05, 0.01)
+            lower -= margin
+            upper += margin
+        padding = max((upper - lower) * 0.04, 0.02)
+        lower -= padding
+        upper += padding
+        axis.set_xlim(lower, upper)
+        axis.set_ylim(lower, upper)
+
+    axis.set_xlabel(_travel_cost_axis_label(variable, source="reference"))
+    axis.set_ylabel(_travel_cost_axis_label(variable, source="model"))
+    axis.grid(axis="y", color=MOBILITY_COLORS["grid"], linewidth=1.0)
+    axis.grid(axis="x", visible=False)
+    axis.set_facecolor(MOBILITY_COLORS["background"])
+    for spine in axis.spines.values():
+        spine.set_visible(False)
+    axis.legend(
+        title="mode",
+        loc="lower center",
+        bbox_to_anchor=(0.5, -0.28),
+        ncol=max(1, len(modes)),
+        frameon=False,
+        columnspacing=1.4,
+        handletextpad=0.5,
+    )
+    fig.patch.set_facecolor(MOBILITY_COLORS["background"])
+    fig.subplots_adjust(left=0.11, right=0.98, top=0.95, bottom=0.28)
+    fig.savefig(output_path, format="svg")
+    plt.close(fig)

--- a/mobility/trips/group_day_trips/transitions/transition_metrics.py
+++ b/mobility/trips/group_day_trips/transitions/transition_metrics.py
@@ -297,9 +297,11 @@ def _enrich_transitions(
         .join(demand_group_keys, on="demand_group_id", how="left")
         .with_columns(
             activity_seq_id=pl.col("activity_seq_id").cast(pl.UInt32),
+            time_seq_id=pl.col("time_seq_id").cast(pl.UInt32),
             dest_seq_id=pl.col("dest_seq_id").cast(pl.UInt32),
             mode_seq_id=pl.col("mode_seq_id").cast(pl.UInt32),
             activity_seq_id_trans=pl.col("activity_seq_id_trans").cast(pl.UInt32),
+            time_seq_id_trans=pl.col("time_seq_id_trans").cast(pl.UInt32),
             dest_seq_id_trans=pl.col("dest_seq_id_trans").cast(pl.UInt32),
             mode_seq_id_trans=pl.col("mode_seq_id_trans").cast(pl.UInt32),
             home_zone_id_str=pl.col("home_zone_id").cast(pl.String),
@@ -321,16 +323,18 @@ def _enrich_transitions(
         .join(home_zone_labels, on="home_zone_id_str", how="left")
         .with_columns(
             state_from=pl.format(
-                "dg{}-m{}-d{}-mo{}",
+                "dg{}-a{}-t{}-d{}-mo{}",
                 pl.col("demand_group_id"),
                 pl.col("activity_seq_id"),
+                pl.col("time_seq_id"),
                 pl.col("dest_seq_id"),
                 pl.col("mode_seq_id"),
             ),
             state_to=pl.format(
-                "dg{}-m{}-d{}-mo{}",
+                "dg{}-a{}-t{}-d{}-mo{}",
                 pl.col("demand_group_id"),
                 pl.col("activity_seq_id_trans"),
+                pl.col("time_seq_id_trans"),
                 pl.col("dest_seq_id_trans"),
                 pl.col("mode_seq_id_trans"),
             ),

--- a/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
+++ b/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
@@ -105,16 +105,19 @@ def test_008e_group_day_trips_can_resume_from_saved_iteration(test_data):
     assert iteration_metrics["iteration"].to_list() == [1, 2]
     assert {
         "total_loss",
-        "distance_loss",
-        "n_trips_loss",
-        "time_loss",
+        "activity_loss",
+        "distance_bin_loss",
+        "time_bin_loss",
+        "mode_loss",
         "observed_entropy",
         "mean_utility",
         "mean_trip_count",
         "mean_travel_time",
         "mean_travel_distance",
+        "excess_occupation_share",
     }.issubset(set(iteration_metrics.columns))
     assert iteration_metrics["mean_utility"].null_count() == 0
     assert iteration_metrics["mean_trip_count"].null_count() == 0
     assert iteration_metrics["mean_travel_time"].null_count() == 0
     assert iteration_metrics["mean_travel_distance"].null_count() == 0
+    assert iteration_metrics["excess_occupation_share"].null_count() == 0

--- a/tests/back/unit/domain/group_day_trips/test_006_state_waterfall_requires_persisted_transitions.py
+++ b/tests/back/unit/domain/group_day_trips/test_006_state_waterfall_requires_persisted_transitions.py
@@ -16,3 +16,103 @@ def test_state_waterfall_requires_persisted_transition_events():
             quantity="distance",
             plot=False,
         )
+
+
+class _SimpleTable:
+    """Small table wrapper with the `drop` method used by transport zones."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def drop(self, *args, **kwargs):
+        """Return rows without geometry, matching the transport-zones API."""
+        return self.rows
+
+
+class _SimpleTransportZones:
+    """Minimal transport-zones object for state-waterfall tests."""
+
+    class _StudyArea:
+        def get(self):
+            """Return local-admin-unit labels."""
+            return _SimpleTable(
+                [
+                    {
+                        "local_admin_unit_id": "100",
+                        "local_admin_unit_name": "Test town",
+                    }
+                ]
+            )
+
+    study_area = _StudyArea()
+
+    def get(self):
+        """Return transport-zone to local-admin-unit links."""
+        return _SimpleTable(
+            [
+                {
+                    "transport_zone_id": "10",
+                    "local_admin_unit_id": "100",
+                }
+            ]
+        )
+
+
+def test_state_waterfall_state_pair_uses_activity_time_destination_and_mode_sequences():
+    transitions = pl.DataFrame(
+        [
+            {
+                "iteration": 1,
+                "demand_group_id": 1,
+                "activity_seq_id": 11,
+                "time_seq_id": 21,
+                "dest_seq_id": 31,
+                "mode_seq_id": 41,
+                "activity_seq_id_trans": 12,
+                "time_seq_id_trans": 22,
+                "dest_seq_id_trans": 32,
+                "mode_seq_id_trans": 42,
+                "n_persons_moved": 3.0,
+                "utility_prev_from": 1.0,
+                "utility_prev_to": 2.0,
+                "utility_from": 1.5,
+                "utility_to": 2.5,
+                "tau_transition": 0.0,
+                "q_transition": 1.0,
+                "adjustment_factor": 1.0,
+                "is_self_transition": False,
+                "trip_count_from": 1.0,
+                "activity_time_from": 10.0,
+                "travel_time_from": 1.0,
+                "distance_from": 5.0,
+                "steps_from": "#1 | to: 10 | activity: work | mode: car | dist_km: 5.0 | time_h: 1.0",
+                "trip_count_to": 1.0,
+                "activity_time_to": 9.5,
+                "travel_time_to": 1.2,
+                "distance_to": 7.0,
+                "steps_to": "#1 | to: 10 | activity: work | mode: car | dist_km: 7.0 | time_h: 1.2",
+            }
+        ],
+        schema=TRANSITION_EVENT_SCHEMA,
+    )
+    demand_groups = pl.DataFrame(
+        [
+            {
+                "demand_group_id": 1,
+                "home_zone_id": 10,
+                "csp": "worker",
+                "n_cars": 1,
+                "n_persons": 3.0,
+            }
+        ]
+    )
+
+    _, state_pairs = state_waterfall(
+        transitions=transitions.lazy(),
+        demand_groups=demand_groups.lazy(),
+        transport_zones=_SimpleTransportZones(),
+        quantity="distance",
+        plot=False,
+    )
+
+    assert state_pairs["state_pair"].to_list() == ["dg1-a11-t21-d31-mo41 -> dg1-a12-t22-d32-mo42"]

--- a/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
+++ b/tests/back/unit/domain/group_day_trips/test_008_run_results_activity_time_series.py
@@ -4,6 +4,7 @@ from plotly.basedatatypes import BaseFigure
 import pytest
 import polars as pl
 
+from mobility.reports.theme import MOBILITY_COLORS
 from mobility.trips.group_day_trips.core.results import RunResults
 
 
@@ -171,7 +172,7 @@ def test_activity_time_series_plot_builds_survey_panel_when_survey_assets_are_av
 
     seen = {}
 
-    def fake_plot(df):
+    def fake_plot(df, **_kwargs):
         seen["rows"] = df.height
         seen["sources"] = sorted(df["source"].unique().to_list())
         return "figure"
@@ -289,8 +290,9 @@ def test_plot_activity_time_series_wrapper_passes_scope_and_returns_plot_result(
         seen["inner_zone_residents_only"] = inner_zone_residents_only
         return expected_series
 
-    def fake_plot(df):
+    def fake_plot(df, **kwargs):
         seen["plotted_series"] = df
+        seen["save_to_file"] = kwargs["save_to_file"]
         return "figure"
 
     monkeypatch.setattr(results.metrics, "activity_time_series", fake_activity_time_series)
@@ -305,6 +307,7 @@ def test_plot_activity_time_series_wrapper_passes_scope_and_returns_plot_result(
     assert seen["interval_minutes"] == 30
     assert seen["inner_zone_residents_only"] is True
     assert seen["plotted_series"].equals(expected_series)
+    assert seen["save_to_file"] is False
 
 
 def test_plot_activity_time_series_builds_one_panel_per_available_source(monkeypatch):
@@ -340,9 +343,120 @@ def test_plot_activity_time_series_builds_one_panel_per_available_source(monkeyp
 
     assert seen["show_called"] is True
     assert len(fig.data) == 4
+    assert [trace.legendgroup for trace in fig.data] == ["mystery", "work", "mystery", "work"]
+    assert [trace.showlegend for trace in fig.data] == [True, True, False, False]
     assert fig.layout.barmode == "stack"
+    assert fig.layout.paper_bgcolor == MOBILITY_COLORS["background"]
+    assert fig.layout.plot_bgcolor == MOBILITY_COLORS["background"]
+    assert fig.layout.title.text is None
+    assert fig.layout.xaxis.showgrid is False
     assert list(fig.layout.xaxis.categoryarray) == ["08:00", "08:15"]
     assert list(fig.layout.xaxis2.categoryarray) == ["08:00", "08:15"]
+
+
+def test_plot_activity_time_series_activity_panels_compare_sources(monkeypatch):
+    results = _make_results(
+        pl.DataFrame(
+            {
+                "activity": ["home"],
+                "mode": ["stay_home"],
+                "n_persons": [1.0],
+                "departure_time": [0.0],
+                "arrival_time": [0.0],
+                "next_departure_time": [24.0],
+            }
+        )
+    )
+    time_series = pl.DataFrame(
+        {
+            "source": ["survey", "observed", "survey", "observed", "survey"],
+            "time_bin_start": [8.0, 8.0, 8.25, 8.25, 8.0],
+            "time_label": ["08:00", "08:00", "08:15", "08:15", "08:00"],
+            "label": ["work", "work", "studies", "studies", "in_transit:car"],
+            "n_persons": [1.0, 2.0, 0.5, 0.75, 0.2],
+        }
+    )
+    seen = {}
+
+    class FakeFigure:
+        def update_layout(self, **kwargs):
+            seen.setdefault("layout_updates", []).append(kwargs)
+            return self
+
+        def update_yaxes(self, **kwargs):
+            seen["yaxes"] = kwargs
+            return self
+
+        def update_xaxes(self, **kwargs):
+            seen["xaxes"] = kwargs
+            return self
+
+        def for_each_annotation(self, callback):
+            seen["annotation_callback"] = callback
+            return self
+
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    def fake_line(data_frame, **kwargs):
+        seen["data_frame"] = data_frame
+        seen["kwargs"] = kwargs
+        return FakeFigure()
+
+    monkeypatch.setattr("mobility.trips.group_day_trips.core.metrics.px.line", fake_line)
+
+    fig = results.metrics._plot_activity_time_series(time_series, mode="activity_panels")
+
+    assert isinstance(fig, FakeFigure)
+    assert seen["kwargs"]["facet_col"] == "label"
+    assert seen["kwargs"]["facet_col_wrap"] == 2
+    assert seen["kwargs"]["color"] == "source"
+    assert seen["kwargs"]["category_orders"]["source"] == ["Survey", "Model"]
+    assert seen["kwargs"]["color_discrete_map"] == {
+        "Survey": MOBILITY_COLORS["survey"],
+        "Model": MOBILITY_COLORS["model"],
+    }
+    assert sorted(seen["data_frame"]["label"].unique().tolist()) == ["studies", "work"]
+    assert sorted(seen["data_frame"]["source"].unique().tolist()) == ["Model", "Survey"]
+    assert any(update.get("title_text") is None for update in seen["layout_updates"])
+    assert seen["xaxes"]["showgrid"] is False
+    assert any(
+        update.get("paper_bgcolor") == MOBILITY_COLORS["background"]
+        and update.get("plot_bgcolor") == MOBILITY_COLORS["background"]
+        for update in seen["layout_updates"]
+    )
+    assert seen["renderer"] == "browser"
+
+
+def test_plot_activity_time_series_can_save_stacked_svg(monkeypatch, tmp_path):
+    results = _make_results(
+        pl.DataFrame(
+            {
+                "activity": ["home"],
+                "mode": ["stay_home"],
+                "n_persons": [1.0],
+                "departure_time": [0.0],
+                "arrival_time": [0.0],
+                "next_departure_time": [24.0],
+            }
+        )
+    )
+    time_series = pl.DataFrame(
+        {
+            "source": ["survey", "observed"],
+            "time_bin_start": [8.0, 8.0],
+            "time_label": ["08:00", "08:00"],
+            "label": ["work", "work"],
+            "n_persons": [1.0, 2.0],
+        }
+    )
+
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    monkeypatch.setattr(BaseFigure, "show", lambda *_args, **_kwargs: None, raising=False)
+
+    results.metrics._plot_activity_time_series(time_series, save_to_file=True)
+
+    assert (tmp_path / "run-activity-time-series.svg").exists()
 
 
 def test_activity_time_series_color_map_uses_fixed_and_fallback_colors():

--- a/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
+++ b/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
@@ -4,14 +4,26 @@ import pandas as pd
 import polars as pl
 import pytest
 
+from mobility.reports.theme import MOBILITY_COLORS
 from mobility.trips.group_day_trips.core.diagnostics import RunDiagnostics
+from mobility.trips.group_day_trips.core.parameters import (
+    BehaviorChangePhase,
+    BehaviorChangeScope,
+    Parameters,
+)
+from mobility.trips.group_day_trips.core.metrics import RunMetrics
 from mobility.trips.group_day_trips.core.results import RunResults
 from mobility.trips.group_day_trips.evaluation.iteration_metrics import (
     IterationMetricsBuilder,
     IterationMetricsHistory,
 )
+from mobility.trips.group_day_trips.evaluation.calibration_plan_steps import to_calibration_plan_steps
 from mobility.trips.group_day_trips.evaluation.model_entropy import ModelEntropy
 from mobility.trips.group_day_trips.evaluation.model_loss import ModelLoss
+from mobility.trips.group_day_trips.evaluation.model_trip_count_loss import (
+    ModelTripCountLoss,
+    build_trip_count_distribution,
+)
 from mobility.trips.group_day_trips.evaluation.public_transport_network_evaluation import (
     PublicTransportNetworkEvaluation,
 )
@@ -63,10 +75,12 @@ def _make_results_for_metrics() -> RunResults:
         {
             "activity_seq_id": [1, 1],
             "home_zone_id": ["z1", "z1"],
+            "seq_step_index": [1, 2],
             "activity": ["work", "shop"],
             "mode": ["car", "walk"],
             "time": [0.5, 0.25],
             "distance": [5.0, 1.0],
+            "duration": [1.0, 0.25],
             "n_persons": [2.0, 1.0],
         }
     )
@@ -77,8 +91,10 @@ def _make_results_for_metrics() -> RunResults:
             "country": ["fr", "fr"],
             "activity": ["work", "shop"],
             "mode": ["car", "walk"],
+            "seq_step_index": [1, 2],
             "travel_time": [0.5, 0.25],
             "distance": [5.0, 1.0],
+            "duration_per_pers": [0.5, 0.25],
             "n_persons": [2.0, 1.0],
         }
     )
@@ -118,6 +134,103 @@ def test_metrics_aggregate_and_travel_indicators_by_match_reference_when_inputs_
     assert by_time_bin["delta"].to_list() == pytest.approx([0.0] * by_time_bin.height)
 
 
+def test_travel_indicators_by_can_plot_and_save_svg(tmp_path):
+    results = _make_results_for_metrics()
+    output_path = tmp_path / "travel-indicators.svg"
+
+    comparison, fig = results.metrics.travel_indicators_by(
+        variable="mode",
+        plot=False,
+        save_to_file=True,
+        output_path=output_path,
+        return_figure=True,
+    )
+
+    assert comparison.height > 0
+    assert output_path.exists()
+    assert fig.layout.barmode == "group"
+    assert fig.layout.paper_bgcolor == MOBILITY_COLORS["background"]
+    assert fig.layout.plot_bgcolor == MOBILITY_COLORS["background"]
+    assert fig.layout.title.text is None
+    assert fig.layout.xaxis.showgrid is False
+    assert fig.layout.yaxis.gridcolor == MOBILITY_COLORS["grid"]
+    assert {trace.name for trace in fig.data} == {"Survey", "Model"}
+
+
+def test_activity_duration_distribution_weights_model_and_survey_durations():
+    plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [1, 1, 1, 1, 1, 0],
+            "time_seq_id": [10, 10, 10, 10, 10, 0],
+            "home_zone_id": ["z1", "z1", "z1", "z1", "z1", "z1"],
+            "seq_step_index": [1, 1, 2, 3, 4, 0],
+            "activity": ["work", "work", "home", "shop", "home", "home"],
+            "mode": ["car", "car", "walk", "walk", "car", "car"],
+            "duration": [4.0, 4.0, 2.0, 1.0, 20.0, 120.0],
+            "n_persons": [2.0, 1.0, 2.0, 1.0, 2.0, 5.0],
+        }
+    )
+    survey_plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [1, 1, 1, 1, 1, 0],
+            "time_seq_id": [10, 10, 10, 10, 10, 0],
+            "home_zone_id": ["z1", "z1", "z1", "z1", "z1", "z1"],
+            "seq_step_index": [1, 1, 2, 3, 4, 0],
+            "activity": ["work", "work", "home", "shop", "home", "home"],
+            "mode": ["car", "car", "walk", "walk", "car", "car"],
+            "duration_per_pers": [2.0, 3.0, 1.0, 1.0, 10.0, 24.0],
+            "n_persons": [1.0, 2.0, 2.0, 3.0, 2.0, 5.0],
+        }
+    )
+    results = _make_results_for_metrics()
+    results.plan_steps = plan_steps.lazy()
+    results.population_weighted_plan_steps = survey_plan_steps.lazy()
+
+    distribution = results.metrics.activity_duration_distribution(bin_width_minutes=60, plot=False)
+
+    work_model = distribution.filter((pl.col("source") == "model") & (pl.col("activity") == "work"))
+    assert work_model["duration_bin_start"].to_list() == pytest.approx([2.0, 4.0])
+    assert work_model["weighted_visits"].to_list() == pytest.approx([2.0, 1.0])
+    assert work_model["probability"].to_list() == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+
+    probability_sums = distribution.group_by(["source", "activity"]).agg(pl.col("probability").sum())
+    assert probability_sums["probability"].to_list() == pytest.approx([1.0] * probability_sums.height)
+
+    home_model = distribution.filter((pl.col("source") == "model") & (pl.col("activity") == "home"))
+    assert home_model["duration_bin_start"].to_list() == pytest.approx([1.0])
+
+
+def test_activity_duration_distribution_plot_path_uses_activity_facets(monkeypatch):
+    results = _make_results_for_metrics()
+    seen = {}
+
+    class FakeFigure:
+        def update_yaxes(self, **kwargs):
+            seen["yaxes"] = kwargs
+            return self
+
+        def update_xaxes(self, **kwargs):
+            seen["xaxes"] = kwargs
+            return self
+
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    def fake_line(data_frame, **kwargs):
+        seen["data_frame"] = data_frame
+        seen["kwargs"] = kwargs
+        return FakeFigure()
+
+    monkeypatch.setattr("mobility.trips.group_day_trips.core.metrics.px.line", fake_line)
+
+    distribution = results.metrics.activity_duration_distribution(plot=True)
+
+    assert not distribution.is_empty()
+    assert seen["kwargs"]["facet_col"] == "activity"
+    assert seen["kwargs"]["color"] == "source"
+    assert seen["renderer"] == "browser"
+
+
 def test_metrics_evaluation_wrappers_pass_run_results(monkeypatch):
     results = _make_results_for_metrics()
     seen = {}
@@ -148,6 +261,101 @@ def test_metrics_evaluation_wrappers_pass_run_results(monkeypatch):
         "routing": results,
         "public_transport_network": results,
     }
+
+
+def test_travel_costs_plot_uses_report_style_and_mode_colors(monkeypatch, tmp_path):
+    class FakeTransportCosts:
+        def asset_for_iteration(self, run, iteration):
+            seen["iteration"] = iteration
+            return self
+
+        def get_costs_by_od_and_mode(self, columns):
+            seen["columns"] = columns
+            return pl.DataFrame(
+                {
+                    "from": ["z1", "z1"],
+                    "to": ["z2", "z2"],
+                    "mode": ["car", "bicycle"],
+                    "time": [0.5, 0.75],
+                    "distance": [10.0, 8.0],
+                }
+            )
+
+    class FakeFigure:
+        def update_layout(self, **kwargs):
+            seen.setdefault("layout_updates", []).append(kwargs)
+            return self
+
+        def update_xaxes(self, **kwargs):
+            seen["xaxes"] = kwargs
+            return self
+
+        def update_yaxes(self, **kwargs):
+            seen["yaxes"] = kwargs
+            return self
+
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    def fake_scatter(data_frame, **kwargs):
+        seen["scatter_frame"] = data_frame
+        seen["scatter_kwargs"] = kwargs
+        return FakeFigure()
+
+    results = SimpleNamespace(
+        parameters=SimpleNamespace(n_iterations=3),
+        run=SimpleNamespace(transport_costs=FakeTransportCosts()),
+        transport_zones=SimpleNamespace(get=lambda: pd.DataFrame()),
+    )
+    seen = {}
+    evaluator = TravelCostsEvaluation(results)
+    monkeypatch.setattr(
+        evaluator,
+        "convert_to_dataframe",
+        lambda _ref_costs: pl.DataFrame(
+            {
+                "ref_index": [0, 1],
+                "origin": ["A", "A"],
+                "destination": ["B", "B"],
+                "from": ["z1", "z1"],
+                "to": ["z2", "z2"],
+                "mode": ["car", "bicycle"],
+                "time": [0.4, 0.8],
+                "distance": [9.0, 7.5],
+            }
+        ),
+    )
+    monkeypatch.setattr(evaluator, "join_transport_zone_ids", lambda frame, _zones: frame)
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.evaluation.travel_costs_evaluation.px.scatter",
+        fake_scatter,
+    )
+
+    output_path = tmp_path / "travel-costs.svg"
+    comparison = evaluator.get(
+        [],
+        variable="time",
+        plot=True,
+        save_to_file=True,
+        output_path=output_path,
+    )
+
+    assert comparison.height == 2
+    assert output_path.exists()
+    assert seen["iteration"] == 3
+    assert seen["columns"] == ["time", "distance"]
+    assert seen["scatter_kwargs"]["color"] == "mode"
+    assert seen["scatter_kwargs"]["color_discrete_map"] == {
+        "car": "#4D4D4D",
+        "bicycle": "#0B5A66",
+    }
+    assert any(update.get("paper_bgcolor") == MOBILITY_COLORS["background"] for update in seen["layout_updates"])
+    assert any(update.get("plot_bgcolor") == MOBILITY_COLORS["background"] for update in seen["layout_updates"])
+    assert seen["xaxes"]["title_text"] == "Reference travel time (h)"
+    assert seen["xaxes"]["showgrid"] is False
+    assert seen["yaxes"]["title_text"] == "Model travel time (h)"
+    assert seen["yaxes"]["gridcolor"] == MOBILITY_COLORS["grid"]
+    assert seen["renderer"] == "browser"
 
 
 def test_opportunity_occupation_includes_full_capacity_stock_once_per_destination_activity():
@@ -463,6 +671,1956 @@ def test_metric_per_person_plot_and_wrapper_methods(monkeypatch):
     ]
 
 
+def test_modal_share_evolution_by_iteration_returns_share_table(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=states[iteration])
+            return SimpleNamespace(load_state=lambda: state)
+
+    states = {
+        1: pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk"],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+        2: pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2, 3],
+                "mode": ["car", "walk", "bicycle"],
+                "n_persons": [1.0, 2.0, 1.0],
+            }
+        ),
+    }
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=2),
+        run=SimpleNamespace(
+            inputs_hash="runhash",
+            is_weekday=True,
+            cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        ),
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    modal_share = results.metrics.modal_share_evolution_by_iteration(
+        modes=["walk", "bicycle", "car"],
+        plot=False,
+    )
+
+    assert modal_share.to_dict(as_series=False) == {
+        "iteration": [1, 1, 1, 2, 2, 2],
+        "mode": ["walk", "bicycle", "car", "walk", "bicycle", "car"],
+        "mode_label": ["Walk", "Bicycle", "Car", "Walk", "Bicycle", "Car"],
+        "n_trips": pytest.approx([1.0, 0.0, 2.0, 2.0, 1.0, 1.0]),
+        "modal_share": pytest.approx([1.0 / 3.0, 0.0, 2.0 / 3.0, 0.5, 0.25, 0.25]),
+    }
+
+
+def test_modal_share_evolution_by_iteration_groups_public_transport(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            return None
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [1, 2, 3],
+            "mode": [
+                "walk/public_transport/walk",
+                "bicycle/public_transport/walk",
+                "car",
+            ],
+            "n_persons": [2.0, 1.0, 1.0],
+        }
+    )
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=1),
+        run=SimpleNamespace(
+            inputs_hash="runhash",
+            is_weekday=True,
+            cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        ),
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    modal_share = results.metrics.modal_share_evolution_by_iteration(
+        modes=["walk/public_transport/walk", "car"],
+        plot=False,
+    )
+
+    assert modal_share.to_dict(as_series=False) == {
+        "iteration": [1, 1],
+        "mode": ["public_transport", "car"],
+        "mode_label": ["Public transport", "Car"],
+        "n_trips": pytest.approx([3.0, 1.0]),
+        "modal_share": pytest.approx([0.75, 0.25]),
+    }
+
+
+def test_modal_share_evolution_by_iteration_can_use_inner_zones_only(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            return None
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    plan_steps = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z2", "outer"],
+            "activity_seq_id": [1, 2, 3],
+            "mode": ["walk", "car", "car"],
+            "n_persons": [1.0, 1.0, 8.0],
+        }
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "outer"],
+                "is_inner_zone": [True, True, False],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=1),
+        run=SimpleNamespace(
+            inputs_hash="runhash",
+            is_weekday=True,
+            cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        ),
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    modal_share = results.metrics.modal_share_evolution_by_iteration(
+        modes=["walk", "car"],
+        inner_zones_only=True,
+        plot=False,
+    )
+
+    assert modal_share.to_dict(as_series=False) == {
+        "iteration": [1, 1],
+        "mode": ["walk", "car"],
+        "mode_label": ["Walk", "Car"],
+        "n_trips": pytest.approx([1.0, 1.0]),
+        "modal_share": pytest.approx([0.5, 0.5]),
+    }
+
+
+def test_modal_share_evolution_by_iteration_can_plot_and_save_svg(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            return None
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [1, 2],
+            "mode": ["car", "walk"],
+            "n_persons": [1.0, 1.0],
+        }
+    )
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=1),
+        run=SimpleNamespace(
+            inputs_hash="runhash",
+            is_weekday=True,
+            cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        ),
+    )
+    seen = {}
+
+    def fake_plot(modal_share, *, width, height, chart_type):
+        seen["plot"] = (modal_share, width, height, chart_type)
+        return FakeFigure()
+
+    def fake_save(modal_share, *, output_path, width, height, chart_type):
+        seen["save"] = (modal_share, output_path, width, height, chart_type)
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(results.metrics, "_plot_modal_share_evolution", fake_plot)
+    monkeypatch.setattr(results.metrics, "_save_modal_share_evolution_svg", fake_save)
+
+    modal_share, fig = results.metrics.modal_share_evolution_by_iteration(
+        plot=True,
+        plot_method="notebook",
+        save_to_file=True,
+        output_path=tmp_path / "modal-share.svg",
+        width=700,
+        height=420,
+        chart_type="line",
+        return_figure=True,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["plot"][1:] == (700, 420, "line")
+    assert seen["save"][1:] == (tmp_path / "modal-share.svg", 700, 420, "line")
+    assert modal_share["modal_share"].to_list() == pytest.approx([0.5, 0.5])
+    assert isinstance(fig, FakeFigure)
+
+
+def test_modal_share_delta_evolution_by_iteration_compares_two_scenarios(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plan_steps=states[(self.run_inputs_hash, iteration)]
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    states = {
+        ("current", 1): pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk/public_transport/walk"],
+                "n_persons": [2.0, 2.0],
+            }
+        ),
+        ("reference", 1): pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk/public_transport/walk"],
+                "n_persons": [3.0, 1.0],
+            }
+        ),
+        ("current", 2): pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk/public_transport/walk"],
+                "n_persons": [1.0, 3.0],
+            }
+        ),
+        ("reference", 2): pl.DataFrame(
+            {
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk/public_transport/walk"],
+                "n_persons": [2.0, 2.0],
+            }
+        ),
+    }
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=2),
+        run=current_run,
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    delta = results.metrics.modal_share_delta_evolution_by_iteration(
+        SimpleNamespace(run=reference_run, demand_groups=pl.DataFrame().lazy()),
+        modes=["public_transport", "car"],
+        plot=False,
+    )
+
+    assert delta.to_dict(as_series=False) == {
+        "iteration": [1, 1, 2, 2],
+        "mode": ["public_transport", "car", "public_transport", "car"],
+        "mode_label": ["Public transport", "Car", "Public transport", "Car"],
+        "n_trips": pytest.approx([2.0, 2.0, 3.0, 1.0]),
+        "n_trips_reference": pytest.approx([1.0, 3.0, 2.0, 2.0]),
+        "n_trips_delta": pytest.approx([1.0, -1.0, 1.0, -1.0]),
+        "modal_share": pytest.approx([0.5, 0.5, 0.75, 0.25]),
+        "modal_share_reference": pytest.approx([0.25, 0.75, 0.5, 0.5]),
+        "modal_share_delta": pytest.approx([0.25, -0.25, 0.25, -0.25]),
+    }
+
+
+def test_modal_share_delta_evolution_by_iteration_can_plot_and_save_svg(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=states[self.run_inputs_hash])
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    states = {
+        "current": pl.DataFrame(
+            {
+                "activity_seq_id": [1],
+                "mode": ["car"],
+                "n_persons": [1.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "activity_seq_id": [1],
+                "mode": ["walk"],
+                "n_persons": [1.0],
+            }
+        ),
+    }
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(n_iterations=1),
+        run=current_run,
+    )
+    seen = {}
+
+    def fake_plot(delta, *, width, height):
+        seen["plot"] = (delta, width, height)
+        return FakeFigure()
+
+    def fake_save(delta, *, output_path, width, height):
+        seen["save"] = (delta, output_path, width, height)
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(results.metrics, "_plot_modal_share_delta_evolution", fake_plot)
+    monkeypatch.setattr(results.metrics, "_save_modal_share_delta_evolution_svg", fake_save)
+
+    delta, fig = results.metrics.modal_share_delta_evolution_by_iteration(
+        SimpleNamespace(run=reference_run, demand_groups=pl.DataFrame().lazy()),
+        plot=True,
+        plot_method="notebook",
+        save_to_file=True,
+        output_path=tmp_path / "modal-share-delta.svg",
+        width=700,
+        height=420,
+        return_figure=True,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["plot"][1:] == (700, 420)
+    assert seen["save"][1:] == (tmp_path / "modal-share-delta.svg", 700, 420)
+    assert delta["modal_share_delta"].to_list() == pytest.approx([-1.0, 1.0])
+    assert isinstance(fig, FakeFigure)
+
+
+def test_car_modal_share_delta_by_iteration_uses_saved_home_zone_states(monkeypatch, tmp_path):
+    """Compare car shares by resident zone for one saved iteration."""
+
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+            self.is_weekday = is_weekday
+            self.base_folder = base_folder
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plan_steps=states[(self.run_inputs_hash, iteration)]
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "z3"],
+                "is_inner_zone": [True, True, True],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    current_demand_groups = pl.DataFrame(
+        {
+            "demand_group_id": [1, 2],
+            "home_zone_id": ["z1", "z2"],
+        }
+    )
+    reference_demand_groups = pl.DataFrame(
+        {
+            "demand_group_id": [10, 20],
+            "home_zone_id": ["z1", "z2"],
+        }
+    )
+    states = {
+        ("current", 3): pl.DataFrame(
+            {
+                "demand_group_id": [1, 1, 2],
+                "activity_seq_id": [1, 2, 1],
+                "mode": ["car", "walk", "walk"],
+                "n_persons": [3.0, 1.0, 2.0],
+            }
+        ),
+        ("reference", 3): pl.DataFrame(
+            {
+                "demand_group_id": [10, 10, 20],
+                "activity_seq_id": [1, 2, 1],
+                "mode": ["car", "walk", "car"],
+                "n_persons": [1.0, 1.0, 2.0],
+            }
+        ),
+    }
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=current_demand_groups.lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+    reference_results = SimpleNamespace(
+        run=reference_run,
+        demand_groups=reference_demand_groups.lazy(),
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    modal_share_delta = results.metrics.car_modal_share_delta_by_iteration(
+        reference_results,
+        iteration=3,
+        plot=False,
+    )
+
+    assert modal_share_delta.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2", "z3"],
+        "car_modal_share": pytest.approx([0.75, 0.0, 0.0]),
+        "car_modal_share_reference": pytest.approx([0.5, 1.0, 0.0]),
+        "car_modal_share_delta": pytest.approx([0.25, -1.0, 0.0]),
+    }
+
+    walk_modal_share_delta = results.metrics.modal_share_delta_by_iteration(
+        reference_results,
+        iteration=3,
+        mode="walk",
+        plot=False,
+    )
+
+    assert walk_modal_share_delta.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2", "z3"],
+        "modal_share": pytest.approx([0.25, 1.0, 0.0]),
+        "n_trips": pytest.approx([1.0, 2.0, 0.0]),
+        "modal_share_reference": pytest.approx([0.5, 0.0, 0.0]),
+        "n_trips_reference": pytest.approx([1.0, 0.0, 0.0]),
+        "modal_share_delta": pytest.approx([-0.25, 1.0, 0.0]),
+        "n_trips_delta": pytest.approx([0.0, 2.0, 0.0]),
+        "mode": ["walk", "walk", "walk"],
+    }
+
+
+def test_modal_share_by_iteration_plots_one_scenario(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            return None
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    class FakeTransportZoneMaps:
+        def __init__(self, transport_zones, **kwargs):
+            seen["transport_zones"] = transport_zones
+            seen["map_kwargs"] = kwargs
+
+        def metric(self, values, **kwargs):
+            seen["values"] = values
+            seen["metric_kwargs"] = kwargs
+            return FakeFigure()
+
+    plan_steps = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z1", "z2"],
+            "activity_seq_id": [1, 2, 1],
+            "mode": ["walk", "car", "walk"],
+            "n_persons": [1.0, 1.0, 2.0],
+        }
+    )
+    run = SimpleNamespace(
+        inputs_hash="run",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        population=SimpleNamespace(name="population"),
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "z3"],
+                "is_inner_zone": [True, True, False],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=Parameters(
+            behavior_change_phases=[
+                BehaviorChangePhase(
+                    start_iteration=2,
+                    scope=BehaviorChangeScope.MODE_REPLANNING,
+                )
+            ]
+        ),
+        run=run,
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    modal_share, fig = results.metrics.modal_share_by_iteration(
+        iteration=2,
+        mode="walk",
+        plot=True,
+        plot_method="notebook",
+        return_figure=True,
+        inner_zones_only=True,
+        color_range=0.8,
+        labels=False,
+        width=500,
+        height=400,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["map_kwargs"] == {
+        "population": run.population,
+        "max_labels": 30,
+        "simplify_tolerance": 50.0,
+    }
+    assert seen["metric_kwargs"]["value_column"] == "modal_share"
+    assert seen["metric_kwargs"]["save_name"] == "weekdays-walk-modal-share-iteration-2-map"
+    assert seen["metric_kwargs"]["inner_zones_only"] is True
+    assert seen["metric_kwargs"]["labels"] is False
+    assert seen["metric_kwargs"]["width"] == 500
+    assert seen["metric_kwargs"]["height"] == 400
+    assert seen["metric_kwargs"]["hover_columns"] == ["n_trips", "mode"]
+    assert seen["metric_kwargs"]["legend_label"] == "Walk modal share"
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 2\nMode replanning\nGlobal share: 75.00%"
+    assert seen["metric_kwargs"]["classify"] is False
+    assert seen["metric_kwargs"]["range_color"] == (0.0, 0.8)
+    assert seen["metric_kwargs"]["colorbar_tickformat"] == ".0%"
+    assert modal_share.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2", "z3"],
+        "modal_share": pytest.approx([0.5, 1.0, 0.0]),
+        "n_trips": pytest.approx([1.0, 2.0, 0.0]),
+        "mode": ["walk", "walk", "walk"],
+    }
+    assert seen["values"]["modal_share"].to_list() == pytest.approx([0.5, 1.0, 0.0])
+    assert isinstance(fig, FakeFigure)
+
+
+def test_plot_metric_by_iteration_plots_average_distance(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            return None
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    class FakeTransportZoneMaps:
+        def __init__(self, transport_zones, **kwargs):
+            seen["transport_zones"] = transport_zones
+            seen["map_kwargs"] = kwargs
+
+        def metric(self, values, **kwargs):
+            seen["values"] = values
+            seen["metric_kwargs"] = kwargs
+            return FakeFigure()
+
+    plan_steps = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z2", "z2"],
+            "activity_seq_id": [1, 1, 0],
+            "mode": ["car", "walk", "walk"],
+            "n_persons": [2.0, 2.0, 2.0],
+            "distance": [10.0, 8.0, 0.0],
+            "time": [0.5, 0.4, 0.0],
+        }
+    )
+    demand_groups = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z2"],
+            "n_persons": [2.0, 2.0],
+        }
+    )
+    run = SimpleNamespace(
+        inputs_hash="run",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        population=SimpleNamespace(name="population"),
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "z3"],
+                "is_inner_zone": [True, True, False],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=demand_groups.lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=run,
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    metric, fig = results.metrics.plot_metric_by_iteration(
+        iteration=3,
+        quantity="distance",
+        plot=True,
+        plot_method="notebook",
+        return_figure=True,
+        inner_zones_only=True,
+        labels=False,
+        width=500,
+        height=400,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["map_kwargs"] == {
+        "population": run.population,
+        "max_labels": 30,
+        "simplify_tolerance": 50.0,
+    }
+    assert seen["metric_kwargs"]["value_column"] == "value"
+    assert seen["metric_kwargs"]["save_name"] == "weekdays-average-travel-distance-iteration-3-map"
+    assert seen["metric_kwargs"]["inner_zones_only"] is True
+    assert seen["metric_kwargs"]["labels"] is False
+    assert seen["metric_kwargs"]["width"] == 500
+    assert seen["metric_kwargs"]["height"] == 400
+    assert seen["metric_kwargs"]["hover_columns"] == ["total", "population", "quantity"]
+    assert seen["metric_kwargs"]["legend_label"] == "Average travel distance (km/pers.)"
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 3\nFull replanning\nGlobal average: 9.00 km/pers."
+    assert seen["metric_kwargs"]["classify"] is False
+    assert seen["metric_kwargs"]["color_continuous_scale"][0] == [0.0, "#ffffcc"]
+    assert seen["metric_kwargs"]["color_continuous_scale"][-1] == [1.0, "#800026"]
+    assert seen["metric_kwargs"]["range_color"] == (8.0, 10.0)
+    assert seen["metric_kwargs"]["colorbar_tickformat"] is None
+    assert metric.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2", "z3"],
+        "value": pytest.approx([10.0, 8.0, 0.0]),
+        "total": pytest.approx([20.0, 16.0, 0.0]),
+        "population": pytest.approx([2.0, 2.0, 0.0]),
+        "quantity": ["distance", "distance", "distance"],
+    }
+    assert seen["values"]["value"].to_list() == pytest.approx([10.0, 8.0, 0.0])
+    assert isinstance(fig, FakeFigure)
+
+
+def test_plot_metric_color_range_can_clamp_outliers_by_quantile():
+    metric = pl.DataFrame({"value": [1.0, 2.0, 3.0, 4.0, 100.0]})
+
+    color_range = RunMetrics._positive_metric_color_range(
+        metric,
+        None,
+        value_column="value",
+        clamp_outliers=True,
+        outlier_quantile=0.75,
+    )
+
+    assert color_range == pytest.approx((2.0, 4.0))
+
+
+def test_mode_color_map_uses_report_mode_palette():
+    colors = RunMetrics._mode_label_color_map(
+        [
+            "Car",
+            "Carpool",
+            "Car / public transport / walk",
+            "Bicycle / public transport / walk",
+            "Walk / public transport / walk",
+            "Bicycle",
+            "Walk",
+        ]
+    )
+
+    assert colors == {
+        "Car": "#4D4D4D",
+        "Carpool": "#8C8C8C",
+        "Car / public transport / walk": "#EF4B3E",
+        "Bicycle / public transport / walk": "#D7191C",
+        "Walk / public transport / walk": "#F06A5A",
+        "Bicycle": "#0B5A66",
+        "Walk": "#5F7F73",
+    }
+
+
+def test_car_modal_share_delta_by_iteration_plots_with_transport_zone_maps(
+    monkeypatch,
+    tmp_path,
+):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=plan_steps)
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    class FakeTransportZoneMaps:
+        def __init__(self, transport_zones, **kwargs):
+            seen["transport_zones"] = transport_zones
+            seen["map_kwargs"] = kwargs
+
+        def metric(self, values, **kwargs):
+            seen["values"] = values
+            seen["metric_kwargs"] = kwargs
+            return FakeFigure()
+
+    plan_steps = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z1"],
+            "activity_seq_id": [1, 2],
+            "mode": ["car", "walk"],
+            "n_persons": [1.0, 1.0],
+        }
+    )
+    run = SimpleNamespace(
+        inputs_hash="run",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        population=SimpleNamespace(name="population"),
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1"],
+                "is_inner_zone": [True],
+                "geometry": [None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=run,
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    returned_delta, returned_fig = results.metrics.modal_share_delta_by_iteration(
+        SimpleNamespace(run=run, demand_groups=pl.DataFrame().lazy()),
+        iteration=1,
+        mode="walk/public_transport/walk",
+        plot=True,
+        plot_method="notebook",
+        return_figure=True,
+        inner_zones_only=True,
+        color_range=(-0.03, 0.04),
+        labels=False,
+        width=500,
+        height=400,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["map_kwargs"] == {
+        "population": run.population,
+        "max_labels": 30,
+        "simplify_tolerance": 50.0,
+    }
+    assert seen["metric_kwargs"]["value_column"] == "modal_share_delta"
+    assert seen["metric_kwargs"]["save_name"] == "weekdays-walk-public-transport-walk-modal-share-delta-iteration-1-map"
+    assert seen["metric_kwargs"]["save_to_file"] is False
+    assert seen["metric_kwargs"]["inner_zones_only"] is True
+    assert seen["metric_kwargs"]["labels"] is False
+    assert seen["metric_kwargs"]["width"] == 500
+    assert seen["metric_kwargs"]["height"] == 400
+    assert seen["metric_kwargs"]["classify"] is False
+    assert seen["metric_kwargs"]["color_continuous_midpoint"] == 0.0
+    assert seen["metric_kwargs"]["range_color"] == (-0.03, 0.04)
+    assert seen["metric_kwargs"]["colorbar_tickformat"] == ".0%"
+    assert seen["metric_kwargs"]["hover_columns"] == [
+        "modal_share",
+        "modal_share_reference",
+        "n_trips",
+        "n_trips_reference",
+    ]
+    assert seen["metric_kwargs"]["legend_label"] == "Walk / public transport / walk modal share difference"
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 1\nFull replanning\nGlobal delta: +0.00%"
+    assert seen["values"]["modal_share_delta"].to_list() == pytest.approx([0.0])
+    assert returned_delta["modal_share_delta"].to_list() == pytest.approx([0.0])
+    assert returned_delta["mode"].to_list() == ["walk/public_transport/walk"]
+    assert isinstance(returned_fig, FakeFigure)
+
+
+def test_plot_delta_by_iteration_can_compare_mean_utility(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=plans[self.run_inputs_hash],
+                current_plan_steps=pl.DataFrame(),
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    plans = {
+        "current": pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "utility": [4.0, 1.0],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "demand_group_id": [10, 20],
+                "utility": [3.0, 2.0],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+    }
+    current_demand_groups = pl.DataFrame(
+        {"demand_group_id": [1, 2], "home_zone_id": ["z1", "z2"]}
+    )
+    reference_demand_groups = pl.DataFrame(
+        {"demand_group_id": [10, 20], "home_zone_id": ["z1", "z2"]}
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "z3"],
+                "is_inner_zone": [True, True, True],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=current_demand_groups.lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    delta = results.metrics.plot_delta_by_iteration(
+        SimpleNamespace(run=reference_run, demand_groups=reference_demand_groups.lazy()),
+        iteration=1,
+        value="mean_utility",
+        plot=False,
+    )
+
+    assert delta.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2", "z3"],
+        "value": pytest.approx([4.0, 1.0, 0.0]),
+        "value_reference": pytest.approx([3.0, 2.0, 0.0]),
+        "value_delta": pytest.approx([1.0, -1.0, 0.0]),
+        "value_name": ["mean_utility", "mean_utility", "mean_utility"],
+    }
+
+
+def test_plot_delta_by_iteration_can_compare_ghg_emissions(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=pl.DataFrame(),
+                current_plan_steps=plan_steps[self.run_inputs_hash],
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    plan_steps = {
+        "current": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "activity_seq_id": [1, 1],
+                "from": ["a", "b"],
+                "to": ["c", "d"],
+                "mode": ["car", "walk"],
+                "n_persons": [2.0, 1.0],
+            }
+        ).with_columns(pl.col("mode").cast(pl.Enum(["car", "walk"]))),
+        "reference": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "activity_seq_id": [1, 1],
+                "from": ["a", "b"],
+                "to": ["c", "d"],
+                "mode": ["car", "walk"],
+                "n_persons": [1.0, 1.0],
+            }
+        ).with_columns(pl.col("mode").cast(pl.Enum(["car", "walk"]))),
+    }
+    current_costs = pl.DataFrame(
+        {
+            "from": ["a", "b"],
+            "to": ["c", "d"],
+            "mode": ["car", "walk"],
+            "ghg_emissions_per_trip": [5.0, 0.0],
+        }
+    )
+    reference_costs = pl.DataFrame(
+        {
+            "from": ["a", "b"],
+            "to": ["c", "d"],
+            "mode": ["car", "walk"],
+            "ghg_emissions_per_trip": [5.0, 2.0],
+        }
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2"],
+                "is_inner_zone": [True, True],
+                "geometry": [None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "n_persons": [2.0, 2.0],
+            }
+        ).lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=current_costs.lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    delta = results.metrics.plot_delta_by_iteration(
+        SimpleNamespace(
+            run=reference_run,
+            demand_groups=pl.DataFrame(
+                {
+                    "home_zone_id": ["z1", "z2"],
+                    "n_persons": [2.0, 2.0],
+                }
+            ).lazy(),
+            costs=reference_costs.lazy(),
+        ),
+        iteration=1,
+        value="ghg_emissions",
+        plot=False,
+    )
+
+    assert delta.to_dict(as_series=False) == {
+        "transport_zone_id": ["z1", "z2"],
+        "value": pytest.approx([5.0, 0.0]),
+        "value_reference": pytest.approx([2.5, 1.0]),
+        "value_delta": pytest.approx([2.5, -1.0]),
+        "value_name": ["ghg_emissions", "ghg_emissions"],
+    }
+
+
+def test_plot_delta_by_iteration_can_compare_relative_ghg_emissions(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=pl.DataFrame(),
+                current_plan_steps=plan_steps[self.run_inputs_hash],
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    plan_steps = {
+        "current": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "activity_seq_id": [1, 1],
+                "from": ["a", "b"],
+                "to": ["c", "d"],
+                "mode": ["car", "walk"],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "activity_seq_id": [1, 1],
+                "from": ["a", "b"],
+                "to": ["c", "d"],
+                "mode": ["car", "walk"],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+    }
+    current_costs = pl.DataFrame(
+        {
+            "from": ["a", "b"],
+            "to": ["c", "d"],
+            "mode": ["car", "walk"],
+            "ghg_emissions_per_trip": [5.0, 0.0],
+        }
+    )
+    reference_costs = pl.DataFrame(
+        {
+            "from": ["a", "b"],
+            "to": ["c", "d"],
+            "mode": ["car", "walk"],
+            "ghg_emissions_per_trip": [5.0, 2.0],
+        }
+    )
+    demand_groups = pl.DataFrame(
+        {
+            "home_zone_id": ["z1", "z2"],
+            "n_persons": [2.0, 2.0],
+        }
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2"],
+                "is_inner_zone": [True, True],
+                "geometry": [None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="current",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=demand_groups.lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=current_costs.lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+
+    delta = results.metrics.plot_delta_by_iteration(
+        SimpleNamespace(
+            run=reference_run,
+            demand_groups=demand_groups.lazy(),
+            costs=reference_costs.lazy(),
+        ),
+        iteration=1,
+        value="ghg_emissions",
+        relative_delta=True,
+        plot=False,
+    )
+
+    assert delta["value_delta"].to_list() == pytest.approx([1.0, -1.0])
+
+
+def test_plot_delta_by_iteration_rejects_relative_modal_share(tmp_path):
+    run = SimpleNamespace(
+        inputs_hash="run",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=_make_transport_zones(),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=run,
+    )
+
+    with pytest.raises(ValueError, match="relative_delta=True is not available"):
+        results.metrics.plot_delta_by_iteration(
+            SimpleNamespace(run=run, demand_groups=pl.DataFrame().lazy()),
+            iteration=1,
+            value="modal_share",
+            relative_delta=True,
+            plot=False,
+        )
+
+
+def test_plot_delta_by_iteration_plots_with_transport_zone_maps(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=pl.DataFrame(
+                    {
+                        "home_zone_id": ["z1"],
+                        "utility": [2.0],
+                        "n_persons": [1.0],
+                    }
+                ),
+                current_plan_steps=pl.DataFrame(),
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    class FakeTransportZoneMaps:
+        def __init__(self, transport_zones, **kwargs):
+            seen["transport_zones"] = transport_zones
+            seen["map_kwargs"] = kwargs
+
+        def metric(self, values, **kwargs):
+            seen["values"] = values
+            seen["metric_kwargs"] = kwargs
+            return FakeFigure()
+
+    run = SimpleNamespace(
+        inputs_hash="run",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "run" / "plan_steps.parquet"},
+        population=SimpleNamespace(name="population"),
+    )
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1"],
+                "is_inner_zone": [True],
+                "geometry": [None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=run,
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    delta, fig = results.metrics.plot_delta_by_iteration(
+        SimpleNamespace(run=run, demand_groups=pl.DataFrame().lazy()),
+        iteration=2,
+        value="mean_utility",
+        plot=True,
+        plot_method="notebook",
+        return_figure=True,
+        inner_zones_only=True,
+        color_range=2.0,
+        labels=False,
+        width=500,
+        height=400,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert seen["metric_kwargs"]["value_column"] == "value_delta"
+    assert seen["metric_kwargs"]["legend_label"] == "Mean utility difference"
+    assert seen["metric_kwargs"]["range_color"] == (-2.0, 2.0)
+    assert seen["metric_kwargs"]["inner_zones_only"] is True
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 2\nFull replanning\nGlobal delta: +0.000"
+    assert delta["value_delta"].to_list() == pytest.approx([0.0])
+    assert isinstance(fig, FakeFigure)
+
+
+def test_plot_delta_by_iteration_can_auto_cap_outliers(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=plans[self.run_inputs_hash],
+                current_plan_steps=pl.DataFrame(),
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeTransportZoneMaps:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def metric(self, values, **kwargs):
+            seen["metric_kwargs"] = kwargs
+            return SimpleNamespace(show=lambda _renderer: None)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    plans = {
+        "current": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2", "z3"],
+                "utility": [2.0, 3.0, 20.0],
+                "n_persons": [1.0, 1.0, 1.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2", "z3"],
+                "utility": [1.0, 2.0, 1.0],
+                "n_persons": [1.0, 1.0, 1.0],
+            }
+        ),
+    }
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2", "z3"],
+                "is_inner_zone": [True, True, True],
+                "geometry": [None, None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    results.metrics.plot_delta_by_iteration(
+        SimpleNamespace(run=reference_run, demand_groups=pl.DataFrame().lazy()),
+        iteration=1,
+        value="mean_utility",
+        auto_cap_outliers=True,
+        outlier_quantile=0.5,
+        plot=True,
+    )
+
+    assert seen["metric_kwargs"]["range_color"] == pytest.approx((-1.0, 1.0))
+
+
+def test_plot_delta_by_iteration_can_average_paired_seed_deltas(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(
+                current_plans=plans[self.run_inputs_hash],
+                current_plan_steps=pl.DataFrame(),
+            )
+            return SimpleNamespace(load_state=lambda: state)
+
+    class FakeFigure:
+        def show(self, renderer):
+            seen["renderer"] = renderer
+
+    class FakeTransportZoneMaps:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def metric(self, values, **kwargs):
+            seen["values"] = values
+            seen["metric_kwargs"] = kwargs
+            return FakeFigure()
+
+    def run(name):
+        return SimpleNamespace(
+            inputs_hash=name,
+            is_weekday=True,
+            cache_path={"plan_steps": tmp_path / name / "plan_steps.parquet"},
+        )
+
+    def context(name):
+        return SimpleNamespace(run=run(name), demand_groups=pl.DataFrame().lazy())
+
+    plans = {
+        "scenario-0": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "utility": [3.0, 1.0],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+        "base-0": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "utility": [1.0, 2.0],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+        "scenario-1": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "utility": [5.0, 4.0],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+        "base-1": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "utility": [1.0, 2.0],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+    }
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1", "z2"],
+                "is_inner_zone": [True, True],
+                "geometry": [None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="run",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=run("scenario-0"),
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    delta, fig = results.metrics.plot_delta_by_iteration(
+        None,
+        iteration=1,
+        value="mean_utility",
+        paired_runs=[
+            (context("scenario-0"), context("base-0")),
+            (context("scenario-1"), context("base-1")),
+        ],
+        plot=True,
+        plot_method="notebook",
+        return_figure=True,
+    )
+
+    assert seen["renderer"] == "notebook"
+    assert delta["value_delta"].to_list() == pytest.approx([3.0, 0.5])
+    assert delta["value"].to_list() == pytest.approx([4.0, 2.5])
+    assert delta["value_reference"].to_list() == pytest.approx([1.0, 2.0])
+    assert delta["n_pairs"].to_list() == [2, 2]
+    assert seen["metric_kwargs"]["hover_columns"] == [
+        "value",
+        "value_reference",
+        "value_delta_std",
+        "n_pairs",
+    ]
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 1\nFull replanning\nGlobal delta: +1.750"
+    assert isinstance(fig, FakeFigure)
+
+
+def test_modal_share_delta_gifs_by_iteration_writes_one_gif_per_mode(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=states[self.run_inputs_hash])
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+        population=SimpleNamespace(name="population"),
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    states = {
+        "current": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z1"],
+                "activity_seq_id": [1, 2],
+                "mode": ["car", "walk"],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z1"],
+                "activity_seq_id": [1, 2],
+                "mode": ["walk", "car"],
+                "n_persons": [1.0, 1.0],
+            }
+        ),
+    }
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["z1"],
+                "is_inner_zone": [True],
+                "geometry": [None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+    reference_results = SimpleNamespace(
+        run=reference_run,
+        demand_groups=pl.DataFrame().lazy(),
+    )
+    seen = {"frames": [], "gifs": []}
+
+    def fake_save_frame(**kwargs):
+        seen["frames"].append(kwargs)
+
+    def fake_write_gif(frame_paths, output_path, duration_ms):
+        seen["gifs"].append((frame_paths, output_path, duration_ms))
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(results.metrics, "_save_modal_share_delta_frame", fake_save_frame)
+    monkeypatch.setattr(results.metrics, "_write_gif", fake_write_gif)
+
+    gif_paths = results.metrics.modal_share_delta_gifs_by_iteration(
+        reference_results,
+        modes=["walk", "car"],
+        iterations=range(1, 3),
+        value_type="n_trips_delta",
+        inner_zones_only=True,
+        color_range=0.25,
+        labels=False,
+        output_folder=tmp_path,
+        duration_ms=250,
+    )
+
+    assert set(gif_paths) == {"walk", "car"}
+    assert gif_paths["walk"].name == "runhash-weekdays-walk-n-trips-delta-iterations-1-2-map.gif"
+    assert gif_paths["car"].name == "runhash-weekdays-car-n-trips-delta-iterations-1-2-map.gif"
+    assert len(seen["frames"]) == 4
+    assert len(seen["gifs"]) == 2
+    assert all(frame["value_type"] == "n_trips_delta" for frame in seen["frames"])
+    assert all(frame["inner_zones_only"] is True for frame in seen["frames"])
+    assert all(frame["color_range"] == 0.25 for frame in seen["frames"])
+    assert [frame["global_delta"] for frame in seen["frames"]] == pytest.approx([0.0, 0.0, 0.0, 0.0])
+    assert all(gif_call[2] == 250 for gif_call in seen["gifs"])
+
+
+def test_modal_share_delta_gif_global_delta_uses_inner_zone_scope(monkeypatch, tmp_path):
+    class FakeIterations:
+        def __init__(self, *, run_inputs_hash, is_weekday, base_folder):
+            self.run_inputs_hash = run_inputs_hash
+
+        def iteration(self, iteration):
+            state = SimpleNamespace(current_plan_steps=states[self.run_inputs_hash])
+            return SimpleNamespace(load_state=lambda: state)
+
+    current_run = SimpleNamespace(
+        inputs_hash="current",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "current" / "plan_steps.parquet"},
+        population=None,
+    )
+    reference_run = SimpleNamespace(
+        inputs_hash="reference",
+        is_weekday=True,
+        cache_path={"plan_steps": tmp_path / "reference" / "plan_steps.parquet"},
+    )
+    states = {
+        "current": pl.DataFrame(
+            {
+                "home_zone_id": ["inner", "inner", "outer"],
+                "activity_seq_id": [1, 2, 1],
+                "mode": ["car", "walk", "walk"],
+                "n_persons": [2.0, 2.0, 100.0],
+            }
+        ),
+        "reference": pl.DataFrame(
+            {
+                "home_zone_id": ["inner", "inner", "outer"],
+                "activity_seq_id": [1, 2, 1],
+                "mode": ["car", "walk", "car"],
+                "n_persons": [1.0, 3.0, 100.0],
+            }
+        ),
+    }
+    transport_zones = SimpleNamespace(
+        get=lambda: pd.DataFrame(
+            {
+                "transport_zone_id": ["inner", "outer"],
+                "is_inner_zone": [True, False],
+                "geometry": [None, None],
+            }
+        )
+    )
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=transport_zones,
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=SimpleNamespace(),
+        run=current_run,
+    )
+    seen = {"frames": []}
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.Iterations",
+        FakeIterations,
+    )
+    monkeypatch.setattr(
+        results.metrics,
+        "_save_modal_share_delta_frame",
+        lambda **kwargs: seen["frames"].append(kwargs),
+    )
+    monkeypatch.setattr(results.metrics, "_write_gif", lambda *args, **kwargs: None)
+
+    results.metrics.modal_share_delta_gifs_by_iteration(
+        SimpleNamespace(run=reference_run, demand_groups=pl.DataFrame().lazy()),
+        modes=["car"],
+        iterations=[1],
+        inner_zones_only=True,
+        output_folder=tmp_path,
+    )
+
+    assert [frame["global_delta"] for frame in seen["frames"]] == pytest.approx([0.25])
+
+
+def test_modal_share_delta_gif_frame_adds_iteration_counter(monkeypatch, tmp_path):
+    class FakeTransportZoneMaps:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def metric(self, *args, **kwargs):
+            seen["metric_kwargs"] = kwargs
+
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=SimpleNamespace(get=lambda: pd.DataFrame()),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=Parameters(
+            behavior_change_phases=[
+                BehaviorChangePhase(
+                    start_iteration=5,
+                    scope=BehaviorChangeScope.MODE_REPLANNING,
+                )
+            ]
+        ),
+        run=SimpleNamespace(population=None),
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    results.metrics._save_modal_share_delta_frame(
+        modal_share_delta=pl.DataFrame(
+            {
+                "transport_zone_id": ["z1"],
+                "modal_share": [0.5],
+                "modal_share_reference": [0.4],
+                "modal_share_delta": [0.1],
+                "mode": ["car"],
+            }
+        ),
+        mode="car",
+        iteration=7,
+        value_type="modal_share_delta",
+        global_delta=0.12,
+        output_path=tmp_path / "frame.png",
+        inner_zones_only=True,
+        color_range=0.25,
+        labels=False,
+        width=500,
+        height=400,
+        max_labels=30,
+        simplify_tolerance=50.0,
+    )
+
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 7\nMode replanning\nGlobal delta: +12.00%"
+
+
+def test_modal_share_delta_frame_can_plot_trip_count_delta(monkeypatch, tmp_path):
+    class FakeTransportZoneMaps:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def metric(self, *args, **kwargs):
+            seen["metric_kwargs"] = kwargs
+
+    results = RunResults(
+        inputs_hash="runhash",
+        is_weekday=True,
+        transport_zones=SimpleNamespace(get=lambda: pd.DataFrame()),
+        demand_groups=pl.DataFrame().lazy(),
+        plan_steps=pl.DataFrame().lazy(),
+        opportunities=pl.DataFrame().lazy(),
+        costs=pl.DataFrame().lazy(),
+        population_weighted_plan_steps=pl.DataFrame().lazy(),
+        transitions=pl.DataFrame().lazy(),
+        surveys=[],
+        modes=[],
+        parameters=Parameters(),
+        run=SimpleNamespace(population=None),
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.core.metrics.TransportZoneMaps",
+        FakeTransportZoneMaps,
+    )
+
+    results.metrics._save_modal_share_delta_frame(
+        modal_share_delta=pl.DataFrame(
+            {
+                "transport_zone_id": ["z1"],
+                "modal_share": [0.5],
+                "modal_share_reference": [0.4],
+                "modal_share_delta": [0.1],
+                "n_trips": [12.0],
+                "n_trips_reference": [9.0],
+                "n_trips_delta": [3.0],
+                "mode": ["car"],
+            }
+        ),
+        mode="car",
+        iteration=2,
+        value_type="n_trips_delta",
+        global_delta=3.0,
+        output_path=tmp_path / "frame.png",
+        inner_zones_only=True,
+        color_range=5.0,
+        labels=False,
+        width=500,
+        height=400,
+        max_labels=30,
+        simplify_tolerance=50.0,
+    )
+
+    assert seen["metric_kwargs"]["value_column"] == "n_trips_delta"
+    assert seen["metric_kwargs"]["legend_label"] == "Car trip count difference"
+    assert seen["metric_kwargs"]["colorbar_tickformat"] is None
+    assert seen["metric_kwargs"]["frame_title"] == "Iteration 2\nFull replanning\nGlobal delta: +3 trips"
+
+
 def test_plot_map_builds_choropleth_without_opening_backend(monkeypatch):
     class _GeoFrame(pd.DataFrame):
         @property
@@ -754,11 +2912,42 @@ def test_mask_outliers_replaces_extreme_values_with_nan():
 
     assert pd.isna(masked.iloc[-1])
     assert masked.iloc[0] == pytest.approx(1.0)
+
+
+def test_calibration_plan_steps_keep_stay_home_as_a_distribution_state():
+    raw_plan_steps = pl.DataFrame(
+        {
+            "activity_seq_id": [1, 0],
+            "activity": ["work", "home"],
+            "mode": ["car", "stay_home"],
+            "distance": [10.0, 0.0],
+            "time": [0.5, 0.0],
+            "n_persons": [2.0, 3.0],
+        }
+    ).with_columns(
+        activity=pl.col("activity").cast(pl.Enum(["home", "work"])),
+        mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"])),
+    )
+
+    calibration_steps = to_calibration_plan_steps(raw_plan_steps).collect()
+
+    assert calibration_steps.sort("mode").to_dict(as_series=False) == {
+        "activity": ["work", "stay_home"],
+        "distance_bin": ["[10, 20)", "stay_home"],
+        "time_bin": ["[30, 45)", "stay_home"],
+        "mode": ["car", "stay_home"],
+        "distance": [10.0, 0.0],
+        "time": [0.5, 0.0],
+        "n_persons": [2.0, 3.0],
+    }
+
+
 def test_model_loss_summary_history_and_validation():
     expected = pl.DataFrame(
         {
             "activity": ["work", "shop"],
             "distance_bin": ["(1, 5]", "(0, 1]"],
+            "time_bin": ["[60, 1000000000)", "[60, 1000000000)"],
             "mode": ["car", "walk"],
             "distance": [10.0, 1.0],
             "time": [2.0, 1.0],
@@ -769,6 +2958,7 @@ def test_model_loss_summary_history_and_validation():
         {
             "activity": ["work", "shop"],
             "distance_bin": ["(1, 5]", "(0, 1]"],
+            "time_bin": ["[60, 1000000000)", "[60, 1000000000)"],
             "mode": ["car", "walk"],
             "distance": [8.0, 1.0],
             "time": [1.5, 2.0],
@@ -780,9 +2970,11 @@ def test_model_loss_summary_history_and_validation():
             {
                 "iteration": [1],
                 "total_loss": [0.3],
-                "distance_loss": [0.1],
-                "n_trips_loss": [0.05],
-                "time_loss": [0.15],
+                "trip_count_loss": [0.08],
+                "activity_loss": [0.04],
+                "distance_bin_loss": [0.05],
+                "time_bin_loss": [0.06],
+                "mode_loss": [0.07],
                 "observed_entropy": [0.7],
                 "mean_utility": [1.0],
                 "mean_trip_count": [2.0],
@@ -801,11 +2993,22 @@ def test_model_loss_summary_history_and_validation():
     history = loss.history()
     history_row = loss.history_row(iteration=2, plan_steps=observed)
 
-    assert summary.height == 3
+    assert summary.height == 1
     assert summary["total_loss"].unique().item() > 0.0
-    assert history.columns == ["iteration", "total_loss", "distance_loss", "n_trips_loss", "time_loss"]
+    assert history.columns == [
+        "iteration",
+        "total_loss",
+        "trip_count_loss",
+        "activity_loss",
+        "distance_bin_loss",
+        "time_bin_loss",
+        "mode_loss",
+    ]
     assert history_row["total_loss"] > 0.0
-    assert history_row["distance_loss"] >= 0.0
+    assert history_row["activity_loss"] >= 0.0
+    assert history_row["distance_bin_loss"] >= 0.0
+    assert history_row["time_bin_loss"] >= 0.0
+    assert history_row["mode_loss"] >= 0.0
 
     with pytest.raises(ValueError, match="ModelLoss expects canonical calibration plan steps"):
         loss.comparison(
@@ -818,6 +3021,131 @@ def test_model_loss_summary_history_and_validation():
                 }
             )
         )
+
+
+def test_model_loss_is_based_on_distribution_shares_not_global_scale():
+    expected = pl.DataFrame(
+        {
+            "activity": ["work", "shop", "stay_home"],
+            "distance_bin": ["(1, 5]", "(0, 1]", "stay_home"],
+            "time_bin": ["[60, 1000000000)", "[60, 1000000000)", "stay_home"],
+            "mode": ["car", "walk", "stay_home"],
+            "distance": [10.0, 1.0, 0.0],
+            "time": [2.0, 1.0, 0.0],
+            "n_persons": [2.0, 1.0, 1.0],
+        }
+    )
+    observed = pl.DataFrame(
+        {
+            "activity": ["work", "shop", "stay_home"],
+            "distance_bin": ["(1, 5]", "(0, 1]", "stay_home"],
+            "time_bin": ["[60, 1000000000)", "[60, 1000000000)", "stay_home"],
+            "mode": ["car", "walk", "stay_home"],
+            "distance": [10.0, 1.0, 0.0],
+            "time": [2.0, 1.0, 0.0],
+            "n_persons": [1.0, 2.0, 1.0],
+        }
+    )
+
+    scaled_expected = expected.with_columns(n_persons=pl.col("n_persons") * 10.0)
+    scaled_observed = observed.with_columns(n_persons=pl.col("n_persons") * 10.0)
+
+    loss = ModelLoss(expected_plan_steps=_FrameAsset(expected, lazy=False))
+    scaled_loss = ModelLoss(expected_plan_steps=_FrameAsset(scaled_expected, lazy=False))
+
+    assert loss.total_loss(plan_steps=observed) == pytest.approx(
+        scaled_loss.total_loss(plan_steps=scaled_observed)
+    )
+
+
+def test_model_loss_ignores_stay_home_when_comparing_trip_distributions():
+    """Stay-home is a person state, not a trip class in the trip-count loss."""
+    expected = pl.DataFrame(
+        {
+            "activity": ["work"],
+            "distance_bin": ["(1, 5]"],
+            "time_bin": ["[60, 1000000000)"],
+            "mode": ["car"],
+            "distance": [10.0],
+            "time": [2.0],
+            "n_persons": [2.0],
+        }
+    )
+    observed = pl.DataFrame(
+        {
+            "activity": ["work", "stay_home"],
+            "distance_bin": ["(1, 5]", "stay_home"],
+            "time_bin": ["[60, 1000000000)", "stay_home"],
+            "mode": ["car", "stay_home"],
+            "distance": [10.0, 0.0],
+            "time": [2.0, 0.0],
+            "n_persons": [2.0, 3.0],
+        }
+    )
+
+    comparison = ModelLoss(expected_plan_steps=_FrameAsset(expected, lazy=False)).comparison(plan_steps=observed)
+
+    assert comparison["activity"].to_list() == ["work"]
+    assert comparison["observed_total"].to_list() == pytest.approx([2.0])
+    assert comparison["expected_total"].to_list() == pytest.approx([2.0])
+
+
+def test_model_trip_count_loss_uses_cleaned_survey_steps_and_immobility():
+    """The zero-trip mass comes from survey immobility, not calibration step rows."""
+    expected_mobile_steps = pl.DataFrame(
+        {
+            "country": ["fr", "fr", "fr", "fr", "fr", "fr"],
+            "home_zone_id": ["z1", "z1", "z2", "z2", "z2", "z2"],
+            "city_category": ["dense", "dense", "dense", "dense", "dense", "dense"],
+            "csp": ["A", "A", "A", "A", "A", "A"],
+            "n_cars": [1, 1, 1, 1, 1, 1],
+            "activity_seq_id": [1, 1, 2, 2, 2, 2],
+            "time_seq_id": [10, 10, 20, 20, 20, 20],
+            "seq_step_index": [1, 2, 1, 2, 3, 4],
+            "n_persons": [10.0, 10.0, 5.0, 5.0, 5.0, 5.0],
+        }
+    )
+    survey = SimpleNamespace(
+        inputs={"parameters": SimpleNamespace(country="fr")},
+        get=lambda: {
+            "p_immobility": pd.DataFrame(
+                {"immobility_weekday": [0.2], "immobility_weekend": [0.3]},
+                index=pd.Index(["A"], name="csp"),
+            )
+        },
+    )
+    observed_steps = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1, 2],
+            "activity_seq_id": [1, 1, 0],
+            "time_seq_id": [10, 10, 0],
+            "dest_seq_id": [10, 10, 0],
+            "mode_seq_id": [10, 10, 0],
+            "seq_step_index": [1, 2, 0],
+            "n_persons": [2.0, 2.0, 3.0],
+        }
+    )
+
+    distribution = build_trip_count_distribution(
+        expected_mobile_steps,
+        immobility_probabilities=pl.DataFrame({"country": ["fr"], "csp": ["A"], "p_immobility": [0.2]}),
+    )
+    loss = ModelTripCountLoss(
+        expected_plan_steps=_FrameAsset(expected_mobile_steps),
+        surveys=[survey],
+        is_weekday=True,
+        observed_plan_steps=_FrameAsset(observed_steps),
+    )
+
+    expected_by_bin = dict(zip(distribution["trip_count_bin"], distribution["n_persons"]))
+    comparison = loss.comparison()
+
+    assert expected_by_bin["0"] == pytest.approx(3.0)
+    assert expected_by_bin["2"] == pytest.approx(8.0)
+    assert expected_by_bin["4"] == pytest.approx(4.0)
+    assert comparison["expected_total"].max() == pytest.approx(15.0)
+    assert comparison["observed_total"].max() == pytest.approx(5.0)
+    assert loss.total_loss() >= 0.0
 
 
 def test_model_entropy_and_trip_pattern_distribution_cover_mobile_and_stay_home_patterns():
@@ -853,9 +3181,11 @@ def test_model_entropy_and_trip_pattern_distribution_cover_mobile_and_stay_home_
             {
                 "iteration": [1],
                 "total_loss": [0.3],
-                "distance_loss": [0.1],
-                "n_trips_loss": [0.05],
-                "time_loss": [0.15],
+                "trip_count_loss": [0.08],
+                "activity_loss": [0.04],
+                "distance_bin_loss": [0.05],
+                "time_bin_loss": [0.06],
+                "mode_loss": [0.07],
                 "observed_entropy": [0.7],
                 "mean_utility": [1.0],
                 "mean_trip_count": [2.0],
@@ -890,9 +3220,17 @@ def test_iteration_metrics_builder_rebuilds_history_and_run_diagnostics_exposes_
             return {
                 "iteration": iteration,
                 "total_loss": float(iteration),
-                "distance_loss": 0.1,
-                "n_trips_loss": 0.2,
-                "time_loss": 0.3,
+                "activity_loss": 0.1,
+                "distance_bin_loss": 0.2,
+                "time_bin_loss": 0.3,
+                "mode_loss": 0.4,
+            }
+
+    class FakeTripCountLoss:
+        def history_row(self, *, iteration, plan_steps):
+            return {
+                "iteration": iteration,
+                "trip_count_loss": 0.5,
             }
 
     class FakeEntropy:
@@ -913,12 +3251,23 @@ def test_iteration_metrics_builder_rebuilds_history_and_run_diagnostics_exposes_
             "mode": ["car", "stay_home"],
         }
     )
-    builder = IterationMetricsBuilder(model_loss=FakeLoss(), model_entropy=FakeEntropy())
+    builder = IterationMetricsBuilder(
+        model_loss=FakeLoss(),
+        model_trip_count_loss=FakeTripCountLoss(),
+        model_entropy=FakeEntropy(),
+    )
 
     row = builder.history_row(
         iteration=2,
         current_plans=current_plans,
         current_plan_steps=current_plan_steps,
+        destination_saturation=pl.DataFrame(
+            {
+                "opportunity_occupation": [100.0, 80.0],
+                "opportunity_capacity": [50.0, 100.0],
+                "destination_soft_capacity_factor": [1.25, 1.25],
+            }
+        ),
     )
 
     class FakeIteration:
@@ -928,7 +3277,11 @@ def test_iteration_metrics_builder_rebuilds_history_and_run_diagnostics_exposes_
         def load_state(self):
             return self._state
 
-    fake_state = SimpleNamespace(current_plans=current_plans, current_plan_steps=current_plan_steps)
+    fake_state = SimpleNamespace(
+        current_plans=current_plans,
+        current_plan_steps=current_plan_steps,
+        destination_saturation=pl.DataFrame(),
+    )
     fake_iterations = SimpleNamespace(iteration=lambda _: FakeIteration(fake_state))
     rebuilt = builder.rebuild_history(iterations=fake_iterations, resume_from_iteration=2)
     history_store = IterationMetricsHistory(IterationMetricsHistory.from_records([row]).lazy())
@@ -938,15 +3291,31 @@ def test_iteration_metrics_builder_rebuilds_history_and_run_diagnostics_exposes_
             observed_calibration_plan_steps=object(),
             expected_entropy_plan_steps=object(),
             observed_entropy_plan_steps=object(),
+            population_weighted_plan_steps=object(),
+            surveys=[],
+            is_weekday=True,
+            plan_steps=object(),
             iteration_metrics_store=history_store,
         )
     )
 
+    assert row["total_loss"] == pytest.approx(2.5)
+    assert row["trip_count_loss"] == pytest.approx(0.5)
     assert row["mean_utility"] == pytest.approx(2.5)
     assert row["mean_trip_count"] == pytest.approx(0.5)
     assert row["mean_travel_time"] == pytest.approx(0.5)
     assert row["mean_travel_distance"] == pytest.approx(5.0)
+    assert row["excess_occupation_share"] == pytest.approx((100.0 - 62.5) / 180.0)
     assert [record["iteration"] for record in rebuilt] == [1, 2]
     assert diagnostics.iteration_metrics()["iteration"].to_list() == [2]
-    assert diagnostics.loss().history().columns == ["iteration", "total_loss", "distance_loss", "n_trips_loss", "time_loss"]
+    assert diagnostics.loss().history().columns == [
+        "iteration",
+        "total_loss",
+        "trip_count_loss",
+        "activity_loss",
+        "distance_bin_loss",
+        "time_bin_loss",
+        "mode_loss",
+    ]
+    assert diagnostics.trip_count_loss().history().columns == ["iteration", "trip_count_loss"]
     assert diagnostics.entropy().history().columns == ["iteration", "observed_entropy"]


### PR DESCRIPTION
### Motivation

This PR improves the tools used to understand and compare grouped day-trip runs.

Before this PR, diagnostics mostly focused on a few aggregate values. It was harder to see whether the model matched the observed distribution of activities, distances, travel times, modes, and trip counts per person.

This made parameter tuning harder, because a run could look acceptable on a global average while still having the wrong trip-count distribution, wrong modal split by zone, wrong activity schedule, or overloaded destinations.

After this PR, diagnostics describe more of the shape of the modelled mobility. This gives clearer feedback when comparing a run with survey data or when tuning model parameters.

### Changes

This PR adds richer diagnostics and metrics for grouped day trips.

Main changes:

- adds `ModelTripCountLoss` to compare the modelled and survey trip-count distributions;
- changes `ModelLoss` to compare distribution shares by activity, distance bin, time bin, and mode;
- stores more iteration diagnostics:
  - `trip_count_loss`
  - `activity_loss`
  - `distance_bin_loss`
  - `time_bin_loss`
  - `mode_loss`
  - `excess_occupation_share`
- adds activity duration and activity time-series metrics;
- adds plotting and SVG export helpers for activity time series, travel indicators, travel costs, modal share, and modal-share deltas;
- improves transition state labels so they include activity sequence, time sequence, destination sequence, and mode sequence;
- updates resume diagnostics so saved destination saturation can be used when rebuilding iteration metrics.

### Example

```python
results = group_day_trips.weekday_run.get()

iteration_metrics = results.diagnostics.iteration_metrics()
trip_count_loss = results.diagnostics.trip_count_loss().summary()
activity_time = results.metrics.activity_time_series(interval_minutes=15)
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: implementation split from the larger dump branch, tests, and PR text.
- What you reviewed or changed: diagnostics, metrics, calibration loss, trip-count loss, plotting/export helpers, and tests.
- How you validated it: ran focused diagnostics tests, the full group-day-trip unit suite, related integration tests, `py_compile`, and `git diff --check`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior