### PR TITLE
Refine group day trip utility calibration

### DIFF
--- a/mobility/activities/leisure/leisure.py
+++ b/mobility/activities/leisure/leisure.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import polars as pl
 import geopandas as gpd
-from typing import List
 import numpy as np
 import os
 
@@ -31,6 +30,7 @@ class LeisureActivity(Activity):
         survey_ids: List[str] = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
+        country_value_coefficients: dict[str, float] | None = None,
         parameters: "LeisureParameters" | None = None
     ):
         
@@ -54,6 +54,7 @@ class LeisureActivity(Activity):
                 ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
+                "country_value_coefficients": country_value_coefficients,
             },
             owner_name="LeisureActivity",
         )
@@ -181,3 +182,7 @@ class LeisureParameters(ActivityParameters):
         Field(default_factory=lambda: ["7.71", "7.72", "7.73", "7.74", "7.75", "7.76", "7.77", "7.78"]),
     ]
     radiation_lambda: Annotated[UnitIntervalFloat, Field(default=0.99986)]
+    country_value_coefficients: Annotated[
+        dict[str, float],
+        Field(default_factory=lambda: {"fr": 1.0, "ch": 1.0}),
+    ]

--- a/mobility/activities/shopping/shop.py
+++ b/mobility/activities/shopping/shop.py
@@ -28,6 +28,7 @@ class ShopActivity(Activity):
         survey_ids: List[str] = None,
         radiation_lambda: float = None,
         opportunities: pd.DataFrame = None,
+        country_value_coefficients: dict[str, float] | None = None,
         parameters: "ShopParameters" | None = None
     ):
 
@@ -51,6 +52,7 @@ class ShopActivity(Activity):
                 ),
                 "survey_ids": survey_ids,
                 "radiation_lambda": radiation_lambda,
+                "country_value_coefficients": country_value_coefficients,
             },
             owner_name="ShopActivity",
         )
@@ -103,3 +105,7 @@ class ShopParameters(ActivityParameters):
     saturation_fun_beta: Annotated[float, Field(default=4.0, ge=0.0)]
     survey_ids: Annotated[list[str], Field(default_factory=lambda: ["2.20", "2.21"])]
     radiation_lambda: Annotated[UnitIntervalFloat, Field(default=0.99986)]
+    country_value_coefficients: Annotated[
+        dict[str, float],
+        Field(default_factory=lambda: {"fr": 1.0, "ch": 0.9}),
+    ]

--- a/mobility/activities/studies/study.py
+++ b/mobility/activities/studies/study.py
@@ -59,6 +59,7 @@ class StudyActivity(Activity):
 
         super().__init__(
             name="studies",
+            is_anchor=True,
             opportunities=opportunities,
             parameters=parameters
         )

--- a/mobility/activities/work/work.py
+++ b/mobility/activities/work/work.py
@@ -131,5 +131,5 @@ class WorkParameters(ActivityParameters):
 
     country_value_coefficients: Annotated[
         dict[str, float],
-        Field(default_factory=lambda: {"fr": 1.0, "ch": 1.0}),
+        Field(default_factory=lambda: {"fr": 1.0, "ch": 1.1}),
     ]

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -89,6 +89,17 @@ class PlanUpdater:
             arrival_time_rigidity_by_activity=arrival_time_rigidity_by_activity,
             enabled=parameters.update_plan_timings_from_modeled_travel_times,
         )
+        possible_plan_steps = (
+            possible_plan_steps
+            .with_columns(
+                utility=(
+                    pl.col("activity_utility_scale")
+                    * (pl.col("duration_per_pers") / pl.col("min_activity_time")).log().clip(0.0)
+                    - pl.col("cost")
+                )
+            )
+            .drop("activity_utility_scale", "destination_shadow_price")
+        )
         possible_plan_utility = self.get_possible_plan_utility(
             possible_plan_steps,
             home_night_dur,
@@ -325,7 +336,7 @@ class PlanUpdater:
             "k_saturation_utility",
             "destination_shadow_price",
             "min_activity_time",
-            "utility",
+            "activity_utility_scale",
         ]
 
         scored_candidates = (
@@ -368,7 +379,7 @@ class PlanUpdater:
                 min_activity_time=pl.col("mean_duration_per_pers") * math.exp(-min_activity_time_constant),
             )
             .with_columns(
-                utility=(
+                activity_utility_scale=(
                     (
                         pl.col("country_value_coefficient") * pl.col("value_of_time")
                         + pl.col("destination_shadow_price")
@@ -380,8 +391,6 @@ class PlanUpdater:
                         )
                     )
                     * pl.col("mean_duration_per_pers")
-                    * (pl.col("duration_per_pers") / pl.col("min_activity_time")).log().clip(0.0)
-                    - pl.col("cost")
                 )
             )
             .drop(["destination_country", "country_value_coefficient"])
@@ -408,7 +417,9 @@ class PlanUpdater:
             )
             .agg(
                 utility=pl.col("utility").sum(),
-                home_night_per_pers=24.0 - pl.col("duration_per_pers").sum(),
+                home_night_per_pers=(
+                    24.0 - pl.col("duration_per_pers").sum() - pl.col("time").fill_null(0.0).sum()
+                ).clip(0.0),
             )
             .join(home_night_dur.lazy(), on=["country", "csp"])
             .with_columns(
@@ -1253,7 +1264,7 @@ class PlanUpdater:
         if "capacity_ratio" not in columns:
             expressions.append(pl.lit(0.0, dtype=pl.Float64).alias("capacity_ratio"))
         if "destination_soft_capacity_factor" not in columns:
-            expressions.append(pl.lit(1.0, dtype=pl.Float64).alias("destination_soft_capacity_factor"))
+            expressions.append(pl.lit(1.25, dtype=pl.Float64).alias("destination_soft_capacity_factor"))
         if not expressions:
             return destination_saturation
         return destination_saturation.with_columns(expressions)

--- a/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
+++ b/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
@@ -5,10 +5,11 @@ import pandas as pd
 import polars as pl
 import pytest
 
+from mobility.trips.group_day_trips.plans.plan_ids import add_plan_id
 from mobility.trips.group_day_trips.plans.plan_updater import PlanUpdater
 
 
-def test_plan_updater_applies_destination_country_value_coefficient():
+def test_plan_updater_prepares_destination_country_value_coefficient():
     updater = PlanUpdater()
     candidates = pl.DataFrame(
         {
@@ -30,6 +31,7 @@ def test_plan_updater_applies_destination_country_value_coefficient():
             "iteration": [1, 1],
             "csp": ["x", "x"],
             "first_seen_iteration": [None, None],
+            "last_seen_iteration": [None, None],
             "last_active_iteration": [None, None],
         }
     ).with_columns(mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"]))).lazy()
@@ -88,9 +90,12 @@ def test_plan_updater_applies_destination_country_value_coefficient():
         allow_missing_costs_for_current_plans=False,
     ).collect()
 
-    utilities_by_destination = dict(zip(result["to"].to_list(), result["utility"].to_list(), strict=True))
-    assert utilities_by_destination[10] == pytest.approx(7.0)
-    assert utilities_by_destination[20] == pytest.approx(15.0)
+    coefficients_by_destination = dict(
+        zip(result["to"].to_list(), result["activity_utility_scale"].to_list(), strict=True)
+    )
+    assert coefficients_by_destination[10] == pytest.approx(8.0)
+    assert coefficients_by_destination[20] == pytest.approx(16.0)
+    assert "last_seen_iteration" in result.columns
 
 
 def test_plan_updater_integrates_shadow_price_in_activity_value_when_enabled():
@@ -115,6 +120,7 @@ def test_plan_updater_integrates_shadow_price_in_activity_value_when_enabled():
             "iteration": [1],
             "csp": ["x"],
             "first_seen_iteration": [None],
+            "last_seen_iteration": [None],
             "last_active_iteration": [None],
         }
     ).with_columns(mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"]))).lazy()
@@ -175,8 +181,7 @@ def test_plan_updater_integrates_shadow_price_in_activity_value_when_enabled():
         use_destination_shadow_prices=True,
     ).collect()
 
-    expected_utility = -8.0 * math.log(math.e) - 1.0
-    assert result["utility"].item() == pytest.approx(expected_utility)
+    assert result["activity_utility_scale"].item() == pytest.approx(-8.0)
     assert result["destination_shadow_price"].item() == pytest.approx(-2.0)
 
 
@@ -226,41 +231,98 @@ def test_destination_saturation_computes_shadow_price_above_soft_capacity():
     assert below_soft_capacity["destination_sampling_attraction_factor"] == pytest.approx(1.0)
 
 
-def test_add_stay_home_plan_steps_adds_neutral_shadow_price(tmp_path):
+def test_possible_plan_utility_subtracts_travel_time_from_home_night(tmp_path):
+    """Check that plan utility does not count travel time as home/night time."""
     updater = PlanUpdater()
     index_folder = tmp_path / "plan_index"
     index_folder.mkdir()
-    possible_plan_steps = pl.DataFrame(
+    possible_plan_steps = add_plan_id(
+        pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "country": ["fr"],
+                "activity_seq_id": [10],
+                "time_seq_id": [100],
+                "dest_seq_id": [1000],
+                "mode_seq_id": [10000],
+                "csp": ["worker"],
+                "duration_per_pers": [8.0],
+                "time": [2.0],
+                "utility": [5.0],
+            }
+        ),
+        index_folder=index_folder,
+    ).lazy()
+    home_night_dur = pl.DataFrame(
         {
-            "demand_group_id": [1],
             "country": ["fr"],
             "csp": ["worker"],
-            "activity_seq_id": [10],
-            "time_seq_id": [100],
-            "dest_seq_id": [1000],
-            "mode_seq_id": [10000],
-            "seq_step_index": [1],
-            "activity": ["work"],
-            "from": [1],
-            "to": [2],
-            "mode": ["car"],
-            "duration_per_pers": [8.0],
-            "departure_time": [8.0],
-            "arrival_time": [9.0],
-            "next_departure_time": [17.0],
-            "iteration": [2],
-            "cost": [1.0],
-            "distance": [10.0],
-            "time": [1.0],
-            "mean_duration_per_pers": [8.0],
-            "value_of_time": [1.0],
-            "k_saturation_utility": [1.0],
-            "destination_shadow_price": [-0.5],
-            "min_activity_time": [1.0],
-            "first_seen_iteration": [2],
-            "last_active_iteration": [None],
-            "utility": [5.0],
+            "mean_home_night_per_pers": [10.0],
         }
+    )
+    stay_home_plan = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "activity_seq_id": [0],
+            "time_seq_id": [0],
+            "mode_seq_id": [0],
+            "dest_seq_id": [0],
+            "mean_home_night_per_pers": [10.0],
+        }
+    )
+
+    result = updater.get_possible_plan_utility(
+        possible_plan_steps,
+        home_night_dur,
+        value_of_time_stay_home=1.0,
+        stay_home_plan=stay_home_plan,
+        min_activity_time_constant=1.0,
+        sequence_index_folder=index_folder,
+    ).collect()
+
+    mobile_utility = result.filter(pl.col("mode_seq_id") != 0)["utility"].item()
+    expected_home_night_utility = 10.0 * math.log(14.0 / (10.0 * math.exp(-1.0)))
+    assert mobile_utility == pytest.approx(5.0 + expected_home_night_utility)
+
+
+def test_add_stay_home_plan_steps_preserves_candidate_retention_columns(tmp_path):
+    updater = PlanUpdater()
+    index_folder = tmp_path / "stay_home_plan_index"
+    index_folder.mkdir()
+    possible_plan_steps = add_plan_id(
+        pl.DataFrame(
+            {
+                "demand_group_id": [1],
+                "country": ["fr"],
+                "csp": ["worker"],
+                "activity_seq_id": [10],
+                "time_seq_id": [100],
+                "dest_seq_id": [1000],
+                "mode_seq_id": [10000],
+                "seq_step_index": [1],
+                "activity": ["work"],
+                "from": [1],
+                "to": [2],
+                "mode": ["car"],
+                "duration_per_pers": [8.0],
+                "departure_time": [8.0],
+                "arrival_time": [9.0],
+                "next_departure_time": [17.0],
+                "iteration": [2],
+                "cost": [1.0],
+                "distance": [10.0],
+                "time": [1.0],
+                "mean_duration_per_pers": [8.0],
+                "value_of_time": [1.0],
+                "k_saturation_utility": [1.0],
+                "min_activity_time": [1.0],
+                "first_seen_iteration": [2],
+                "last_seen_iteration": [2],
+                "last_active_iteration": [None],
+                "utility": [5.0],
+            }
+        ),
+        index_folder=index_folder,
     ).lazy()
     stay_home_plan = pl.DataFrame(
         {
@@ -293,11 +355,5 @@ def test_add_stay_home_plan_steps_adds_neutral_shadow_price(tmp_path):
         sequence_index_folder=index_folder,
     ).collect()
 
-    assert "destination_shadow_price" in result.columns
-    stay_home_shadow_price = (
-        result
-        .filter(pl.col("mode_seq_id") == 0)
-        .select("destination_shadow_price")
-        .item()
-    )
-    assert stay_home_shadow_price == 0.0
+    assert "last_seen_iteration" in result.columns
+    assert result.filter(pl.col("mode_seq_id") == 0).select("last_seen_iteration").item() is None


### PR DESCRIPTION
### Motivation

This PR refines how grouped day-trip utilities are prepared and calibrated.

Before this PR, the model computed the final activity utility before optional timing updates. This made the utility less clear when travel times changed the schedule, because the final utility was not directly based on the final activity duration.

Before this PR, mobile plans also computed remaining home/night time as:

`
24h - activity durations
`

This counted travel time as if it were still available for home/night time.

After this PR, the model first computes an activity utility scale. After optional timing updates, it then computes the final activity utility using the updated activity duration.

Mobile plans now compute remaining home/night time as:

`
24h - activity durations - travel time
`

This avoids giving extra home-time utility to plans with long travel times.

### Changes

This PR changes candidate plan utility preparation in PlanUpdater.

The model now first computes an activity_utility_scale, based on:

- value of time;
- country value coefficient;
- destination saturation or destination shadow price;
- mean activity duration.

After optional timing updates, the model computes the final step utility from:

- activity_utility_scale;
- updated duration_per_pers;
- min_activity_time;
- travel cost.

This makes the final utility follow the final schedule more directly.

This PR also:

- subtracts travel time from home/night time when computing the home utility part of mobile plans;
- adds country value coefficients to shopping and leisure activities;
- changes the default work country value coefficient for Switzerland;
- marks study as an anchor activity;
- aligns the fallback destination soft capacity factor with the activity default;
- updates focused utility tests.

### Example

No user-facing API change.

The behavioral change is internal: utility calculation now uses updated activity durations more explicitly, and mobile plans no longer count travel time as home/night time.

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: implementation split from the larger dump branch, focused tests, and PR text.
- What you reviewed or changed: activity defaults, candidate utility preparation, home/night utility calculation, and tests.
- How you validated it: ran focused utility/activity tests, the full group-day-trip unit suite, the group-day-trip integration smoke test, py_compile, and git diff --check.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior