### PR TITLE
Add scenario-aware group day trip runs

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -40,7 +40,6 @@ It then computes weekday trip plans, global metrics, and a first origin-destinat
 import os
 import dotenv
 import mobility
-from mobility.trips.group_day_trips import Parameters
 
 dotenv.load_dotenv()
 
@@ -72,25 +71,28 @@ population_trips = mobility.PopulationGroupDayTrips(
         mobility.OtherActivity(population=population),
     ],
     surveys=[survey],
-    parameters=Parameters(
-        n_iterations=1,
-        mode_sequence_search_parallel=False,
+    parameters=mobility.GroupDayTripsParameters(
+        run=mobility.GroupDayTripsRunParameters(n_iterations=1),
+        mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
+            mode_sequence_search_parallel=False,
+        ),
     ),
 )
 
 # You can get weekday plan steps to inspect them
-weekday_plan_steps = population_trips.get()["weekday_plan_steps"].collect()
+weekday_run = population_trips.run("weekday")
+weekday_plan_steps = weekday_run.get()["plan_steps"].collect()
 
 # You can compute global metrics for weekday trips
-global_metrics = population_trips.weekday_run.evaluate("global_metrics")
+global_metrics = weekday_run.results().metrics.aggregate()
 
 # You can plot weekday OD flows, with labels for prominent cities
-weekday_results = population_trips.weekday_run.results()
-labels = weekday_results.get_prominent_cities()
-weekday_results.plot_od_flows(labels=labels)
+weekday_results = weekday_run.results()
+labels = weekday_results.metrics.get_prominent_cities()
+weekday_results.metrics.plot_od_flows(labels=labels)
 
 # You can get a report of the parameters used in the model
-report = population_trips.parameters_dataframe()
+report = weekday_run.parameters_dataframe()
 ```
 
 ## Reading the example
@@ -134,9 +136,11 @@ population_trips = mobility.PopulationGroupDayTrips(
         mobility.OtherActivity(population=population),
     ],
     surveys=[survey],
-    parameters=Parameters(
-        n_iterations=1,
-        mode_sequence_search_parallel=False,
+    parameters=mobility.GroupDayTripsParameters(
+        run=mobility.GroupDayTripsRunParameters(n_iterations=1),
+        mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
+            mode_sequence_search_parallel=False,
+        ),
     ),
 )
 ```
@@ -152,10 +156,11 @@ population_trips = mobility.PopulationGroupDayTrips(
 ### 5. Inspect the outputs
 
 ```python
-weekday_plan_steps = population_trips.get()["weekday_plan_steps"].collect()
-global_metrics = population_trips.weekday_run.evaluate("global_metrics")
-weekday_results = population_trips.weekday_run.results()
-report = population_trips.parameters_dataframe()
+weekday_run = population_trips.run("weekday")
+weekday_plan_steps = weekday_run.get()["plan_steps"].collect()
+global_metrics = weekday_run.results().metrics.aggregate()
+weekday_results = weekday_run.results()
+report = weekday_run.parameters_dataframe()
 ```
 
 These outputs are useful for a first check:

--- a/examples/quickstart-fr-ci.py
+++ b/examples/quickstart-fr-ci.py
@@ -1,5 +1,4 @@
 import mobility
-from mobility.trips.group_day_trips import Parameters
 
 # This file is not the actual quickstart. It is used by our CI system to ensure that the quickstart always work!
 
@@ -29,25 +28,28 @@ def run_quickstart_ci():
             mobility.OtherActivity(population=population),
         ],
         surveys=[survey],
-        parameters=Parameters(
-            n_iterations=1,
-            mode_sequence_search_parallel=False,
+        parameters=mobility.GroupDayTripsParameters(
+            run=mobility.GroupDayTripsRunParameters(n_iterations=1),
+            mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
     # You can get weekday plan steps to inspect them
-    weekday_plan_steps = population_trips.get()["weekday_plan_steps"].collect()
+    weekday_run = population_trips.run("weekday")
+    weekday_plan_steps = weekday_run.get()["plan_steps"].collect()
 
     # You can compute global metrics for this population
-    global_metrics = population_trips.weekday_run.results().metrics.aggregate()
+    global_metrics = weekday_run.results().metrics.aggregate()
     
     # You can plot weekday OD flows, with labels for prominent cities
-    weekday_results = population_trips.weekday_run.results()
+    weekday_results = weekday_run.results()
     labels = weekday_results.metrics.get_prominent_cities()
     #weekday_results.metrics.plot_od_flows(labels=labels) #Not plotting on CI to avoid crashes
 
     # You can get a report of the parameters used in the model
-    parameters_report = population_trips.weekday_run.parameters_dataframe()
+    parameters_report = weekday_run.parameters_dataframe()
 
     return {
         "weekday_plan_steps": weekday_plan_steps,

--- a/examples/quickstart-fr.py
+++ b/examples/quickstart-fr.py
@@ -1,7 +1,6 @@
 import os
 import dotenv
 import mobility
-from mobility.trips.group_day_trips import Parameters
 
 # Dear Mobility users, this quickstart should always work, please open an issue if this is not the case (and sorry for that)
 
@@ -37,22 +36,25 @@ population_trips = mobility.PopulationGroupDayTrips(
         mobility.OtherActivity(population=population),
     ],
     surveys=[survey],
-    parameters=Parameters(
-        n_iterations=1,
-        mode_sequence_search_parallel=False,
+    parameters=mobility.GroupDayTripsParameters(
+        run=mobility.GroupDayTripsRunParameters(n_iterations=1),
+        mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
+            mode_sequence_search_parallel=False,
+        ),
     ),
 )
 
 # You can get weekday plan steps to inspect them
-weekday_plan_steps = population_trips.get()["weekday_plan_steps"].collect()
+weekday_run = population_trips.run("weekday")
+weekday_plan_steps = weekday_run.get()["plan_steps"].collect()
 
 # You can compute global metrics for weekday trips
-global_metrics = population_trips.weekday_run.results().metrics.aggregate()
+global_metrics = weekday_run.results().metrics.aggregate()
 
 # You can plot weekday OD flows, with labels for prominent cities
-weekday_results = population_trips.weekday_run.results()
+weekday_results = weekday_run.results()
 labels = weekday_results.metrics.get_prominent_cities()
 weekday_results.metrics.plot_od_flows(labels=labels)
 
 # You can get a report of the parameters used in the model
-parameters_report = population_trips.weekday_run.parameters_dataframe()
+parameters_report = weekday_run.parameters_dataframe()

--- a/mobility/__init__.py
+++ b/mobility/__init__.py
@@ -40,6 +40,15 @@ from .trips.individual_year_trips import IndividualYearTrips
 from .trips.group_day_trips import (
     BehaviorChangePhase,
     BehaviorChangeScope,
+    GroupDayTripsActivitySequenceParameters,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsPlanUpdateParameters,
+    GroupDayTripsRunParameters,
     PopulationGroupDayTrips,
 )
 

--- a/mobility/surveys/__init__.py
+++ b/mobility/surveys/__init__.py
@@ -4,3 +4,4 @@ from .survey_plan_assets import SurveyPlanAssets
 from .survey_plans import MobilitySurveyPlans
 from .survey_plan_steps import MobilitySurveyPlanSteps
 from .survey_plan_summaries import MobilitySurveyPlanSummaries
+from .selection import select_surveys_for_population

--- a/mobility/surveys/selection.py
+++ b/mobility/surveys/selection.py
@@ -1,0 +1,52 @@
+import warnings
+
+from mobility.population import Population
+from mobility.surveys.mobility_survey import MobilitySurvey
+
+
+def select_surveys_for_population(
+    population: Population,
+    surveys: list[MobilitySurvey],
+) -> list[MobilitySurvey]:
+    """Return the surveys that cover the population countries."""
+    population_countries = set(_get_population_countries(population))
+    survey_countries = {
+        survey.inputs["parameters"].country
+        for survey in surveys
+    }
+
+    missing_countries = sorted(population_countries - survey_countries)
+    if missing_countries:
+        raise ValueError(
+            "PopulationGroupDayTrips requires at least one survey for each population country. "
+            f"Missing survey coverage for: {', '.join(missing_countries)}. "
+            f"Provided survey countries: {', '.join(sorted(survey_countries))}."
+        )
+
+    unused_countries = sorted(survey_countries - population_countries)
+    if unused_countries:
+        warnings.warn(
+            "Some provided surveys will not be used because their countries are absent from the population: "
+            + ", ".join(unused_countries)
+            + ".",
+            stacklevel=2,
+        )
+
+    return [
+        survey
+        for survey in surveys
+        if survey.inputs["parameters"].country in population_countries
+    ]
+
+
+def _get_population_countries(population: Population) -> list[str]:
+    """Infer population countries from the study-area local admin ids."""
+    transport_zones = population.transport_zones
+    if hasattr(transport_zones, "get_study_area_countries"):
+        return transport_zones.get_study_area_countries()
+
+    study_area = transport_zones.study_area.get()
+    return sorted({
+        str(local_admin_unit_id)[:2]
+        for local_admin_unit_id in study_area["local_admin_unit_id"]
+    })

--- a/mobility/transport/costs/path/path_travel_costs.py
+++ b/mobility/transport/costs/path/path_travel_costs.py
@@ -224,9 +224,9 @@ class PathTravelCosts(TravelCostsAsset):
         """Return the travel-cost asset instance corresponding to one simulation iteration."""
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.parameters.n_iterations):
+        if iteration > int(run.n_iterations):
             raise ValueError(
-                f"Iteration should be <= {int(run.parameters.n_iterations)} for this run."
+                f"Iteration should be <= {int(run.n_iterations)} for this run."
             )
 
         flow_asset = self.inputs["congested_path_graph"].get_flow_asset_for_iteration(run, iteration)

--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -176,9 +176,9 @@ class TransportCosts(FileAsset):
         """
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.parameters.n_iterations):
+        if iteration > int(run.n_iterations):
             raise ValueError(
-                f"Iteration should be <= {int(run.parameters.n_iterations)} for this run."
+                f"Iteration should be <= {int(run.n_iterations)} for this run."
             )
 
         asset = self.for_iteration(
@@ -190,7 +190,7 @@ class TransportCosts(FileAsset):
             run_key=run.inputs_hash,
             is_weekday=run.is_weekday,
             last_completed_iteration=iteration - 1,
-            cost_update_interval=run.parameters.n_iter_per_cost_update,
+            cost_update_interval=run.n_iter_per_cost_update,
         )
         logging.info(
             "TransportCosts asset_for_iteration: run_key=%s is_weekday=%s iteration=%s "
@@ -478,11 +478,11 @@ class TransportCosts(FileAsset):
         if self.has_enabled_congestion() is False:
             return
 
-        update_interval = run.parameters.n_iter_per_cost_update
+        update_interval = run.n_iter_per_cost_update
         if update_interval == 0:
             return
 
-        for completed_iteration in range(1, int(run.parameters.n_iterations) + 1):
+        for completed_iteration in range(1, int(run.n_iterations) + 1):
             if self.should_recompute_congested_costs(completed_iteration, update_interval) is False:
                 continue
 

--- a/mobility/transport/graphs/congested/congested_path_graph.py
+++ b/mobility/transport/graphs/congested/congested_path_graph.py
@@ -115,9 +115,9 @@ class CongestedPathGraph(FileAsset):
         """Return the graph instance corresponding to the congestion active at one iteration."""
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.parameters.n_iterations):
+        if iteration > int(run.n_iterations):
             raise ValueError(
-                f"Iteration should be <= {int(run.parameters.n_iterations)} for this run."
+                f"Iteration should be <= {int(run.n_iterations)} for this run."
             )
 
         flow_asset = self.get_flow_asset_for_iteration(run, iteration)
@@ -145,7 +145,7 @@ class CongestedPathGraph(FileAsset):
         if self.inputs["handles_congestion"] is False:
             return None
 
-        cost_update_interval = int(run.parameters.n_iter_per_cost_update)
+        cost_update_interval = int(run.n_iter_per_cost_update)
         if cost_update_interval <= 0 or iteration <= 1:
             return None
 

--- a/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
+++ b/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
@@ -147,9 +147,9 @@ class DetailedCarpoolTravelCosts(TravelCostsAsset):
     def asset_for_iteration(self, run, iteration: int):
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.parameters.n_iterations):
+        if iteration > int(run.n_iterations):
             raise ValueError(
-                f"Iteration should be <= {int(run.parameters.n_iterations)} for this run."
+                f"Iteration should be <= {int(run.n_iterations)} for this run."
             )
 
         flow_asset = self.inputs["car_travel_costs"].inputs["congested_path_graph"].get_flow_asset_for_iteration(

--- a/mobility/trips/group_day_trips/__init__.py
+++ b/mobility/trips/group_day_trips/__init__.py
@@ -1,11 +1,29 @@
-from .core.parameters import BehaviorChangePhase, BehaviorChangeScope, Parameters
+from .core.parameters import (
+    BehaviorChangePhase,
+    BehaviorChangeScope,
+    GroupDayTripsActivitySequenceParameters,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsPlanUpdateParameters,
+    GroupDayTripsRunParameters,
+)
 from .core.group_day_trips import PopulationGroupDayTrips
-from .core.results import RunResults
 
 __all__ = [
     "BehaviorChangePhase",
     "BehaviorChangeScope",
+    "GroupDayTripsActivitySequenceParameters",
+    "GroupDayTripsBehaviorChangeParameters",
+    "GroupDayTripsDestinationSequenceParameters",
+    "GroupDayTripsModeSequenceParameters",
+    "GroupDayTripsOutputParameters",
+    "GroupDayTripsParameters",
+    "GroupDayTripsPeriodParameters",
+    "GroupDayTripsPlanUpdateParameters",
+    "GroupDayTripsRunParameters",
     "PopulationGroupDayTrips",
-    "Parameters",
-    "RunResults",
 ]

--- a/mobility/trips/group_day_trips/core/__init__.py
+++ b/mobility/trips/group_day_trips/core/__init__.py
@@ -1,5 +1,17 @@
 from .diagnostics import RunDiagnostics
-from .parameters import Parameters
+from .parameters import (
+    BehaviorChangePhase,
+    BehaviorChangeScope,
+    GroupDayTripsActivitySequenceParameters,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsPlanUpdateParameters,
+    GroupDayTripsRunParameters,
+)
 from .group_day_trips import PopulationGroupDayTrips
 from .metrics import RunMetrics
 from .results import RunResults
@@ -8,8 +20,18 @@ from .run_state import RunState
 from .transitions import RunTransitions
 
 __all__ = [
+    "BehaviorChangePhase",
+    "BehaviorChangeScope",
+    "GroupDayTripsActivitySequenceParameters",
+    "GroupDayTripsBehaviorChangeParameters",
+    "GroupDayTripsDestinationSequenceParameters",
+    "GroupDayTripsModeSequenceParameters",
+    "GroupDayTripsOutputParameters",
+    "GroupDayTripsParameters",
+    "GroupDayTripsPeriodParameters",
+    "GroupDayTripsPlanUpdateParameters",
+    "GroupDayTripsRunParameters",
     "PopulationGroupDayTrips",
-    "Parameters",
     "RunDiagnostics",
     "RunMetrics",
     "Run",

--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -1,68 +1,50 @@
-import warnings
+from enum import StrEnum
 
-import polars as pl
-from typing import Dict, List
-
-from mobility.runtime.assets.asset import Asset
+from mobility.runtime.parameter_values import DEFAULT_SCENARIO
+from mobility.runtime.scenarios import Scenarios
 from mobility.transport.costs.transport_costs import TransportCosts
-from .parameters import BehaviorChangePhase, Parameters
+from .parameters import GroupDayTripsParameters
 from .run import Run
 from mobility.activities import Activity, HomeActivity, OtherActivity
-from mobility.surveys import SurveyPlanAssets
+from mobility.surveys import SurveyPlanAssets, select_surveys_for_population
 from mobility.surveys.mobility_survey import MobilitySurvey
 from mobility.population import Population
 from mobility.transport.modes.core.transport_mode import TransportMode
 
 
+class DayType(StrEnum):
+    """Day type supported by grouped day-trip runs."""
+
+    WEEKDAY = "weekday"
+    WEEKEND = "weekend"
+
+
 class PopulationGroupDayTrips:
-    """Top-level asset exposing weekday and weekend grouped day trips."""
+    """Top-level setup for grouped day-trip simulations.
+
+    This object stores the population, transport modes, activities, surveys,
+    and grouped day-trip parameters. It creates concrete weekday and weekend
+    runs on demand when a day type, scenario, and stochastic replication are
+    selected. Model execution happens through the returned run, for example
+    with `population_trips.run("weekday").get()`. If no scenario is given, the
+    setup uses the package default scenario named `"default"`.
+    """
 
     def __init__(
         self,
         population: Population,
-        modes: List[TransportMode] = None,
-        activities: List[Activity] = None,
-        surveys: List[MobilitySurvey] = None,
-        parameters: Parameters = None,
-        n_iterations: int = None,
-        alpha: float = None,
-        k_activity_sequences: int | None = None,
-        k_destination_sequences: int = None,
-        k_mode_sequences: int = None,
-        n_warmup_iterations: int = None,
-        max_inactive_age: int = None,
-        refresh_active_mode_alternatives: bool = None,
-        dest_prob_cutoff: float = None,
-        n_iter_per_cost_update: int = None,
-        cost_uncertainty_sd: float = None,
-        seed: int = None,
-        mode_sequence_search_parallel: bool = None,
-        use_rust_mode_sequence_search: bool = None,
-        save_transition_events: bool = None,
-        persist_iteration_artifacts: bool = None,
-        min_activity_time_constant: float = None,
-        update_plan_timings_from_modeled_travel_times: bool = None,
-        use_destination_shadow_prices: bool = None,
-        transition_distance_threshold: float = None,
-        enable_transition_distance_model: bool = None,
-        transition_revision_probability: float = None,
-        transition_logit_scale: float = None,
-        transition_utility_pruning_delta: float = None,
-        min_transition_utility_gain: float = None,
-        plan_probability_pruning_retained_share: float = None,
-        plan_probability_pruning_min_iteration: int = None,
-        transition_distance_friction: float = None,
-        plan_embedding_dimension_weights: list[float] | None = None,
-        behavior_change_phases: list[BehaviorChangePhase] | None = None,
-        simulate_weekend: bool = None,
+        modes: list[TransportMode] | None = None,
+        activities: list[Activity] | None = None,
+        surveys: list[MobilitySurvey] | None = None,
+        parameters: GroupDayTripsParameters | None = None,
+        scenarios: Scenarios | None = None,
     ):
-        """Initialize the grouped day-trips asset.
+        """Create a grouped day-trips simulation setup.
 
-        The wrapper validates its high-level inputs, normalizes constructor
-        parameters into a `Parameters` instance, builds a shared
-        `TransportCosts`, and creates one underlying `Run`
-        asset for weekdays plus one for weekends. The weekend run is enabled or
-        disabled according to `simulate_weekend`.
+        The setup checks that the required model inputs are present and keeps
+        them together until a concrete run is requested. This keeps scenario
+        values and replication seeds unresolved until `run(...)` selects the
+        context to use. Omitting `scenario` selects the default scenario.
 
         Args:
             population: Population object containing demand groups and transport
@@ -74,68 +56,11 @@ class PopulationGroupDayTrips:
                 and `OtherActivity`.
             surveys: Mobility surveys providing empirical activity programs. Must
                 contain at least one `MobilitySurvey`.
-            parameters: Parameter container. When provided, explicit keyword
-                arguments are merged into this model and revalidated.
-            n_iterations: Optional override for
-                `Parameters.n_iterations`.
-            alpha: Optional override for `Parameters.alpha`.
-            k_activity_sequences: Optional override for
-                `Parameters.k_activity_sequences`.
-            k_destination_sequences: Optional override for
-                `Parameters.k_destination_sequences`.
-            k_mode_sequences: Optional override for
-                `Parameters.k_mode_sequences`.
-            n_warmup_iterations: Optional override for
-                `Parameters.n_warmup_iterations`.
-            max_inactive_age: Optional override for
-                `Parameters.max_inactive_age`.
-            refresh_active_mode_alternatives: Optional override for
-                `Parameters.refresh_active_mode_alternatives`.
-            dest_prob_cutoff: Optional override for
-                `Parameters.dest_prob_cutoff`.
-            n_iter_per_cost_update: Optional override for
-                `Parameters.n_iter_per_cost_update`.
-            cost_uncertainty_sd: Optional override for
-                `Parameters.cost_uncertainty_sd`.
-            seed: Optional override for `Parameters.seed`.
-            mode_sequence_search_parallel: Optional override for
-                `Parameters.mode_sequence_search_parallel`.
-            use_rust_mode_sequence_search: Optional override for
-                `Parameters.use_rust_mode_sequence_search`.
-            save_transition_events: Optional override for
-                `Parameters.save_transition_events`.
-            persist_iteration_artifacts: Optional override for
-                `Parameters.persist_iteration_artifacts`.
-            min_activity_time_constant: Optional override for
-                `Parameters.min_activity_time_constant`.
-            update_plan_timings_from_modeled_travel_times: Optional override for
-                `Parameters.update_plan_timings_from_modeled_travel_times`.
-            use_destination_shadow_prices: Optional override for
-                `Parameters.use_destination_shadow_prices`.
-            transition_distance_threshold: Optional override for
-                `Parameters.transition_distance_threshold`.
-            enable_transition_distance_model: Optional override for
-                `Parameters.enable_transition_distance_model`.
-            transition_revision_probability: Optional override for
-                `Parameters.transition_revision_probability`.
-            transition_logit_scale: Optional override for
-                `Parameters.transition_logit_scale`.
-            transition_utility_pruning_delta: Optional override for
-                `Parameters.transition_utility_pruning_delta`.
-            min_transition_utility_gain: Optional override for
-                `Parameters.min_transition_utility_gain`.
-            plan_probability_pruning_retained_share: Optional override for
-                `Parameters.plan_probability_pruning_retained_share`.
-            plan_probability_pruning_min_iteration: Optional override for
-                `Parameters.plan_probability_pruning_min_iteration`.
-            transition_distance_friction: Optional override for
-                `Parameters.transition_distance_friction`.
-            plan_embedding_dimension_weights: Optional override for
-                `Parameters.plan_embedding_dimension_weights`.
-            behavior_change_phases: Optional override for
-                `Parameters.behavior_change_phases`.
-            simulate_weekend: Optional override for
-                `Parameters.simulate_weekend`.
+            parameters: Grouped day-trip settings. If omitted, default settings
+                are used.
+            scenarios: Optional scenario manifest used to document scenario names
+                and validate scenario-varying parameter values. It is required
+                when any `ParameterValue` uses a non-default scenario.
 
         Raises:
             ValueError: If modes, activities, or surveys are empty, or if required
@@ -147,138 +72,106 @@ class PopulationGroupDayTrips:
         self._validate_activities(activities)
         self._validate_surveys(surveys)
 
-        parameters = Asset.prepare_parameters(
-            parameters=parameters,
-            parameters_cls=Parameters,
-            explicit_args={
-                "n_iterations": n_iterations,
-                "alpha": alpha,
-                "k_activity_sequences": k_activity_sequences,
-                "k_destination_sequences": k_destination_sequences,
-                "k_mode_sequences": k_mode_sequences,
-                "n_warmup_iterations": n_warmup_iterations,
-                "max_inactive_age": max_inactive_age,
-                "refresh_active_mode_alternatives": refresh_active_mode_alternatives,
-                "dest_prob_cutoff": dest_prob_cutoff,
-                "n_iter_per_cost_update": n_iter_per_cost_update,
-                "cost_uncertainty_sd": cost_uncertainty_sd,
-                "seed": seed,
-                "mode_sequence_search_parallel": mode_sequence_search_parallel,
-                "use_rust_mode_sequence_search": use_rust_mode_sequence_search,
-                "save_transition_events": save_transition_events,
-                "persist_iteration_artifacts": persist_iteration_artifacts,
-                "min_activity_time_constant": min_activity_time_constant,
-                "update_plan_timings_from_modeled_travel_times": update_plan_timings_from_modeled_travel_times,
-                "use_destination_shadow_prices": use_destination_shadow_prices,
-                "transition_distance_threshold": transition_distance_threshold,
-                "enable_transition_distance_model": enable_transition_distance_model,
-                "transition_revision_probability": transition_revision_probability,
-                "transition_logit_scale": transition_logit_scale,
-                "transition_utility_pruning_delta": transition_utility_pruning_delta,
-                "min_transition_utility_gain": min_transition_utility_gain,
-                "plan_probability_pruning_retained_share": plan_probability_pruning_retained_share,
-                "plan_probability_pruning_min_iteration": plan_probability_pruning_min_iteration,
-                "transition_distance_friction": transition_distance_friction,
-                "plan_embedding_dimension_weights": plan_embedding_dimension_weights,
-                "behavior_change_phases": behavior_change_phases,
-                "simulate_weekend": simulate_weekend,
-            },
-            owner_name="PopulationGroupDayTrips",
+        if parameters is None:
+            parameters = GroupDayTripsParameters()
+
+        self.population = population
+        self.modes = modes
+        self.activities = activities
+        self.surveys = select_surveys_for_population(population, surveys)
+        self.parameters = parameters
+        self.scenarios = Scenarios.for_setup(
+            scenarios,
+            modes=self.modes,
+            activities=self.activities,
+            parameters=self.parameters,
         )
+        self._runs: dict[tuple[str, int, DayType], Run] = {}
 
-        transport_costs = TransportCosts(modes)
-        selected_surveys = self._select_surveys_for_population(population, surveys)
-        survey_plan_assets = SurveyPlanAssets(
-            surveys=selected_surveys,
-            activities=activities,
-            modes=modes,
-        )
+    def run(
+        self,
+        day_type: str | DayType,
+        *,
+        scenario: str | None = None,
+        replication: int = 0,
+    ) -> Run:
+        """Return one weekday or weekend run.
 
-        weekday_run = Run(
-            population=population,
-            transport_costs=transport_costs,
-            activities=activities,
-            modes=modes,
-            surveys=selected_surveys,
-            survey_plan_assets=survey_plan_assets,
-            parameters=parameters,
-            is_weekday=True,
-            enabled=True,
-        )
-
-        weekend_run = Run(
-            population=population,
-            transport_costs=transport_costs,
-            activities=activities,
-            modes=modes,
-            surveys=selected_surveys,
-            survey_plan_assets=survey_plan_assets,
-            parameters=parameters,
-            is_weekday=False,
-            enabled=parameters.simulate_weekend,
-        )
-
-        self.survey_plan_assets = survey_plan_assets
-        self.weekday_run = weekday_run
-        self.weekend_run = weekend_run
-
-        self.cache_path = self._build_cache_path()
-
-    
-    def get(self) -> Dict[str, pl.LazyFrame]:
-        """Return the combined weekday/weekend outputs for this wrapper.
-
-        This method delegates execution to the underlying
-        `Run` assets. Weekend outputs are included
-        only when the weekend run is enabled.
-
-        Returns:
-            dict[str, pl.LazyFrame]: Lazy readers for weekday outputs, shared
-            `demand_groups`, and weekend outputs when weekend simulation is
-            enabled.
-        """
-        self.weekday_run.get()
-        if self.weekend_run.enabled:
-            self.weekend_run.get()
-        return self.get_cached_asset()
-
-    
-    def create_and_get_asset(self) -> Dict[str, pl.LazyFrame]:
-        """Return the combined outputs through the legacy asset-style API.
-
-        Returns:
-            dict[str, pl.LazyFrame]: Mapping of cache names to parquet scans.
-        """
-        return self.get()
-    
-
-    def get_cached_asset(self) -> Dict[str, pl.LazyFrame]:
-        """Compatibility alias returning lazy readers for cached outputs.
-
-        Returns:
-            dict[str, pl.LazyFrame]: Mapping of cache names to parquet scans.
-        """
-        return {key: pl.scan_parquet(path) for key, path in self.cache_path.items()}
-
-
-    def remove(self):
-        """Remove cached outputs and saved iteration artifacts for both run assets."""
-        self.weekday_run.remove()
-        self.weekend_run.remove()
-
-
-    def _validate_activities(self, activities: List[Activity]) -> None:
-        """Validate the activities passed to the wrapper constructor.
+        The run is built on first access, then reused if the same `day_type`,
+        `scenario`, and `replication` are requested again. Omitting `scenario`
+        selects the default scenario named `"default"`. Plain parameter values
+        are shared by all scenarios. Scenario-varying `ParameterValue` objects
+        must define the requested scenario.
 
         Args:
-            activities: Activity objects that define the activity types available to
-                the simulation.
+            day_type: `"weekday"` or `"weekend"`.
+            scenario: Scenario name to resolve scenario-varying values. If
+                omitted, `"default"` is used.
+            replication: Stochastic replication index. Replication seeds are
+                taken from `parameters.run`.
 
-        Raises:
-            ValueError: If no activities are provided, or if `HomeActivity` or
-                `OtherActivity` is missing.
-            TypeError: If any element is not an `Activity` instance.
+        Returns:
+            Run: Concrete run for the selected day type and context.
         """
+        day_type = DayType(day_type)
+        scenario = DEFAULT_SCENARIO if scenario is None else scenario
+        self.scenarios.validate_requested([scenario])
+        key = (scenario, replication, day_type)
+        if key not in self._runs:
+            parameters = self.parameters.with_replication(replication)
+            survey_plan_assets = SurveyPlanAssets(
+                surveys=self.surveys,
+                activities=self.activities,
+                modes=self.modes,
+            )
+            transport_costs = TransportCosts(self.modes)
+            is_weekday = day_type is DayType.WEEKDAY
+            self._runs[key] = Run(
+                population=self.population,
+                transport_costs=transport_costs,
+                activities=self.activities,
+                modes=self.modes,
+                surveys=self.surveys,
+                survey_plan_assets=survey_plan_assets,
+                parameters=parameters,
+                is_weekday=is_weekday,
+                enabled=is_weekday or parameters.periods.simulate_weekend,
+                scenario=scenario,
+            )
+        return self._runs[key]
+
+    def remove(self):
+        """Remove cached run outputs for this setup.
+
+        This removes all runs that can be inferred from the setup: the default
+        scenario, scenarios found in parameter values, configured replications,
+        enabled day types, and any runs already built in this Python session.
+        """
+        scenarios = {DEFAULT_SCENARIO}
+        scenarios.update(self.scenarios.names)
+        scenarios.update(scenario for scenario, _, _ in self._runs)
+
+        replications = set(range(self.parameters.run.n_replications))
+        replications.update(replication for _, replication, _ in self._runs)
+
+        day_types = {DayType.WEEKDAY}
+        if self.parameters.periods.simulate_weekend:
+            day_types.add(DayType.WEEKEND)
+        day_types.update(day_type for _, _, day_type in self._runs)
+
+        for scenario in scenarios:
+            for replication in replications:
+                for day_type in day_types:
+                    self.run(
+                        day_type,
+                        scenario=scenario,
+                        replication=replication,
+                    ).remove()
+
+        self._runs = {}
+
+    def _validate_activities(self, activities: list[Activity] | None) -> None:
+        """Check that activity inputs are present and usable."""
         if not activities:
             raise ValueError("PopulationGroupDayTrips needs at least one activity in `activities`.")
 
@@ -295,16 +188,8 @@ class PopulationGroupDayTrips:
         if not any(isinstance(a, HomeActivity) for a in activities):
             raise ValueError("PopulationGroupDayTrips `activities` argument should contain a `HomeActivity`.")
 
-    def _validate_modes(self, modes: List[TransportMode]) -> None:
-        """Validate the transport modes passed to the wrapper constructor.
-
-        Args:
-            modes: Transport modes available to the simulation.
-
-        Raises:
-            ValueError: If no modes are provided.
-            TypeError: If any element is not a `TransportMode` instance.
-        """
+    def _validate_modes(self, modes: list[TransportMode] | None) -> None:
+        """Check that transport mode inputs are present and usable."""
         if not modes:
             raise ValueError("PopulationGroupDayTrips needs at least one mode in `modes`.")
 
@@ -315,16 +200,8 @@ class PopulationGroupDayTrips:
                     f"instances, but received one object of class {type(mode)}."
                 )
 
-    def _validate_surveys(self, surveys: List[MobilitySurvey]) -> None:
-        """Validate the mobility surveys passed to the wrapper constructor.
-
-        Args:
-            surveys: Survey assets used to derive survey-based schedules.
-
-        Raises:
-            ValueError: If no surveys are provided.
-            TypeError: If any element is not a `MobilitySurvey` instance.
-        """
+    def _validate_surveys(self, surveys: list[MobilitySurvey] | None) -> None:
+        """Check that survey inputs are present and usable."""
         if not surveys:
             raise ValueError("PopulationGroupDayTrips needs at least one survey in `surveys`.")
 
@@ -334,90 +211,3 @@ class PopulationGroupDayTrips:
                     "PopulationGroupDayTrips surveys argument should be a list of `MobilitySurvey` "
                     f"instances, but received one object of class {type(survey)}."
                 )
-
-    def _get_population_countries(self, population: Population) -> list[str]:
-        """Infer population countries from the study-area admin prefixes."""
-        study_area = population.transport_zones.study_area.get()
-        if "geometry" in study_area.columns:
-            study_area = study_area.drop("geometry", axis=1)
-        return (
-            pl.from_pandas(study_area[["local_admin_unit_id"]])
-            .with_columns(country=pl.col("local_admin_unit_id").str.slice(0, 2))
-            .get_column("country")
-            .unique()
-            .sort()
-            .to_list()
-        )
-
-    def _select_surveys_for_population(
-        self,
-        population: Population,
-        surveys: list[MobilitySurvey],
-    ) -> list[MobilitySurvey]:
-        """Validate survey coverage against the population and keep relevant surveys."""
-        population_countries = set(self._get_population_countries(population))
-        surveys_by_country: dict[str, list[MobilitySurvey]] = {}
-        for survey in surveys:
-            surveys_by_country.setdefault(survey.inputs["parameters"].country, []).append(survey)
-
-        survey_countries = set(surveys_by_country)
-        missing_countries = sorted(population_countries - survey_countries)
-        if missing_countries:
-            raise ValueError(
-                "PopulationGroupDayTrips requires at least one survey for each population country. "
-                f"Missing survey coverage for: {', '.join(missing_countries)}. "
-                f"Provided survey countries: {', '.join(sorted(survey_countries))}."
-            )
-
-        unused_countries = sorted(survey_countries - population_countries)
-        if unused_countries:
-            warnings.warn(
-                "Some provided surveys will not be used because their countries are absent from the population: "
-                + ", ".join(unused_countries)
-                + ".",
-                stacklevel=2,
-            )
-
-        selected_surveys: list[MobilitySurvey] = []
-        for country in sorted(population_countries):
-            selected_surveys.extend(surveys_by_country[country])
-        return selected_surveys
-
-    def _build_cache_path(self) -> Dict[str, str]:
-        """Expose child run cache paths through the wrapper keys.
-
-        Returns:
-            dict[str, pathlib.Path]: Mapping from wrapper output names to the
-            underlying run asset files. Weekend keys are included only when
-            the weekend run is enabled.
-        """
-        weekday_paths = self.weekday_run.cache_path
-        required_keys = (
-            "plan_steps",
-            "opportunities",
-            "costs",
-            "transitions",
-        )
-        optional_keys = (
-            "iteration_metrics",
-        )
-        cache_paths = {f"weekday_{key}": weekday_paths[key] for key in required_keys}
-        cache_paths.update(
-            {
-                f"weekday_{key}": weekday_paths[key]
-                for key in optional_keys
-                if key in weekday_paths
-            }
-        )
-        cache_paths["demand_groups"] = weekday_paths["demand_groups"]
-        if self.weekend_run.enabled:
-            weekend_paths = self.weekend_run.cache_path
-            cache_paths.update({f"weekend_{key}": weekend_paths[key] for key in required_keys})
-            cache_paths.update(
-                {
-                    f"weekend_{key}": weekend_paths[key]
-                    for key in optional_keys
-                    if key in weekend_paths
-                }
-            )
-        return cache_paths

--- a/mobility/trips/group_day_trips/core/metrics.py
+++ b/mobility/trips/group_day_trips/core/metrics.py
@@ -1506,10 +1506,20 @@ class RunMetrics:
         )
 
         if compare_with is not None:
-            compare_with.get()
-            prefix = "weekday" if self.results.is_weekday else "weekend"
-            plan_steps_comp = pl.scan_parquet(compare_with.cache_path[f"{prefix}_plan_steps"])
-            costs_comp = pl.scan_parquet(compare_with.cache_path[f"{prefix}_costs"])
+            comparison = self._resolve_run_context(compare_with, include_costs=True)
+            reference_run = comparison["run"]
+            plan_steps_path = reference_run.cache_path.get("plan_steps")
+            if plan_steps_path is None:
+                raise TypeError("compare_with run needs `cache_path['plan_steps']`.")
+            if Path(plan_steps_path).exists() is False and callable(getattr(reference_run, "get", None)):
+                reference_run.get()
+            plan_steps_comp = pl.scan_parquet(plan_steps_path)
+            costs_comp = comparison["costs"]
+            demand_groups_comp = comparison["demand_groups"]
+            if isinstance(costs_comp, pl.DataFrame):
+                costs_comp = costs_comp.lazy()
+            if isinstance(demand_groups_comp, pl.DataFrame):
+                demand_groups_comp = demand_groups_comp.lazy()
 
             metric_comp = metric + "_comp"
             metric_per_person_comp = metric + "_per_person_comp"
@@ -1520,7 +1530,10 @@ class RunMetrics:
                 .group_by(["transport_zone_id", "csp", "n_cars"])
                 .agg(metric=(pl.col(metric) * pl.col("n_persons")).sum())
                 .join(transport_zones_df.select(["transport_zone_id", "local_admin_unit_id"]), on=["transport_zone_id"])
-                .join(self.results.demand_groups.rename({"home_zone_id": "transport_zone_id"}), on=["transport_zone_id", "csp", "n_cars"])
+                .join(
+                    demand_groups_comp.rename({"home_zone_id": "transport_zone_id"}),
+                    on=["transport_zone_id", "csp", "n_cars"],
+                )
                 .with_columns(metric_per_person=pl.col("metric") / pl.col("n_persons"))
                 .rename({"metric": metric_comp, "metric_per_person": metric_per_person_comp})
                 .collect(engine="streaming")
@@ -1779,10 +1792,11 @@ class RunMetrics:
     ) -> list[int]:
         """Return the iterations used by modal-share evolution plots."""
         if iterations is None:
-            n_iterations = getattr(self.results.parameters, "n_iterations", None)
+            run_parameters = getattr(self.results.parameters, "run", None)
+            n_iterations = getattr(run_parameters, "n_iterations", None)
             if n_iterations is None:
                 raise ValueError(
-                    "iterations should be provided when results.parameters has no n_iterations."
+                    "iterations should be provided when results.parameters.run has no n_iterations."
                 )
             iterations = range(1, int(n_iterations) + 1)
 
@@ -3716,9 +3730,10 @@ class RunMetrics:
 
     def _behavior_change_scope_label(self, iteration: int) -> str:
         """Return the behavior-change scope label shown on GIF frames."""
-        if not callable(getattr(self.results.parameters, "get_behavior_change_scope", None)):
+        behavior_change = getattr(self.results.parameters, "behavior_change", None)
+        if not callable(getattr(behavior_change, "scope_at", None)):
             return "Full replanning"
-        scope = self.results.parameters.get_behavior_change_scope(iteration)
+        scope = behavior_change.scope_at(iteration)
         scope_value = getattr(scope, "value", str(scope))
         return scope_value.replace("_", " ").capitalize()
 
@@ -4356,17 +4371,18 @@ class RunMetrics:
 
     def _resolve_comparison_run(self, compare_with: Any) -> Any:
         """Return the day-type run used as the reference scenario."""
-        if hasattr(compare_with, "weekday_run") and hasattr(compare_with, "weekend_run"):
-            reference_run = compare_with.weekday_run if self.results.is_weekday else compare_with.weekend_run
-        elif hasattr(compare_with, "run") and hasattr(compare_with.run, "cache_path"):
+        if hasattr(compare_with, "run") and hasattr(compare_with.run, "cache_path"):
             reference_run = compare_with.run
+        elif callable(getattr(compare_with, "run", None)):
+            day_type = "weekday" if self.results.is_weekday else "weekend"
+            reference_run = compare_with.run(day_type)
         else:
             reference_run = compare_with
 
         if not hasattr(reference_run, "cache_path"):
             raise TypeError(
                 "compare_with should be a group-day-trips run, results object, "
-                "or PopulationGroupDayTrips object."
+                "or PopulationGroupDayTrips setup."
             )
         if getattr(reference_run, "is_weekday", self.results.is_weekday) != self.results.is_weekday:
             raise ValueError("compare_with should use the same day type as these results.")

--- a/mobility/trips/group_day_trips/core/parameters.py
+++ b/mobility/trips/group_day_trips/core/parameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Annotated
 
@@ -5,18 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class BehaviorChangeScope(str, Enum):
-    """Highest adaptation layer allowed during one behavior-change phase.
-
-    Attributes:
-        FULL_REPLANNING: Resample motive sequences, then dependent destination
-            and mode sequences. Stay-home transitions remain available.
-        DESTINATION_REPLANNING: Keep each currently occupied non-stay-home
-            motive sequence fixed and resample destination sequences plus
-            dependent mode sequences. Stay-home is frozen.
-        MODE_REPLANNING: Keep each currently occupied non-stay-home motive and
-            destination sequence fixed and resample mode sequences only.
-            Stay-home is frozen.
-    """
+    """Highest adaptation layer allowed during one behavior-change phase."""
 
     FULL_REPLANNING = "full_replanning"
     DESTINATION_REPLANNING = "destination_replanning"
@@ -24,12 +15,7 @@ class BehaviorChangeScope(str, Enum):
 
 
 class BehaviorChangePhase(BaseModel):
-    """Behavior-change phase applied from ``start_iteration`` onward.
-
-    Attributes:
-        start_iteration: First simulation iteration where this phase applies.
-        scope: Highest adaptation layer allowed during the phase.
-    """
+    """Behavior-change phase applied from ``start_iteration`` onward."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -41,7 +27,6 @@ class BehaviorChangePhase(BaseModel):
             description="First simulation iteration where this behavior-change phase applies.",
         ),
     ]
-
     scope: Annotated[
         BehaviorChangeScope,
         Field(
@@ -53,14 +38,15 @@ class BehaviorChangePhase(BaseModel):
                 "occupied non-stay-home motive sequence fixed and resamples "
                 "destination plus mode sequences. `mode_replanning` keeps each "
                 "currently occupied non-stay-home motive and destination "
-                "sequence fixed and resamples mode sequences only. "
-                "Stay-home is frozen in restricted phases."
+                "sequence fixed and resamples mode sequences only. Stay-home is "
+                "frozen in restricted phases."
             ),
         ),
     ]
 
 
-class Parameters(BaseModel):
+class GroupDayTripsRunParameters(BaseModel):
+    """Run length, cost refresh, and stochastic replication settings."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -72,25 +58,223 @@ class Parameters(BaseModel):
             title="Number of iterations",
             description=(
                 "Number of simulation iterations used to compute the population "
-                "trips. Increase this to get more diverse programmes and to allow "
-                "congestion feedbacks to propagate."
+                "trips."
+            ),
+        ),
+    ]
+    n_iter_per_cost_update: Annotated[
+        int,
+        Field(
+            default=3,
+            ge=0,
+            title="Travel costs update period",
+            description=(
+                "The simulation updates travel costs every n_iter_per_cost_update "
+                "iterations. Set it to zero to ignore congestion feedback."
+            ),
+        ),
+    ]
+    seed: Annotated[
+        int,
+        Field(
+            default=0,
+            ge=0,
+            title="Simulation seed",
+            description="Seed used to get reproducible stochastic simulation steps.",
+        ),
+    ]
+    n_replications: Annotated[
+        int,
+        Field(
+            default=1,
+            ge=1,
+            title="Number of stochastic replications",
+            description="Number of repeated model runs for the same scenario.",
+        ),
+    ]
+    seeds: Annotated[
+        list[int] | None,
+        Field(
+            default=None,
+            title="Replication seeds",
+            description="Optional list of seeds, one per stochastic replication.",
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def validate_replication_seeds(self) -> "GroupDayTripsRunParameters":
+        """Validate single-run and multi-run seed settings."""
+        if self.seeds is not None:
+            if len(self.seeds) != self.n_replications:
+                raise ValueError(
+                    "GroupDayTripsRunParameters.seeds should contain one seed per replication."
+                )
+            if any(seed < 0 for seed in self.seeds):
+                raise ValueError(
+                    "GroupDayTripsRunParameters.seeds values should be greater than or equal to 0."
+                )
+
+        if self.seed != 0 and self.n_replications != 1:
+            raise ValueError(
+                "GroupDayTripsRunParameters.seed is the single-replication seed. "
+                "Use GroupDayTripsRunParameters.seeds when n_replications is greater than 1."
+            )
+
+        return self
+
+    def seed_for_replication(self, replication: int) -> int:
+        """Return the seed used by one stochastic replication."""
+        if replication < 0 or replication >= self.n_replications:
+            raise ValueError("replication should be between 0 and n_replications - 1.")
+        if self.seeds is not None:
+            return self.seeds[replication]
+        if self.n_replications == 1:
+            return self.seed
+        return replication
+
+    def with_replication(self, replication: int) -> "GroupDayTripsRunParameters":
+        """Return single-replication run parameters for one replication."""
+        data = self.model_dump(mode="python")
+        data.update(
+            seed=self.seed_for_replication(replication),
+            n_replications=1,
+            seeds=None,
+        )
+        return self.__class__.model_validate(data)
+
+
+class GroupDayTripsPeriodParameters(BaseModel):
+    """Day-type and reporting-period settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    simulate_weekend: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Weekday and weekend simulation",
+            description="Whether to simulate a weekend day in addition to the weekday.",
+        ),
+    ]
+    weekday_weight: Annotated[
+        float,
+        Field(
+            default=5.0 / 7.0,
+            gt=0.0,
+            title="Weekday result weight",
+            description="Weight used when weekday and weekend results are combined.",
+        ),
+    ]
+    weekend_weight: Annotated[
+        float,
+        Field(
+            default=2.0 / 7.0,
+            gt=0.0,
+            title="Weekend result weight",
+            description="Weight used when weekday and weekend results are combined.",
+        ),
+    ]
+    annual_weight: Annotated[
+        float,
+        Field(
+            default=365.0,
+            gt=0.0,
+            title="Annual result weight",
+            description="Number of days used to scale typical-day results to a year.",
+        ),
+    ]
+
+
+class GroupDayTripsOutputParameters(BaseModel):
+    """Settings for saved outputs and resumable iteration artifacts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    save_transition_events: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Save transition events",
+            description="Whether to persist per-iteration transition-event logs.",
+        ),
+    ]
+    persist_iteration_artifacts: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Persist iteration artifacts",
+            description=(
+                "Whether to persist resumable per-iteration state artifacts. "
+                "Disable this to keep only the final outputs."
             ),
         ),
     ]
 
-    alpha: Annotated[
-        float,
+    @model_validator(mode="after")
+    def validate_transition_events(self) -> "GroupDayTripsOutputParameters":
+        """Transition events are only available with iteration artifacts."""
+        if self.persist_iteration_artifacts is False and self.save_transition_events:
+            raise ValueError(
+                "GroupDayTripsOutputParameters.save_transition_events cannot be True "
+                "when persist_iteration_artifacts is False."
+            )
+        return self
+
+
+class GroupDayTripsBehaviorChangeParameters(BaseModel):
+    """Per-iteration behavior-change policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phases: Annotated[
+        list[BehaviorChangePhase] | None,
         Field(
-            default=0.5,
-            ge=0.0,
-            title="Chain cost weighting",
+            default=None,
+            title="Behavior change phases",
             description=(
-                "Weight of the chain cost used to penalize intermediate "
-                "destination options before the next anchor destination in the "
-                "trip chain (shopping place before work, for example)."
+                "Optional per-iteration adaptation policy. If omitted, all "
+                "iterations use full replanning."
             ),
         ),
     ]
+
+    @model_validator(mode="after")
+    def validate_phases(self) -> "GroupDayTripsBehaviorChangeParameters":
+        """Ensure phase definitions are sorted and non-overlapping."""
+        if self.phases is None:
+            return self
+
+        start_iterations = [phase.start_iteration for phase in self.phases]
+        if start_iterations != sorted(start_iterations):
+            raise ValueError(
+                "GroupDayTripsBehaviorChangeParameters.phases must be sorted by start_iteration."
+            )
+        if len(start_iterations) != len(set(start_iterations)):
+            raise ValueError(
+                "GroupDayTripsBehaviorChangeParameters.phases cannot define the same start_iteration twice."
+            )
+        return self
+
+    def scope_at(self, iteration: int) -> BehaviorChangeScope:
+        """Return the active behavior-change scope for one iteration."""
+        if self.phases is None:
+            return BehaviorChangeScope.FULL_REPLANNING
+
+        active_phase = None
+        for phase in self.phases:
+            if phase.start_iteration > iteration:
+                break
+            active_phase = phase
+
+        if active_phase is None:
+            return BehaviorChangeScope.FULL_REPLANNING
+        return active_phase.scope
+
+
+class GroupDayTripsActivitySequenceParameters(BaseModel):
+    """Settings used when sampling activity sequences."""
+
+    model_config = ConfigDict(extra="forbid")
 
     k_activity_sequences: Annotated[
         int | None,
@@ -100,86 +284,43 @@ class Parameters(BaseModel):
             title="Number of activity-sequence seeds",
             description=(
                 "Maximum number of timed survey activity-sequence seeds sampled "
-                "without replacement per demand group during full replanning. "
-                "If omitted, all available seeds are admitted."
+                "without replacement per demand group during full replanning."
             ),
         ),
     ]
 
+
+class GroupDayTripsDestinationSequenceParameters(BaseModel):
+    """Settings used when sampling destination sequences."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    alpha: Annotated[
+        float,
+        Field(
+            default=0.5,
+            ge=0.0,
+            title="Chain cost weighting",
+            description="Weight of the chain cost used to penalize intermediate destination options.",
+        ),
+    ]
     k_destination_sequences: Annotated[
         int,
         Field(
             default=3,
             ge=1,
             title="Number of destination sequences",
-            description=(
-                "Number of destination-chain sequences generated per admitted "
-                "activity sequence. Sequences branch at the anchor-destination "
-                "sampling stage and then complete the remaining destinations "
-                "conditionally."
-            ),
+            description="Number of destination-chain sequences generated per admitted activity sequence.",
         ),
     ]
-    
-    k_mode_sequences: Annotated[
-        int,
-        Field(
-            default=3,
-            ge=1,
-            title="Number of mode combinations",
-            description=(
-                "Number of mode combinations considered in the simulation, for "
-                "a given destination sequence. Only the top k combinations are "
-                "considered."
-            ),
-        ),
-    ]
-
-    n_warmup_iterations: Annotated[
-        int,
-        Field(
-            default=1,
-            ge=0,
-            title="Candidate memory warm-up iterations",
-            description=(
-                "Number of initial iterations during which no candidate-plan "
-                "memory is forgotten. This gives newly generated plans at "
-                "least one iteration to become active before age-based pruning "
-                "starts."
-            ),
-        ),
-    ]
-
-    max_inactive_age: Annotated[
-        int,
-        Field(
-            default=2,
-            ge=0,
-            title="Maximum inactive candidate-plan age",
-            description=(
-                "Maximum number of iterations an inactive candidate plan is "
-                "kept in memory after it was last active or last regenerated. "
-                "Plans that were never active use their last-seen iteration as "
-                "the age reference."
-            ),
-        ),
-    ]
-
     refresh_active_mode_alternatives: Annotated[
         bool,
         Field(
             default=False,
             title="Refresh active mode alternatives",
-            description=(
-                "Whether to append currently active destination chains to the "
-                "iteration destination candidates before the top-k mode search. "
-                "This refreshes mode alternatives for occupied plans with "
-                "current travel costs, while behavior-change phases still "
-                "control which transitions are allowed."
-            ),
+            description="Whether to append active destination chains to the iteration candidates.",
         ),
     ]
-
     dest_prob_cutoff: Annotated[
         float,
         Field(
@@ -187,184 +328,117 @@ class Parameters(BaseModel):
             gt=0.0,
             le=1.0,
             title="Destination probability distribution cutoff",
-            description=(
-                "Cutoff used to prune the less probable destinations for a given "
-                "origin. Only the first dest_prob_cutoff % of the cumulative "
-                "distribution is considered."
-            ),
+            description="Cutoff used to prune less probable destinations.",
         ),
     ]
-
-    n_iter_per_cost_update: Annotated[
-        int,
-        Field(
-            default=3,
-            ge=0,
-            title="Travel costs update period",
-            description=(
-                "The simulation will update the travel costs every n_iter_per_cost_update. ",
-                "Set n_iter_per_cost_update to zero to ignore congestion in the "
-                "simulation, set to 1 to update congestion at each iteration, " 
-                "set to a higher level to speed up the simulation."
-            ),
-        ),
-    ]
-
     cost_uncertainty_sd: Annotated[
         float,
         Field(
             default=1.0,
             gt=0.0,
-            title="Standard deviation of travel costs estimates",
-            description=( 
-                "Travel costs are estimated between specific representative points " 
-                "located in transport zones, but the actual travel costs between "
-                "all origins and all destinations in the transport zones will be "
-                "slightly different than these point estimates. "
-                "cost_uncertainty_sd controls how uncertain are these estimates, "
-                "and spreads the opportunities in the destination transport zone "
-                "based on a normal distribution centered on the point estimates "
-                "and a standard deviation of cost_uncertainty_sd."
-            ),
+            title="Standard deviation of travel cost estimates",
+            description="Standard deviation used to spread destination opportunities around OD point costs.",
         ),
     ]
 
-    seed: Annotated[
+
+class GroupDayTripsModeSequenceParameters(BaseModel):
+    """Settings used when searching mode sequences."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    k_mode_sequences: Annotated[
         int,
         Field(
-            default=0,
-            ge=0,
-            title="Simulation seed",
-            description=(
-                "Seed used to get reproducible results for stochastic simulation "
-                "steps (like destination sampling when building destination chains). "
-                "Change this value to get new programmes and results for a given " 
-                "set of inputs."
-            ),
+            default=3,
+            ge=1,
+            title="Number of mode combinations",
+            description="Number of mode combinations considered for one destination sequence.",
         ),
     ]
-
     mode_sequence_search_parallel: Annotated[
         bool,
         Field(
             default=True,
-            title="Parallel mode for the top k mode sequence search",
-            description=(
-                "Set to False to debug or for small simulations, otherwise set " 
-                "to True to speed up the simulation."
-            ),
+            title="Parallel mode-sequence search",
+            description="Set to False to debug or for small simulations.",
         ),
     ]
-
     use_rust_mode_sequence_search: Annotated[
         bool,
         Field(
             default=False,
             title="Use Rust mode-sequence search backend",
-            description=(
-                "Whether to use the in-process Rust backend for top-k mode "
-                "sequence search instead of the legacy Python implementation. "
-                "This requires the `mobility_mode_sequence_search` package to "
-                "be installed and importable."
-            ),
+            description="Whether to use the in-process Rust backend for top-k mode sequence search.",
         ),
     ]
 
-    save_transition_events: Annotated[
-        bool,
+
+class GroupDayTripsPlanUpdateParameters(BaseModel):
+    """Settings used when updating day-to-day plans."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_warmup_iterations: Annotated[
+        int,
         Field(
-            default=False,
-            title="Save transition events",
-            description=(
-                "Whether to persist per-iteration transition-event logs. "
-                "These logs are useful for post-run analysis but are not "
-                "required to advance the simulation state."
-            ),
+            default=1,
+            ge=0,
+            title="Candidate memory warm-up iterations",
+            description="Number of first iterations where inactive candidate plans are not removed.",
         ),
     ]
-
-    persist_iteration_artifacts: Annotated[
-        bool,
+    max_inactive_age: Annotated[
+        int,
         Field(
-            default=False,
-            title="Persist iteration artifacts",
-            description=(
-                "Whether to persist resumable per-iteration run-state artifacts "
-                "such as current plans, current plan steps, candidate plan steps, "
-                "destination saturation, RNG state, and completion markers. "
-                "Disable this to keep only the final outputs."
-            ),
+            default=2,
+            ge=0,
+            title="Maximum inactive candidate-plan age",
+            description="Number of iterations an inactive candidate plan can stay in memory.",
         ),
     ]
-
-    use_destination_shadow_prices: Annotated[
-        bool,
-        Field(
-            default=False,
-            title="Use destination shadow prices",
-            description=(
-                "Whether to use additive destination shadow prices for "
-                "opportunity-capacity feedback. When disabled, the legacy "
-                "multiplicative sink saturation utility is used."
-            ),
-        ),
-    ]
-
     min_activity_time_constant: Annotated[
         float,
         Field(
             default=1.0,
             ge=0.0,
             title="Minimum activity time coefficient",
-            description=(
-                "Coefficient controlling the minimum activity time necessary to "
-                "get a positive utility from the activity. This minimum time is "
-                "equal to average_activity_time x exp(-min_activity_time_constant)."
-            ),
+            description="Coefficient used to compute the minimum useful duration of an activity.",
         ),
     ]
-
     update_plan_timings_from_modeled_travel_times: Annotated[
         bool,
         Field(
             default=False,
             title="Update plan timings from modeled travel times",
-            description=(
-                "Whether to adjust candidate-plan departure, arrival, and activity "
-                "times from survey reference schedules using the modeled travel "
-                "times at each iteration before recomputing utilities."
-            ),
+            description="Whether to adjust plan timings with modeled travel times at each iteration.",
         ),
     ]
-
+    use_destination_shadow_prices: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Use destination shadow prices",
+            description="Whether to use destination shadow prices for opportunity-capacity feedback.",
+        ),
+    ]
     transition_distance_threshold: Annotated[
         float,
         Field(
             default=float("inf"),
             ge=0.0,
             title="Transition distance threshold",
-            description=(
-                "Maximum embedding distance allowed between a current plan state "
-                "and a candidate plan state. Candidates beyond this threshold are "
-                "excluded from the transition choice set."
-            ),
+            description="Maximum plan-distance allowed when a person changes plan.",
         ),
     ]
-
     enable_transition_distance_model: Annotated[
         bool,
         Field(
             default=False,
             title="Enable transition distance model",
-            description=(
-                "Whether to compute plan-embedding distances during transition "
-                "probability calculation. When disabled, the distance threshold "
-                "and distance friction are ignored to avoid the costly distance "
-                "join and pairwise distance calculation."
-            ),
+            description="Whether plan distance affects day-to-day plan changes.",
         ),
     ]
-
     transition_revision_probability: Annotated[
         float,
         Field(
@@ -372,58 +446,53 @@ class Parameters(BaseModel):
             ge=0.0,
             le=1.0,
             title="Transition revision probability",
-            description=(
-                "Share of persons in a current plan state who reconsider their "
-                "plan at each iteration. Revising persons are redistributed over "
-                "the filtered candidate states according to MNL probabilities."
-            ),
+            description="Share of persons who reconsider their plan at each iteration.",
         ),
     ]
-
     transition_logit_scale: Annotated[
         float,
         Field(
             default=1.0,
             ge=0.0,
             title="Transition logit scale",
-            description=(
-                "Scale applied to plan utilities in the day-to-day plan "
-                "revision multinomial logit. Lower values flatten "
-                "revision probabilities without changing the underlying "
-                "plan utility formulation."
-            ),
+            description="Scale applied to plan utilities when choosing a new plan.",
         ),
     ]
-
     transition_utility_pruning_delta: Annotated[
         float,
         Field(
             default=3.0,
             ge=0.0,
             title="Transition utility pruning delta",
-            description=(
-                "Keep only candidate plans whose scaled utility is within this "
-                "delta of the best candidate utility for a given current plan "
-                "state before computing transition probabilities. Lower values "
-                "shrink the transition choice set and speed up the simulation."
-            ),
+            description="Maximum utility gap used to keep candidate plans in the transition choice set.",
         ),
     ]
-
     min_transition_utility_gain: Annotated[
         float,
         Field(
             default=0.0,
             ge=0.0,
             title="Minimum transition utility gain",
-            description=(
-                "Minimum utility gain needed before a person can switch from "
-                "one plan to another. The current plan is always kept. Set this "
-                "above zero to avoid switching between almost equal plans."
-            ),
+            description="Minimum utility improvement needed before a person can change plan.",
         ),
     ]
-
+    transition_distance_friction: Annotated[
+        float,
+        Field(
+            default=0.5,
+            ge=0.0,
+            title="Transition distance friction",
+            description="Penalty applied to larger plan changes when the distance model is enabled.",
+        ),
+    ]
+    plan_embedding_dimension_weights: Annotated[
+        list[float] | None,
+        Field(
+            default=None,
+            title="Plan embedding dimension weights",
+            description="Optional weights used when computing distances between plans.",
+        ),
+    ]
     plan_probability_pruning_retained_share: Annotated[
         float,
         Field(
@@ -431,131 +500,60 @@ class Parameters(BaseModel):
             gt=0.0,
             le=1.0,
             title="Current-plan retained probability share",
-            description=(
-                "Share of transition mass kept as separate target plans for "
-                "each demand group. Lower-mass target plans are merged into "
-                "the largest retained target plan of the same stay-home or "
-                "mobile type. Set to 1.0 to keep all target plans."
-            ),
+            description="Share of transition probability kept as separate target plans.",
         ),
     ]
-
     plan_probability_pruning_min_iteration: Annotated[
         int,
         Field(
             default=2,
             ge=1,
             title="Current-plan probability pruning start iteration",
-            description=(
-                "First iteration where low-probability target plans may be "
-                "merged when plan_probability_pruning_retained_share is below 1.0."
-            ),
+            description="First iteration where low-probability target plans may be merged.",
         ),
     ]
 
-    transition_distance_friction: Annotated[
-        float,
-        Field(
-            default=0.5,
-            ge=0.0,
-            title="Transition distance friction",
-            description=(
-                "Penalty applied per unit of plan-embedding distance in the "
-                "day-to-day plan revision model. Higher values reduce the "
-                "probability of large jumps between daily programmes."
-            ),
-        ),
+
+class GroupDayTripsParameters(BaseModel):
+    """Root settings for the grouped day-trips model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run: Annotated[
+        GroupDayTripsRunParameters,
+        Field(default_factory=GroupDayTripsRunParameters),
+    ]
+    periods: Annotated[
+        GroupDayTripsPeriodParameters,
+        Field(default_factory=GroupDayTripsPeriodParameters),
+    ]
+    outputs: Annotated[
+        GroupDayTripsOutputParameters,
+        Field(default_factory=GroupDayTripsOutputParameters),
+    ]
+    behavior_change: Annotated[
+        GroupDayTripsBehaviorChangeParameters,
+        Field(default_factory=GroupDayTripsBehaviorChangeParameters),
+    ]
+    activity_sequences: Annotated[
+        GroupDayTripsActivitySequenceParameters,
+        Field(default_factory=GroupDayTripsActivitySequenceParameters),
+    ]
+    destination_sequences: Annotated[
+        GroupDayTripsDestinationSequenceParameters,
+        Field(default_factory=GroupDayTripsDestinationSequenceParameters),
+    ]
+    mode_sequences: Annotated[
+        GroupDayTripsModeSequenceParameters,
+        Field(default_factory=GroupDayTripsModeSequenceParameters),
+    ]
+    plan_update: Annotated[
+        GroupDayTripsPlanUpdateParameters,
+        Field(default_factory=GroupDayTripsPlanUpdateParameters),
     ]
 
-    plan_embedding_dimension_weights: Annotated[
-        list[float] | None,
-        Field(
-            default=None,
-            title="Plan embedding dimension weights",
-            description=(
-                "Optional per-dimension weights used when computing weighted "
-                "Euclidean distances between plan embeddings. If omitted, "
-                "state dimensions use a weight of 1.0 and spatial dimensions "
-                "use the default PlanDistance spatial scaling."
-            ),
-        ),
-    ]
-
-    simulate_weekend: Annotated[
-        bool,
-        Field(
-            default=False,
-            title="Week day only or week day + weekend day mode",
-            description="Wether to simulate a weekend day or only a week day.",
-        ),
-    ]
-
-    behavior_change_phases: Annotated[
-        list[BehaviorChangePhase] | None,
-        Field(
-            default=None,
-            title="Behavior change phases",
-            description=(
-                "Optional per-iteration adaptation policy. Each phase starts at a "
-                "given iteration and selects the highest state layer that may "
-                "adapt: `mode_replanning`, `destination_replanning`, or "
-                "`full_replanning`. Restricted phases apply to currently "
-                "occupied non-stay-home states and freeze stay-home. If omitted, "
-                "all iterations use `full_replanning`."
-            ),
-        ),
-    ]
-
-    @model_validator(mode="after")
-    def validate_behavior_change_phases(self) -> "Parameters":
-        """Ensure phase definitions are sorted and non-overlapping.
-
-        Returns:
-            The validated parameter object.
-
-        Raises:
-            ValueError: If behavior-change phases are not sorted by
-                ``start_iteration`` or if two phases start on the same
-                iteration.
-        """
-        if self.persist_iteration_artifacts is False and self.save_transition_events:
-            raise ValueError(
-                "Parameters.save_transition_events cannot be True when "
-                "Parameters.persist_iteration_artifacts is False."
-            )
-
-        if self.behavior_change_phases is None:
-            return self
-
-        start_iterations = [phase.start_iteration for phase in self.behavior_change_phases]
-        if start_iterations != sorted(start_iterations):
-            raise ValueError("Parameters.behavior_change_phases must be sorted by start_iteration.")
-
-        if len(start_iterations) != len(set(start_iterations)):
-            raise ValueError("Parameters.behavior_change_phases cannot define the same start_iteration twice.")
-
-        return self
-
-    def get_behavior_change_scope(self, iteration: int) -> BehaviorChangeScope:
-        """Return the active behavior-change scope for a given iteration.
-
-        Args:
-            iteration: Current simulation iteration (1-based).
-
-        Returns:
-            The active behavior-change scope. If no phase applies yet, returns
-            ``BehaviorChangeScope.FULL_REPLANNING``.
-        """
-        if self.behavior_change_phases is None:
-            return BehaviorChangeScope.FULL_REPLANNING
-
-        active_phase = None
-        for phase in self.behavior_change_phases:
-            if phase.start_iteration > iteration:
-                break
-            active_phase = phase
-
-        if active_phase is None:
-            return BehaviorChangeScope.FULL_REPLANNING
-
-        return active_phase.scope
+    def with_replication(self, replication: int) -> "GroupDayTripsParameters":
+        """Return validated single-replication parameters for one replication."""
+        data = self.model_dump(mode="python")
+        data["run"] = self.run.with_replication(replication)
+        return self.__class__.model_validate(data)

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -24,7 +24,7 @@ from ..evaluation.trip_pattern_distribution import (
 from ..plans import ActivitySequences, DestinationSequences, ModeSequences, PlanInitializer, PlanUpdater
 from ..transitions.transition_schema import TRANSITION_EVENT_SCHEMA
 from .memory_logging import log_memory_checkpoint
-from .parameters import Parameters
+from .parameters import GroupDayTripsParameters
 from .results import RunResults
 from .run_state import RunState
 from mobility.transport.costs.transport_costs import TransportCosts
@@ -61,9 +61,10 @@ class Run(FileAsset):
         modes: List[TransportMode],
         surveys: List[MobilitySurvey],
         survey_plan_assets: SurveyPlanAssets,
-        parameters: Parameters,
+        parameters: GroupDayTripsParameters,
         is_weekday: bool,
         enabled: bool = True,
+        scenario: str,
     ) -> None:
         """Initialize a single weekday or weekend PopulationGroupDayTrips run."""
         inputs = {
@@ -76,10 +77,11 @@ class Run(FileAsset):
             "parameters": parameters,
             "is_weekday": is_weekday,
             "enabled": enabled,
+            "scenario": scenario,
         }
         
         self.transport_costs = transport_costs
-        self.rng = random.Random(parameters.seed) if parameters.seed is not None else random.Random()
+        self.rng = random.Random(parameters.run.seed) if parameters.run.seed is not None else random.Random()
         self.initializer = PlanInitializer()
         self.updater = PlanUpdater()
         self._expected_diagnostics_inputs: ExpectedDiagnosticsInputs | None = None
@@ -96,6 +98,15 @@ class Run(FileAsset):
         }
         super().__init__(inputs, cache_path)
 
+    @property
+    def n_iterations(self) -> int:
+        """Return the number of simulation iterations for this run."""
+        return self.parameters.run.n_iterations
+
+    @property
+    def n_iter_per_cost_update(self) -> int:
+        """Return how often this run refreshes travel costs."""
+        return self.parameters.run.n_iter_per_cost_update
 
     def create_and_get_asset(self) -> dict[str, pl.LazyFrame]:
         """Run the simulation for this day type and materialize cached outputs."""
@@ -114,7 +125,7 @@ class Run(FileAsset):
             resume_from_iteration=resume_from_iteration,
         )
         self._log_state_memory_checkpoint("state:initialized", state)
-        for iteration_index in range(state.start_iteration, self.parameters.n_iterations + 1):
+        for iteration_index in range(state.start_iteration, self.n_iterations + 1):
             iteration = iterations.iteration(iteration_index)
             self._run_model_iteration(
                 state=state,
@@ -128,7 +139,7 @@ class Run(FileAsset):
                     destination_saturation=state.destination_saturation,
                 )
             )
-            if self.parameters.persist_iteration_artifacts:
+            if self.parameters.outputs.persist_iteration_artifacts:
                 self._log_state_memory_checkpoint(f"iteration:{iteration_index}:before_save_state", state)
                 iteration.save_state(state, self.rng.getstate())
                 log_memory_checkpoint(f"iteration:{iteration_index}:after_save_state")
@@ -219,8 +230,8 @@ class Run(FileAsset):
             is_weekday=self.is_weekday,
             base_folder=self.cache_path["plan_steps"].parent,
         )
-        if self.parameters.persist_iteration_artifacts:
-            resume_from_iteration = iterations.get_resume_iteration(self.parameters.n_iterations)
+        if self.parameters.outputs.persist_iteration_artifacts:
+            resume_from_iteration = iterations.get_resume_iteration(self.n_iterations)
             iterations.prepare(resume=(resume_from_iteration is not None))
         else:
             resume_from_iteration = None
@@ -251,12 +262,16 @@ class Run(FileAsset):
             expected_inputs.population_weighted_plan_steps.get(),
             demand_groups,
         )
-        resolved_activity_parameters = resolve_activity_parameters(self.activities, 1)
+        resolved_activity_parameters = resolve_activity_parameters(
+            self.activities,
+            1,
+            scenario=self.scenario,
+        )
         stay_home_plan, current_plans = self.initializer.get_stay_home_state(
             demand_groups,
             home_night_dur,
             resolved_activity_parameters["home"],
-            self.parameters.min_activity_time_constant,
+            self.parameters.plan_update.min_activity_time_constant,
             iterations.folder_paths["sequences-index"],
             self.modes,
         )
@@ -394,7 +409,7 @@ class Run(FileAsset):
             transition_events=transition_events,
         )
         self._log_state_memory_checkpoint(f"iteration:{iteration.iteration}:after_update_state", state)
-        if transition_events is not None and self.parameters.persist_iteration_artifacts:
+        if transition_events is not None and self.parameters.outputs.persist_iteration_artifacts:
             iteration.save_transition_events(transition_events)
             log_memory_checkpoint(f"iteration:{iteration.iteration}:after_save_transition_events")
 
@@ -424,7 +439,11 @@ class Run(FileAsset):
         activity_sequences: ActivitySequences,
     ) -> DestinationSequences:
         """Run destination sampling and persist destination sequences for one iteration."""
-        resolved_activity_parameters = resolve_activity_parameters(self.activities, iteration.iteration)
+        resolved_activity_parameters = resolve_activity_parameters(
+            self.activities,
+            iteration.iteration,
+            scenario=self.scenario,
+        )
         destination_sequences = iteration.destination_sequences(
             activity_sequences=activity_sequences,
             activities=self.activities,
@@ -468,10 +487,15 @@ class Run(FileAsset):
         resolved_transport_costs: TransportCosts,
     ) -> pl.LazyFrame | None:
         """Advance the simulation state by one iteration and return transition events."""
-        resolved_activity_parameters = resolve_activity_parameters(self.activities, iteration.iteration)
+        resolved_activity_parameters = resolve_activity_parameters(
+            self.activities,
+            iteration.iteration,
+            scenario=self.scenario,
+        )
         arrival_time_rigidity_by_activity = resolve_activity_arrival_time_rigidity(
             self.activities,
             iteration.iteration,
+            scenario=self.scenario,
         )
         state.current_plans, state.current_plan_steps, state.candidate_plan_steps, transition_events = self.updater.get_new_plans(
             state.current_plans,
@@ -496,7 +520,7 @@ class Run(FileAsset):
         state.costs = self.updater.get_new_costs(
             state.costs,
             iteration.iteration,
-            self.parameters.n_iter_per_cost_update,
+            self.n_iter_per_cost_update,
             state.current_plan_steps,
             self.transport_costs.for_iteration(iteration.iteration + 1),
             run=self,
@@ -525,7 +549,7 @@ class Run(FileAsset):
         """Compute the final OD costs to attach to the written outputs."""
         return self.transport_costs.asset_for_iteration(
             self,
-            self.parameters.n_iterations,
+            self.n_iterations,
         ).get_costs_by_od_and_mode(
             ["cost", "distance", "time", "ghg_emissions_per_trip"]
         )
@@ -568,7 +592,10 @@ class Run(FileAsset):
 
     def _build_transitions(self, iterations: Iterations) -> pl.DataFrame | pl.LazyFrame:
         """Combine persisted per-iteration transition events into the final table."""
-        if self.parameters.persist_iteration_artifacts is False or self.parameters.save_transition_events is False:
+        if (
+            self.parameters.outputs.persist_iteration_artifacts is False
+            or self.parameters.outputs.save_transition_events is False
+        ):
             return pl.DataFrame(schema=TRANSITION_EVENT_SCHEMA)
 
         transition_paths = iterations.list_transition_event_paths()

--- a/mobility/trips/group_day_trips/evaluation/car_traffic_evaluation.py
+++ b/mobility/trips/group_day_trips/evaluation/car_traffic_evaluation.py
@@ -16,7 +16,7 @@ class CarTrafficEvaluation:
             iteration: int | None = None
         ):
         if iteration is None:
-            iteration = int(self.results.parameters.n_iterations)
+            iteration = int(self.results.parameters.run.n_iterations)
 
         car_mode = [m for m in self.results.modes if m.inputs["parameters"].name == "car"]
         

--- a/mobility/trips/group_day_trips/evaluation/travel_costs_evaluation.py
+++ b/mobility/trips/group_day_trips/evaluation/travel_costs_evaluation.py
@@ -87,7 +87,7 @@ class TravelCostsEvaluation:
             Input ref_costs dataframe with a distance_model and a time_model column.
         """
         if iteration is None:
-            iteration = int(self.results.parameters.n_iterations)
+            iteration = int(self.results.parameters.run.n_iterations)
 
         costs = ( 
             self.results.run.transport_costs

--- a/mobility/trips/group_day_trips/plans/activity_sequences.py
+++ b/mobility/trips/group_day_trips/plans/activity_sequences.py
@@ -78,7 +78,7 @@ class ActivitySequences(FileAsset):
 
     def _build_activity_sequences_for_scope(self) -> pl.DataFrame:
         """Return admitted timed activity-sequence rows for this iteration."""
-        scope = self.parameters.get_behavior_change_scope(self.iteration)
+        scope = self.parameters.behavior_change.scope_at(self.iteration)
 
         if scope == BehaviorChangeScope.FULL_REPLANNING:
             return self._sample_all_activity_sequences()
@@ -96,7 +96,7 @@ class ActivitySequences(FileAsset):
             .filter(pl.col("time_seq_id") != 0)
         )
 
-        k_activity_sequences = self.parameters.k_activity_sequences
+        k_activity_sequences = self.parameters.activity_sequences.k_activity_sequences
         if k_activity_sequences is None:
             selected = weighted_survey_plans.select(["demand_group_id", "activity_seq_id", "time_seq_id"]).unique()
             return selected.join(

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -108,7 +108,7 @@ class DestinationSequences(FileAsset):
 
     def _build_destination_sequences_for_scope(self) -> pl.DataFrame:
         """Return the destination sequences to use for this iteration."""
-        scope = self.parameters.get_behavior_change_scope(self.iteration)
+        scope = self.parameters.behavior_change.scope_at(self.iteration)
 
         if scope == BehaviorChangeScope.FULL_REPLANNING:
             return self._with_refreshed_active_destination_sequences(
@@ -214,7 +214,7 @@ class DestinationSequences(FileAsset):
 
     def _with_refreshed_active_destination_sequences(self, sampled_sequences: pl.DataFrame) -> pl.DataFrame:
         """Append active destination chains when active-mode refresh is enabled."""
-        if not self.parameters.refresh_active_mode_alternatives:
+        if not self.parameters.destination_sequences.refresh_active_mode_alternatives:
             return sampled_sequences
 
         active_sequences = self._reuse_current_destination_sequences()
@@ -286,13 +286,13 @@ class DestinationSequences(FileAsset):
         utility_inputs = self._get_destination_probability_inputs(
             destination_saturation,
             costs,
-            parameters.cost_uncertainty_sd,
+            parameters.destination_sequences.cost_uncertainty_sd,
         )
         destination_probability = self._get_destination_probability(
             utility_inputs,
             activities,
             self.resolved_activity_parameters,
-            parameters.dest_prob_cutoff,
+            parameters.destination_sequences.dest_prob_cutoff,
         )
         activity_sequences = (
             activity_sequences
@@ -324,7 +324,7 @@ class DestinationSequences(FileAsset):
             anchor_spatialized_sequences,
             destination_probability,
             costs,
-            parameters.alpha,
+            parameters.destination_sequences.alpha,
             seed,
         )
         complete_activity_sequences = self._drop_incomplete_destination_draws(
@@ -385,8 +385,9 @@ class DestinationSequences(FileAsset):
         x = [-2.0, -1.0, 0.0, 1.0, 2.0]
         probabilities = norm.pdf(x, loc=0.0, scale=cost_uncertainty_sd)
         probabilities /= probabilities.sum()
+        plan_update_parameters = getattr(self.parameters, "plan_update", None)
         use_shadow_prices = bool(
-            getattr(self.parameters, "use_destination_shadow_prices", False)
+            getattr(plan_update_parameters, "use_destination_shadow_prices", False)
         )
         opportunities_columns = set(opportunities.columns)
         if (
@@ -557,7 +558,7 @@ class DestinationSequences(FileAsset):
                 )
                 .cast(pl.UInt32)
             )
-            .filter(pl.col("dest_draw_id") <= self.parameters.k_destination_sequences)
+            .filter(pl.col("dest_draw_id") <= self.parameters.destination_sequences.k_destination_sequences)
             .select(["demand_group_id", "activity_seq_id", "time_seq_id", "activity", "dest_draw_id", "to"])
         )
 
@@ -576,7 +577,7 @@ class DestinationSequences(FileAsset):
             .unique()
         )
         destination_draw_ids = pl.DataFrame(
-            {"dest_draw_id": list(range(1, int(self.parameters.k_destination_sequences) + 1))},
+            {"dest_draw_id": list(range(1, int(self.parameters.destination_sequences.k_destination_sequences) + 1))},
             schema={"dest_draw_id": pl.UInt32},
         ).lazy()
         sequences_without_non_home_anchor = (

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
@@ -90,7 +90,7 @@ class ModeSequences(FileAsset):
             destination_chains=destination_steps,
         )
 
-        use_rust_search = self.parameters.use_rust_mode_sequence_search
+        use_rust_search = self.parameters.mode_sequences.use_rust_mode_sequence_search
 
         trip_chains, unique_destination_chains = build_location_chains(destination_steps)
 
@@ -120,7 +120,7 @@ class ModeSequences(FileAsset):
                 is_return_mode_by_id=search_inputs.is_return_mode_by_id,
                 modes_by_name=search_inputs.modes_by_name,
                 mode_name_by_id=search_inputs.mode_name_by_id,
-                k_mode_sequences=self.parameters.k_mode_sequences,
+                k_mode_sequences=self.parameters.mode_sequences.k_mode_sequences,
             )
         else:
             search_rows = run_python_mode_sequence_search(

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/search_python.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/search_python.py
@@ -54,10 +54,10 @@ def run_python_mode_sequence_search(
         leg_modes=mode_ids_by_leg,
     )
 
-    if parameters.mode_sequence_search_parallel is False:
+    if parameters.mode_sequences.mode_sequence_search_parallel is False:
         logging.info("Finding probable mode sequences for the spatialized trip chains...")
         compute_subtour_mode_probabilities_serial(
-            parameters.k_mode_sequences,
+            parameters.mode_sequences.k_mode_sequences,
             unique_destination_chains,
             cost_by_origin_destination_mode,
             mode_ids_by_leg,
@@ -115,7 +115,7 @@ def run_python_mode_sequence_search_subprocess(
                     / "compute_subtour_mode_probabilities.py"
                 ),
                 "--k_sequences",
-                str(parameters.k_mode_sequences),
+                str(parameters.mode_sequences.k_mode_sequences),
                 "--location_chains_path",
                 str(location_chains_path),
                 "--costs_path",

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -61,7 +61,7 @@ class PlanUpdater:
             transport_zones,
             iteration,
             resolved_activity_parameters,
-            parameters.min_activity_time_constant,
+            parameters.plan_update.min_activity_time_constant,
             destination_sequences,
             mode_sequences,
             parameters,
@@ -87,7 +87,7 @@ class PlanUpdater:
         possible_plan_steps = self.schedule_updater.update_plan_timings(
             possible_plan_steps,
             arrival_time_rigidity_by_activity=arrival_time_rigidity_by_activity,
-            enabled=parameters.update_plan_timings_from_modeled_travel_times,
+            enabled=parameters.plan_update.update_plan_timings_from_modeled_travel_times,
         )
         possible_plan_steps = (
             possible_plan_steps
@@ -105,7 +105,7 @@ class PlanUpdater:
             home_night_dur,
             resolved_activity_parameters["home"].value_of_time_stay_home,
             stay_home_plan,
-            parameters.min_activity_time_constant,
+            parameters.plan_update.min_activity_time_constant,
             sequence_index_folder=sequence_index_folder,
         )
         possible_plan_steps = self.add_stay_home_plan_steps(
@@ -124,16 +124,16 @@ class PlanUpdater:
             current_plans,
             possible_plan_utility,
             possible_plan_steps,
-            parameters.get_behavior_change_scope(iteration),
+            parameters.behavior_change.scope_at(iteration),
             transport_zones=transport_zones,
-            transition_distance_threshold=parameters.transition_distance_threshold,
-            enable_transition_distance_model=parameters.enable_transition_distance_model,
-            transition_revision_probability=parameters.transition_revision_probability,
-            transition_logit_scale=parameters.transition_logit_scale,
-            transition_utility_pruning_delta=parameters.transition_utility_pruning_delta,
-            min_transition_utility_gain=parameters.min_transition_utility_gain,
-            transition_distance_friction=parameters.transition_distance_friction,
-            plan_embedding_dimension_weights=parameters.plan_embedding_dimension_weights,
+            transition_distance_threshold=parameters.plan_update.transition_distance_threshold,
+            enable_transition_distance_model=parameters.plan_update.enable_transition_distance_model,
+            transition_revision_probability=parameters.plan_update.transition_revision_probability,
+            transition_logit_scale=parameters.plan_update.transition_logit_scale,
+            transition_utility_pruning_delta=parameters.plan_update.transition_utility_pruning_delta,
+            min_transition_utility_gain=parameters.plan_update.min_transition_utility_gain,
+            transition_distance_friction=parameters.plan_update.transition_distance_friction,
+            plan_embedding_dimension_weights=parameters.plan_update.plan_embedding_dimension_weights,
         )
         log_memory_checkpoint(
             f"plan_updater:iteration:{iteration}:transition_probabilities",
@@ -143,8 +143,8 @@ class PlanUpdater:
             current_plans,
             transition_prob,
             iteration,
-            plan_probability_pruning_retained_share=parameters.plan_probability_pruning_retained_share,
-            plan_probability_pruning_min_iteration=parameters.plan_probability_pruning_min_iteration,
+            plan_probability_pruning_retained_share=parameters.plan_update.plan_probability_pruning_retained_share,
+            plan_probability_pruning_min_iteration=parameters.plan_update.plan_probability_pruning_min_iteration,
         )
         log_memory_checkpoint(
             f"plan_updater:iteration:{iteration}:after_apply_transitions",
@@ -156,7 +156,7 @@ class PlanUpdater:
             f"plan_updater:iteration:{iteration}:current_plan_steps",
             current_plan_steps=current_plan_steps,
         )
-        if parameters.save_transition_events:
+        if parameters.outputs.save_transition_events:
             transition_events = add_transition_plan_details(
                 transition_events,
                 possible_plan_steps.lazy(),
@@ -226,8 +226,8 @@ class PlanUpdater:
             current_plans=current_plans,
             previous_candidate_plan_steps=candidate_plan_steps,
             current_iteration=iteration,
-            n_warmup_iterations=parameters.n_warmup_iterations,
-            max_inactive_age=parameters.max_inactive_age,
+            n_warmup_iterations=parameters.plan_update.n_warmup_iterations,
+            max_inactive_age=parameters.plan_update.max_inactive_age,
         )
         log_memory_checkpoint(
             f"plan_updater:iteration:{iteration}:candidate_memory",
@@ -243,7 +243,7 @@ class PlanUpdater:
             resolved_activity_parameters=resolved_activity_parameters,
             min_activity_time_constant=min_activity_time_constant,
             allow_missing_costs_for_current_plans=(candidate_plan_steps is not None),
-            use_destination_shadow_prices=parameters.use_destination_shadow_prices,
+            use_destination_shadow_prices=parameters.plan_update.use_destination_shadow_prices,
         )
 
     def compute_plan_steps_candidates_utility(

--- a/mobility/trips/group_day_trips/transitions/transition_metrics.py
+++ b/mobility/trips/group_day_trips/transitions/transition_metrics.py
@@ -46,8 +46,8 @@ def state_waterfall(
         raise ValueError(
             "`state_waterfall` requires persisted transition events, but the "
             "run transitions table is empty. Rerun PopulationGroupDayTrips "
-            "with Parameters(persist_iteration_artifacts=True, "
-            "save_transition_events=True)."
+            "with GroupDayTripsParameters(outputs=GroupDayTripsOutputParameters("
+            "persist_iteration_artifacts=True, save_transition_events=True))."
         )
     _validate_transition_inputs(transitions_df)
 

--- a/tests/back/integration/test_008_group_day_trips_can_be_computed.py
+++ b/tests/back/integration/test_008_group_day_trips_can_be_computed.py
@@ -2,7 +2,14 @@ import pytest
 
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
-from mobility.trips.group_day_trips import Parameters, PopulationGroupDayTrips
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 
 
@@ -41,17 +48,23 @@ def test_008_group_day_trips_can_be_computed(test_data):
         modes=[car_mode, walk_mode, bicycle_mode, public_transport_mode],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=1,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            simulate_weekend=False
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=1,
+                n_iter_per_cost_update=0,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
-    plan_steps = group_day_trips.weekday_run.get()["plan_steps"].collect()
+    plan_steps = group_day_trips.run("weekday").get()["plan_steps"].collect()
 
     assert plan_steps.height > 0

--- a/tests/back/integration/test_008b_group_day_trips_congestion_changes_costs.py
+++ b/tests/back/integration/test_008b_group_day_trips_congestion_changes_costs.py
@@ -3,7 +3,14 @@ import polars as pl
 
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
-from mobility.trips.group_day_trips import Parameters, PopulationGroupDayTrips
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 
 
@@ -46,14 +53,20 @@ def test_008b_group_day_trips_congestion_changes_costs(test_data):
         ],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=1,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            simulate_weekend=False,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=1,
+                n_iter_per_cost_update=0,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
@@ -82,25 +95,31 @@ def test_008b_group_day_trips_congestion_changes_costs(test_data):
         ],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=2,
-            n_iter_per_cost_update=1,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            simulate_weekend=False,
-            seed=0,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=2,
+                n_iter_per_cost_update=1,
+                seed=0,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
-    baseline_result = baseline.get()
-    congested_result = congested.get()
+    baseline_result = baseline.run("weekday").get()
+    congested_result = congested.run("weekday").get()
 
-    baseline_plan_steps = baseline_result["weekday_plan_steps"].collect()
-    congested_plan_steps = congested_result["weekday_plan_steps"].collect()
-    baseline_costs = baseline_result["weekday_costs"].collect()
-    congested_costs = congested_result["weekday_costs"].collect()
+    baseline_plan_steps = baseline_result["plan_steps"].collect()
+    congested_plan_steps = congested_result["plan_steps"].collect()
+    baseline_costs = baseline_result["costs"].collect()
+    congested_costs = congested_result["costs"].collect()
 
     assert baseline_plan_steps.height > 0
     assert congested_plan_steps.height > 0

--- a/tests/back/integration/test_008c_group_day_trips_parameter_values_change_iteration_2.py
+++ b/tests/back/integration/test_008c_group_day_trips_parameter_values_change_iteration_2.py
@@ -3,7 +3,15 @@ import polars as pl
 
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
-from mobility.trips.group_day_trips import Parameters, PopulationGroupDayTrips
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 
 
@@ -45,17 +53,25 @@ def test_008c_group_day_trips_parameter_values_change_iteration_2(test_data):
             OtherActivity(population=pop),
         ],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=2,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            persist_iteration_artifacts=True,
-            save_transition_events=True,
-            simulate_weekend=False,
-            seed=0,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=2,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            outputs=GroupDayTripsOutputParameters(
+                persist_iteration_artifacts=True,
+                save_transition_events=True,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
@@ -66,34 +82,41 @@ def test_008c_group_day_trips_parameter_values_change_iteration_2(test_data):
             HomeActivity(),
             WorkActivity(
                 value_of_time=mobility.ParameterValue.by_iteration(
-                    {
-                        1: 5.0,
-                        2: 50.0,
-                    },
-                    mode="step",
-                )
+                    {1: 5.0, 2: 50.0},
+                ),
             ),
             OtherActivity(population=pop),
         ],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=2,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            persist_iteration_artifacts=True,
-            save_transition_events=True,
-            simulate_weekend=False,
-            seed=0,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=2,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            outputs=GroupDayTripsOutputParameters(
+                persist_iteration_artifacts=True,
+                save_transition_events=True,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
-    static_plan_steps = static.weekday_run.get()["plan_steps"].collect()
-    dynamic_plan_steps = dynamic.weekday_run.get()["plan_steps"].collect()
-    static_transitions = static.weekday_run.get()["transitions"].collect()
-    dynamic_transitions = dynamic.weekday_run.get()["transitions"].collect()
+    static_run = static.run("weekday")
+    dynamic_run = dynamic.run("weekday")
+
+    static_plan_steps = static_run.get()["plan_steps"].collect()
+    dynamic_plan_steps = dynamic_run.get()["plan_steps"].collect()
+    static_transitions = static_run.get()["transitions"].collect()
+    dynamic_transitions = dynamic_run.get()["transitions"].collect()
 
     assert static_plan_steps.height > 0
     assert dynamic_plan_steps.height > 0

--- a/tests/back/integration/test_008d_group_day_trips_pt_gtfs_parameter_values_change_iteration_2.py
+++ b/tests/back/integration/test_008d_group_day_trips_pt_gtfs_parameter_values_change_iteration_2.py
@@ -7,7 +7,15 @@ import pytest
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
-from mobility.trips.group_day_trips import PopulationGroupDayTrips, Parameters
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 from mobility.transport.modes.public_transport.gtfs.gtfs_router import GTFSRouter
 
@@ -130,7 +138,7 @@ def _read_cppr_graph_edges(graph_path: str | pathlib.Path, output_path: pathlib.
     ],
     scope="session",
 )
-def test_008d_group_day_trips_pt_intermodal_travel_times_change_with_gtfs_profiles(
+def test_008d_group_day_trips_pt_intermodal_travel_times_change_with_gtfs_parameter_values(
     test_data,
     monkeypatch,
     tmp_path,
@@ -158,17 +166,25 @@ def test_008d_group_day_trips_pt_intermodal_travel_times_change_with_gtfs_profil
         sample_size=test_data["population_sample_size"],
     )
 
-    common_parameters = Parameters(
-        n_iterations=2,
-        n_iter_per_cost_update=0,
-        dest_prob_cutoff=0.9,
-        k_mode_sequences=6,
-        cost_uncertainty_sd=1.0,
-        mode_sequence_search_parallel=False,
-        persist_iteration_artifacts=True,
-        save_transition_events=True,
-        simulate_weekend=False,
-        seed=0,
+    common_parameters = GroupDayTripsParameters(
+        run=GroupDayTripsRunParameters(
+            n_iterations=2,
+            n_iter_per_cost_update=0,
+            seed=0,
+        ),
+        periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+        outputs=GroupDayTripsOutputParameters(
+            persist_iteration_artifacts=True,
+            save_transition_events=True,
+        ),
+        destination_sequences=GroupDayTripsDestinationSequenceParameters(
+            dest_prob_cutoff=0.9,
+            cost_uncertainty_sd=1.0,
+        ),
+        mode_sequences=GroupDayTripsModeSequenceParameters(
+            k_mode_sequences=6,
+            mode_sequence_search_parallel=False,
+        ),
     )
 
     static = PopulationGroupDayTrips(
@@ -211,20 +227,22 @@ def test_008d_group_day_trips_pt_intermodal_travel_times_change_with_gtfs_profil
         parameters=common_parameters,
     )
 
-    static_result = static.get()
-    dynamic_result = dynamic.get()
+    static_run = static.run("weekday")
+    dynamic_run = dynamic.run("weekday")
+    static_result = static_run.get()
+    dynamic_result = dynamic_run.get()
 
-    static_costs = static_result["weekday_costs"].collect()
-    dynamic_costs = dynamic_result["weekday_costs"].collect()
-    dynamic_transitions = dynamic_result["weekday_transitions"].collect()
+    static_costs = static_result["costs"].collect()
+    dynamic_costs = dynamic_result["costs"].collect()
+    dynamic_transitions = dynamic_result["transitions"].collect()
 
     pt_mode_name = "walk/public_transport/walk"
     static_pt_mode = next(
-        mode for mode in static.weekday_run.transport_costs.modes
+        mode for mode in static_run.transport_costs.modes
         if mode.inputs["parameters"].name == pt_mode_name
     ).for_iteration(2)
     dynamic_pt_mode = next(
-        mode for mode in dynamic.weekday_run.transport_costs.modes
+        mode for mode in dynamic_run.transport_costs.modes
         if mode.inputs["parameters"].name == pt_mode_name
     ).for_iteration(2)
 

--- a/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
+++ b/tests/back/integration/test_008e_group_day_trips_can_resume_from_saved_iteration.py
@@ -3,7 +3,15 @@ import pytest
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
 from mobility.surveys.france import EMPMobilitySurvey
-from mobility.trips.group_day_trips import PopulationGroupDayTrips, Parameters
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 
 
 def _build_group_day_trips(test_data):
@@ -32,17 +40,25 @@ def _build_group_day_trips(test_data):
         modes=[car_mode, walk_mode, bicycle_mode, public_transport_mode],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=2,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=6,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            persist_iteration_artifacts=True,
-            save_transition_events=True,
-            simulate_weekend=False,
-            seed=108,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=2,
+                n_iter_per_cost_update=0,
+                seed=108,
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            outputs=GroupDayTripsOutputParameters(
+                persist_iteration_artifacts=True,
+                save_transition_events=True,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=6,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
@@ -55,9 +71,10 @@ def _build_group_day_trips(test_data):
 )
 def test_008e_group_day_trips_can_resume_from_saved_iteration(test_data):
     pop_trips = _build_group_day_trips(test_data)
+    pop_trips.run("weekday")
     pop_trips.remove()
 
-    run = pop_trips.weekday_run
+    run = pop_trips.run("weekday")
     iterations, resume_from_iteration = run._prepare_iterations(run.inputs_hash)
 
     assert resume_from_iteration is None
@@ -92,11 +109,11 @@ def test_008e_group_day_trips_can_resume_from_saved_iteration(test_data):
     ]
 
     resumed_pop_trips = _build_group_day_trips(test_data)
-    result = resumed_pop_trips.get()
+    result = resumed_pop_trips.run("weekday").get()
 
-    plan_steps = result["weekday_plan_steps"].collect()
-    transitions = result["weekday_transitions"].collect()
-    iteration_metrics = result["weekday_iteration_metrics"].collect()
+    plan_steps = result["plan_steps"].collect()
+    transitions = result["transitions"].collect()
+    iteration_metrics = result["iteration_metrics"].collect()
 
     assert plan_steps.height > 0
     assert transitions.height > 0

--- a/tests/back/integration/test_009_group_day_trips_results_can_be_computed.py
+++ b/tests/back/integration/test_009_group_day_trips_results_can_be_computed.py
@@ -2,7 +2,14 @@ import pytest
 
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
-from mobility.trips.group_day_trips import Parameters, PopulationGroupDayTrips
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 
 
@@ -29,21 +36,29 @@ def test_009_group_day_trips_results_can_be_computed(test_data):
         modes=[mobility.CarMode(transport_zones)],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=1,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=3,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            seed=0,
-            persist_iteration_artifacts=True,
-            save_transition_events=True,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=1,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            outputs=GroupDayTripsOutputParameters(
+                persist_iteration_artifacts=True,
+                save_transition_events=True,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=3,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
     # Evaluate various metrics
-    results = pop_trips.weekday_run.results()
+    results = pop_trips.run("weekday").results()
     global_metrics = results.metrics.aggregate()
     weekday_metrics_by_mode = results.metrics.travel_indicators_by(
         variable="mode",
@@ -77,7 +92,7 @@ def test_009_group_day_trips_results_can_be_computed(test_data):
     weekday_cost_per_person = results.metrics.cost_per_person()
     grouped_global_metrics = results.metrics.aggregate()
     iteration_metrics = results.diagnostics.iteration_metrics()
-    weekday_distance_compare = results.metrics.distance_per_person(compare_with=pop_trips)
+    weekday_distance_compare = results.metrics.distance_per_person(compare_with=results)
 
     assert global_metrics.height > 0
     assert weekday_metrics_by_mode.height > 0

--- a/tests/back/integration/test_010_group_day_trips_results_are_reproducible.py
+++ b/tests/back/integration/test_010_group_day_trips_results_are_reproducible.py
@@ -3,7 +3,13 @@ import polars as pl
 
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
-from mobility.trips.group_day_trips import Parameters, PopulationGroupDayTrips
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 from mobility.surveys.france import EMPMobilitySurvey
 
 @pytest.mark.dependency(
@@ -30,18 +36,24 @@ def test_010_group_day_trips_results_are_reproducible(test_data):
         modes=[mobility.CarMode(transport_zones)],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=1,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=3,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            seed=0
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=1,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=3,
+                mode_sequence_search_parallel=False,
+            ),
         )
     )
 
-    metrics_run_1 = pop_trips.weekday_run.results().metrics.aggregate()
+    metrics_run_1 = pop_trips.run("weekday").results().metrics.aggregate()
     
     # Remove the results then re run the model with the same inputs
     pop_trips.remove()
@@ -51,18 +63,24 @@ def test_010_group_day_trips_results_are_reproducible(test_data):
         modes=[mobility.CarMode(transport_zones)],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=1,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=3,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            seed=0
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=1,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=3,
+                mode_sequence_search_parallel=False,
+            ),
         )
     )
 
-    metrics_run_2 = pop_trips.weekday_run.results().metrics.aggregate()
+    metrics_run_2 = pop_trips.run("weekday").results().metrics.aggregate()
     
     # Compare results between runs
     comparison = (

--- a/tests/back/integration/test_011_population_trips_behavior_change_phases_can_be_computed.py
+++ b/tests/back/integration/test_011_population_trips_behavior_change_phases_can_be_computed.py
@@ -4,7 +4,17 @@ import pytest
 import mobility
 from mobility.activities import HomeActivity, OtherActivity, WorkActivity
 from mobility.surveys.france import EMPMobilitySurvey
-from mobility.trips.group_day_trips import BehaviorChangePhase, BehaviorChangeScope, PopulationGroupDayTrips, Parameters
+from mobility.trips.group_day_trips import (
+    BehaviorChangePhase,
+    BehaviorChangeScope,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsOutputParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsRunParameters,
+    PopulationGroupDayTrips,
+)
 
 
 @pytest.mark.dependency(
@@ -33,29 +43,40 @@ def test_011_population_trips_behavior_change_phases_can_be_computed(test_data):
         modes=[car_mode, walk_mode],
         activities=[HomeActivity(), WorkActivity(), OtherActivity(population=pop)],
         surveys=[emp],
-        parameters=Parameters(
-            n_iterations=3,
-            n_iter_per_cost_update=0,
-            dest_prob_cutoff=0.9,
-            k_mode_sequences=3,
-            cost_uncertainty_sd=1.0,
-            mode_sequence_search_parallel=False,
-            persist_iteration_artifacts=True,
-            save_transition_events=True,
-            seed=0,
-            behavior_change_phases=[
-                BehaviorChangePhase(start_iteration=1, scope=BehaviorChangeScope.FULL_REPLANNING),
-                BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING),
-                BehaviorChangePhase(start_iteration=3, scope=BehaviorChangeScope.DESTINATION_REPLANNING),
-            ],
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=3,
+                n_iter_per_cost_update=0,
+                seed=0,
+            ),
+            outputs=GroupDayTripsOutputParameters(
+                persist_iteration_artifacts=True,
+                save_transition_events=True,
+            ),
+            behavior_change=GroupDayTripsBehaviorChangeParameters(
+                phases=[
+                    BehaviorChangePhase(start_iteration=1, scope=BehaviorChangeScope.FULL_REPLANNING),
+                    BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING),
+                    BehaviorChangePhase(start_iteration=3, scope=BehaviorChangeScope.DESTINATION_REPLANNING),
+                ],
+            ),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                dest_prob_cutoff=0.9,
+                cost_uncertainty_sd=1.0,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(
+                k_mode_sequences=3,
+                mode_sequence_search_parallel=False,
+            ),
         ),
     )
 
-    result = pop_trips.get()
-    weekday_plan_steps = result["weekday_plan_steps"].collect()
-    weekday_transitions = result["weekday_transitions"].collect()
-    cache_parent = pop_trips.weekday_run.cache_path["plan_steps"].parent
-    inputs_hash = pop_trips.weekday_run.inputs_hash
+    weekday_run = pop_trips.run("weekday")
+    result = weekday_run.get()
+    weekday_plan_steps = result["plan_steps"].collect()
+    weekday_transitions = result["transitions"].collect()
+    cache_parent = weekday_run.cache_path["plan_steps"].parent
+    inputs_hash = weekday_run.inputs_hash
     destination_sequences_dir = cache_parent / f"{inputs_hash}-destination-sequences"
     destination_sequences_1 = pl.read_parquet(next(destination_sequences_dir.glob("*destination_sequences_1.parquet")))
     destination_sequences_2 = pl.read_parquet(next(destination_sequences_dir.glob("*destination_sequences_2.parquet")))

--- a/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
+++ b/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
@@ -91,7 +91,8 @@ def test_iter_run_congestion_artifacts_returns_nothing_when_disabled(
 ):
     aggregator = TransportCosts(modes=modes)
     run = SimpleNamespace(
-        parameters=SimpleNamespace(n_iter_per_cost_update=update_interval, n_iterations=2),
+        n_iter_per_cost_update=update_interval,
+        n_iterations=2,
         inputs_hash="run-key",
         is_weekday=True,
     )
@@ -133,7 +134,8 @@ def test_iter_run_congestion_artifacts_yields_existing_flow_assets_on_refresh_it
     )
 
     run = SimpleNamespace(
-        parameters=SimpleNamespace(n_iter_per_cost_update=2, n_iterations=3),
+        n_iter_per_cost_update=2,
+        n_iterations=3,
         inputs_hash="run-key",
         is_weekday=False,
     )

--- a/tests/back/unit/domain/group_day_trips/test_001_restore_saved_state.py
+++ b/tests/back/unit/domain/group_day_trips/test_001_restore_saved_state.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 import polars as pl
 import pytest
 
-from mobility.trips.group_day_trips.core.parameters import Parameters
+from mobility.trips.group_day_trips.core.parameters import (
+    GroupDayTripsParameters,
+    GroupDayTripsRunParameters,
+)
 from mobility.trips.group_day_trips.core.run import Run, RunState
 
 
@@ -46,7 +49,9 @@ def make_run():
     run = object.__new__(Run)
     run.inputs_hash = "run-hash"
     run.is_weekday = True
-    run.parameters = Parameters(n_iter_per_cost_update=3)
+    run.parameters = GroupDayTripsParameters(
+        run=GroupDayTripsRunParameters(n_iter_per_cost_update=3),
+    )
     run.transport_costs = FakeCostsAggregator()
     run.rng = random.Random(123)
     return run

--- a/tests/back/unit/domain/group_day_trips/test_002_mode_sequences_parallel_search.py
+++ b/tests/back/unit/domain/group_day_trips/test_002_mode_sequences_parallel_search.py
@@ -30,8 +30,21 @@ class _DummyProcess:
         return 0
 
 
+def _mode_sequence_parameters(
+    *,
+    k_mode_sequences,
+    mode_sequence_search_parallel=True,
+):
+    return SimpleNamespace(
+        mode_sequences=SimpleNamespace(
+            k_mode_sequences=k_mode_sequences,
+            mode_sequence_search_parallel=mode_sequence_search_parallel,
+        )
+    )
+
+
 def test_run_python_mode_sequence_search_subprocess_serializes_inputs_for_worker(monkeypatch, tmp_path):
-    parameters = SimpleNamespace(k_mode_sequences=7)
+    parameters = _mode_sequence_parameters(k_mode_sequences=7)
     unique_destination_chains = pl.DataFrame({"dest_seq_id": [1], "locations": [[101, 202, 303]]})
     cost_by_origin_destination_mode = {(101, 202, 0): 1200, (202, 303, 1): 900}
     mode_ids_by_leg = {(101, 202): [0, 1], (202, 303): [1]}
@@ -117,7 +130,10 @@ def test_run_python_mode_sequence_search_serial_backend_filters_return_modes(mon
 
     result = run_python_mode_sequence_search(
         iteration=3,
-        parameters=SimpleNamespace(k_mode_sequences=4, mode_sequence_search_parallel=False),
+        parameters=_mode_sequence_parameters(
+            k_mode_sequences=4,
+            mode_sequence_search_parallel=False,
+        ),
         working_folder=tmp_path,
         unique_destination_chains=pl.DataFrame({"dest_seq_id": [1], "locations": [[1, 2]]}),
         leg_mode_costs=pl.DataFrame(
@@ -245,7 +261,10 @@ def test_python_and_rust_mode_sequence_backends_match_on_same_inputs(tmp_path):
 
     python_rows = run_python_mode_sequence_search(
         iteration=1,
-        parameters=SimpleNamespace(k_mode_sequences=3, mode_sequence_search_parallel=False),
+        parameters=_mode_sequence_parameters(
+            k_mode_sequences=3,
+            mode_sequence_search_parallel=False,
+        ),
         working_folder=tmp_path,
         unique_destination_chains=unique_destination_chains,
         leg_mode_costs=leg_mode_costs,

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from mobility.trips.group_day_trips import BehaviorChangePhase, BehaviorChangeScope, Parameters
+from mobility.trips.group_day_trips import (
+    BehaviorChangePhase,
+    BehaviorChangeScope,
+    GroupDayTripsBehaviorChangeParameters,
+)
 from mobility.trips.group_day_trips.plans.candidate_plan_steps import CandidatePlanStepsAsset
 from mobility.trips.group_day_trips.plans.plan_ids import add_plan_id
 from mobility.trips.group_day_trips.plans.plan_updater import PlanUpdater
@@ -104,16 +108,16 @@ def _with_plan_id(
 ) -> pl.DataFrame | pl.LazyFrame:
     return add_plan_id(frame, index_folder=_make_local_tmp_path(tmp_path, name))
 def test_parameters_resolve_behavior_change_scope_from_active_phases():
-    parameters = Parameters(
-        behavior_change_phases=[
+    parameters = GroupDayTripsBehaviorChangeParameters(
+        phases=[
             BehaviorChangePhase(start_iteration=3, scope=BehaviorChangeScope.MODE_REPLANNING),
             BehaviorChangePhase(start_iteration=5, scope=BehaviorChangeScope.DESTINATION_REPLANNING),
         ]
     )
 
-    assert Parameters().get_behavior_change_scope(1) == BehaviorChangeScope.FULL_REPLANNING
-    assert parameters.get_behavior_change_scope(3) == BehaviorChangeScope.MODE_REPLANNING
-    assert parameters.get_behavior_change_scope(6) == BehaviorChangeScope.DESTINATION_REPLANNING
+    assert GroupDayTripsBehaviorChangeParameters().scope_at(1) == BehaviorChangeScope.FULL_REPLANNING
+    assert parameters.scope_at(3) == BehaviorChangeScope.MODE_REPLANNING
+    assert parameters.scope_at(6) == BehaviorChangeScope.DESTINATION_REPLANNING
 
 
 def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning(tmp_path):

--- a/tests/back/unit/domain/group_day_trips/test_004_remove_clears_congestion_variants.py
+++ b/tests/back/unit/domain/group_day_trips/test_004_remove_clears_congestion_variants.py
@@ -117,7 +117,9 @@ def test_remove_run_iteration_congestion_artifacts_clears_mode_variant_graph_cha
     run = object.__new__(Run)
     run.inputs_hash = "run-key"
     run.is_weekday = True
-    run.parameters = SimpleNamespace(n_iter_per_cost_update=1, n_iterations=1)
+    run.parameters = SimpleNamespace(
+        run=SimpleNamespace(n_iter_per_cost_update=1, n_iterations=1),
+    )
     run.transport_costs = _TransportCostsWithCongestionVariants(next_transport_costs)
 
     monkeypatch.setattr(
@@ -174,7 +176,9 @@ def test_remove_run_iteration_congestion_artifacts_keeps_non_variant_mode_cleanu
     run = object.__new__(Run)
     run.inputs_hash = "run-key"
     run.is_weekday = True
-    run.parameters = SimpleNamespace(n_iter_per_cost_update=1, n_iterations=1)
+    run.parameters = SimpleNamespace(
+        run=SimpleNamespace(n_iter_per_cost_update=1, n_iterations=1),
+    )
     run.transport_costs = _TransportCostsWithCongestionVariants(next_transport_costs)
 
     monkeypatch.setattr(

--- a/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
+++ b/tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py
@@ -5,16 +5,31 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from mobility.runtime.parameter_values import DEFAULT_SCENARIO, ParameterValue
+from mobility.runtime.scenarios import Scenario, Scenarios
 from mobility.trips.group_day_trips import BehaviorChangePhase, BehaviorChangeScope, PopulationGroupDayTrips
+from mobility.trips.group_day_trips.core.parameters import (
+    GroupDayTripsActivitySequenceParameters,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsModeSequenceParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPeriodParameters,
+    GroupDayTripsPlanUpdateParameters,
+    GroupDayTripsRunParameters,
+)
 from mobility.trips.group_day_trips.core import group_day_trips as group_day_trips_module
 
 
 class _FakeRun:
-    def __init__(self, *, parameters, is_weekday, enabled, survey_plan_assets, **kwargs):
+    removed_runs = []
+
+    def __init__(self, *, parameters, is_weekday, enabled, survey_plan_assets, scenario=None, **kwargs):
         self.parameters = parameters
         self.is_weekday = is_weekday
         self.enabled = enabled
         self.survey_plan_assets = survey_plan_assets
+        self.scenario = scenario
         base = Path("cache") / ("weekday" if is_weekday else "weekend")
         self.cache_path = {
             "plan_steps": base / "plan_steps.parquet",
@@ -24,6 +39,9 @@ class _FakeRun:
             "transitions": base / "transitions.parquet",
             "demand_groups": base / "demand_groups.parquet",
         }
+
+    def remove(self):
+        self.removed_runs.append((self.scenario, self.parameters.run.seed, self.is_weekday))
 
 
 class _FakeSurveyPlanAssets:
@@ -38,14 +56,27 @@ class _FakeSurvey:
         self.inputs = {"parameters": SimpleNamespace(country=country)}
 
 
+def _patch_group_day_trips_wrapper(monkeypatch):
+    """Replace heavy grouped day-trip dependencies with small test doubles."""
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
+    monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
+    monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
+
+
 def _make_population(*countries: str):
     rows = [{"local_admin_unit_id": f"{country}001"} for country in countries]
     study_area = SimpleNamespace(get=lambda: pd.DataFrame(rows))
-    transport_zones = SimpleNamespace(study_area=study_area)
+    transport_zones = SimpleNamespace(
+        study_area=study_area,
+        get_study_area_countries=lambda: sorted(countries),
+    )
     return SimpleNamespace(transport_zones=transport_zones)
 
 
-def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
+def test_group_day_trips_wrapper_uses_explicit_nested_parameters(monkeypatch):
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
     monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
@@ -58,57 +89,72 @@ def test_group_day_trips_wrapper_forwards_new_parameters(monkeypatch):
         modes=[object()],
         activities=[object()],
         surveys=[_FakeSurvey("fr")],
-        n_iterations=4,
-        k_activity_sequences=5,
-        k_destination_sequences=6,
-        n_warmup_iterations=2,
-        max_inactive_age=3,
-        refresh_active_mode_alternatives=True,
-        transition_revision_probability=0.4,
-        transition_logit_scale=0.75,
-        use_destination_shadow_prices=True,
-        min_transition_utility_gain=0.1,
-        plan_probability_pruning_retained_share=0.995,
-        plan_probability_pruning_min_iteration=3,
-        use_rust_mode_sequence_search=True,
-        enable_transition_distance_model=True,
-        transition_distance_threshold=8.0,
-        transition_distance_friction=1.5,
-        plan_embedding_dimension_weights=[1.0, 2.0, 3.0],
-        behavior_change_phases=[
-            BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING),
-        ],
-        simulate_weekend=False,
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(
+                n_iterations=4,
+                n_replications=4,
+                seeds=[0, 1, 3, 4],
+            ),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=False),
+            behavior_change=GroupDayTripsBehaviorChangeParameters(
+                phases=[
+                    BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING),
+                ],
+            ),
+            activity_sequences=GroupDayTripsActivitySequenceParameters(k_activity_sequences=5),
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                k_destination_sequences=6,
+                refresh_active_mode_alternatives=True,
+            ),
+            mode_sequences=GroupDayTripsModeSequenceParameters(use_rust_mode_sequence_search=True),
+            plan_update=GroupDayTripsPlanUpdateParameters(
+                n_warmup_iterations=2,
+                max_inactive_age=3,
+                transition_revision_probability=0.4,
+                transition_logit_scale=0.75,
+                use_destination_shadow_prices=True,
+                min_transition_utility_gain=0.1,
+                plan_probability_pruning_retained_share=0.995,
+                plan_probability_pruning_min_iteration=3,
+                enable_transition_distance_model=True,
+                transition_distance_threshold=8.0,
+                transition_distance_friction=1.5,
+                plan_embedding_dimension_weights=[1.0, 2.0, 3.0],
+            ),
+        ),
     )
 
-    parameters = wrapper.weekday_run.parameters
+    weekday_run = wrapper.run("weekday", replication=2)
+    weekend_run = wrapper.run("weekend", replication=2)
+    parameters = weekday_run.parameters
 
-    assert parameters.n_iterations == 4
-    assert parameters.k_activity_sequences == 5
-    assert parameters.k_destination_sequences == 6
-    assert parameters.n_warmup_iterations == 2
-    assert parameters.max_inactive_age == 3
-    assert parameters.refresh_active_mode_alternatives is True
-    assert parameters.transition_revision_probability == 0.4
-    assert parameters.transition_logit_scale == 0.75
-    assert parameters.use_destination_shadow_prices is True
-    assert parameters.min_transition_utility_gain == 0.1
-    assert parameters.plan_probability_pruning_retained_share == 0.995
-    assert parameters.plan_probability_pruning_min_iteration == 3
-    assert parameters.use_rust_mode_sequence_search is True
-    assert parameters.enable_transition_distance_model is True
-    assert parameters.transition_distance_threshold == 8.0
-    assert parameters.transition_distance_friction == 1.5
-    assert parameters.plan_embedding_dimension_weights == [1.0, 2.0, 3.0]
-    assert parameters.behavior_change_phases == [
+    assert parameters.run.n_iterations == 4
+    assert parameters.activity_sequences.k_activity_sequences == 5
+    assert parameters.destination_sequences.k_destination_sequences == 6
+    assert parameters.plan_update.n_warmup_iterations == 2
+    assert parameters.plan_update.max_inactive_age == 3
+    assert parameters.destination_sequences.refresh_active_mode_alternatives is True
+    assert parameters.plan_update.transition_revision_probability == 0.4
+    assert parameters.plan_update.transition_logit_scale == 0.75
+    assert parameters.plan_update.use_destination_shadow_prices is True
+    assert parameters.plan_update.min_transition_utility_gain == 0.1
+    assert parameters.plan_update.plan_probability_pruning_retained_share == 0.995
+    assert parameters.plan_update.plan_probability_pruning_min_iteration == 3
+    assert parameters.run.n_replications == 1
+    assert parameters.run.seeds is None
+    assert parameters.mode_sequences.use_rust_mode_sequence_search is True
+    assert parameters.plan_update.enable_transition_distance_model is True
+    assert parameters.plan_update.transition_distance_threshold == 8.0
+    assert parameters.plan_update.transition_distance_friction == 1.5
+    assert parameters.plan_update.plan_embedding_dimension_weights == [1.0, 2.0, 3.0]
+    assert parameters.behavior_change.phases == [
         BehaviorChangePhase(start_iteration=2, scope=BehaviorChangeScope.MODE_REPLANNING)
     ]
-    assert wrapper.weekday_run.survey_plan_assets is wrapper.weekend_run.survey_plan_assets
-    assert wrapper.survey_plan_assets is wrapper.weekday_run.survey_plan_assets
-    assert wrapper.survey_plan_assets.surveys == wrapper.weekday_run.survey_plan_assets.surveys
-    assert wrapper.weekend_run.enabled is False
-    assert "weekday_iteration_metrics" not in wrapper.cache_path
-    assert "weekend_iteration_metrics" not in wrapper.cache_path
+    assert [survey.inputs["parameters"].country for survey in weekday_run.survey_plan_assets.surveys] == ["fr"]
+    assert [survey.inputs["parameters"].country for survey in weekend_run.survey_plan_assets.surveys] == ["fr"]
+    assert weekend_run.enabled is False
+    assert "iteration_metrics" not in weekday_run.cache_path
+    assert "iteration_metrics" not in weekend_run.cache_path
 
 
 def test_group_day_trips_wrapper_raises_when_population_country_has_no_matching_survey(monkeypatch):
@@ -147,7 +193,8 @@ def test_group_day_trips_wrapper_warns_when_some_surveys_will_not_be_used(monkey
 
     assert len(caught) == 1
     assert "will not be used" in str(caught[0].message)
-    assert [survey.inputs["parameters"].country for survey in wrapper.survey_plan_assets.surveys] == ["fr"]
+    weekday_run = wrapper.run("weekday")
+    assert [survey.inputs["parameters"].country for survey in weekday_run.survey_plan_assets.surveys] == ["fr"]
 
 
 def test_group_day_trips_wrapper_exposes_iteration_metrics_when_child_runs_provide_them(monkeypatch):
@@ -168,8 +215,231 @@ def test_group_day_trips_wrapper_exposes_iteration_metrics_when_child_runs_provi
         modes=[object()],
         activities=[object()],
         surveys=[_FakeSurvey("fr")],
-        simulate_weekend=True,
+        parameters=GroupDayTripsParameters(
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=True),
+        ),
     )
 
-    assert "weekday_iteration_metrics" in wrapper.cache_path
-    assert "weekend_iteration_metrics" in wrapper.cache_path
+    weekday_run = wrapper.run("weekday")
+    weekend_run = wrapper.run("weekend")
+
+    assert "iteration_metrics" in weekday_run.cache_path
+    assert "iteration_metrics" in weekend_run.cache_path
+
+
+def test_parameters_seed_for_replication_uses_default_run_index_seeds():
+    parameters = GroupDayTripsRunParameters(n_replications=3)
+
+    assert parameters.seed_for_replication(0) == 0
+    assert parameters.seed_for_replication(1) == 1
+    assert parameters.seed_for_replication(2) == 2
+
+
+def test_parameters_seed_for_replication_uses_explicit_seeds():
+    parameters = GroupDayTripsRunParameters(n_replications=4, seeds=[0, 1, 3, 4])
+
+    assert parameters.seed_for_replication(0) == 0
+    assert parameters.seed_for_replication(2) == 3
+    assert parameters.seed_for_replication(3) == 4
+
+
+def test_parameters_for_replication_returns_single_replication_parameters():
+    parameters = GroupDayTripsRunParameters(n_replications=4, seeds=[0, 1, 3, 4])
+
+    replication_parameters = parameters.with_replication(2)
+
+    assert replication_parameters.seed == 3
+    assert replication_parameters.n_replications == 1
+    assert replication_parameters.seeds is None
+
+
+def test_parameters_raise_when_replication_seed_count_does_not_match():
+    with pytest.raises(ValueError, match="one seed per replication"):
+        GroupDayTripsRunParameters(n_replications=2, seeds=[0])
+
+
+def test_scenarios_manifest_adds_default_and_checks_names():
+    scenarios = Scenarios([
+        Scenario(
+            name="saleve_jura",
+            title="Saleve-Jura RER",
+            description="Adds the Saleve-Jura RER service.",
+            reference="default",
+        )
+    ])
+
+    assert scenarios.names == ["default", "saleve_jura"]
+    assert scenarios.get("saleve_jura").display_title == "Saleve-Jura RER"
+
+    with pytest.raises(ValueError, match="duplicate names"):
+        Scenarios([Scenario(name="project"), Scenario(name="project")])
+
+    with pytest.raises(TypeError, match="list of Scenario"):
+        Scenarios(Scenario(name="project"))
+
+    with pytest.raises(ValueError, match="Missing references"):
+        Scenarios([Scenario(name="project", reference="missing")])
+
+
+def test_group_day_trips_documents_scenarios_and_changes(monkeypatch):
+    _patch_group_day_trips_wrapper(monkeypatch)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        wrapper = PopulationGroupDayTrips(
+            population=_make_population("fr"),
+            modes=[
+                ParameterValue.by_scenario_and_iteration(
+                    default="base",
+                    saleve_jura={
+                        1: "base",
+                        5: "project",
+                    },
+                )
+            ],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr")],
+            parameters=GroupDayTripsParameters(
+                run=GroupDayTripsRunParameters(n_iterations=4),
+            ),
+            scenarios=Scenarios([
+                Scenario(
+                    name="saleve_jura",
+                    title="Saleve-Jura RER",
+                    description="Adds the Saleve-Jura RER service from iteration 5.",
+                    reference="default",
+                )
+            ]),
+        )
+
+    assert wrapper.scenarios.names == ["default", "saleve_jura"]
+    assert wrapper.scenarios.changes[0].path == "setup['modes'][0]"
+    assert "Scenario 'saleve_jura' changes setup['modes'][0] at iterations [5]" in str(
+        caught[0].message
+    )
+
+    description = wrapper.scenarios.describe()
+
+    assert "saleve_jura" in description
+    assert "Title: Saleve-Jura RER" in description
+    assert "Reference: default" in description
+    assert "- setup['modes'][0]: iterations 1, 5" in description
+
+
+def test_group_day_trips_rejects_undeclared_parameter_scenario(monkeypatch):
+    _patch_group_day_trips_wrapper(monkeypatch)
+
+    with pytest.raises(ValueError, match="pass it as `scenarios=`"):
+        PopulationGroupDayTrips(
+            population=_make_population("fr"),
+            modes=[ParameterValue.by_scenario(default="base", saleve_jura="project")],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr")],
+        )
+
+    with pytest.raises(ValueError, match="Missing declarations: \\['saleve_jura'\\]"):
+        PopulationGroupDayTrips(
+            population=_make_population("fr"),
+            modes=[ParameterValue.by_scenario(default="base", saleve_jura="project")],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr")],
+            scenarios=Scenarios([Scenario(name="default")]),
+        )
+
+
+def test_group_day_trips_warns_when_declared_scenario_changes_nothing(monkeypatch):
+    _patch_group_day_trips_wrapper(monkeypatch)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        PopulationGroupDayTrips(
+            population=_make_population("fr"),
+            modes=[object()],
+            activities=[object()],
+            surveys=[_FakeSurvey("fr")],
+            scenarios=Scenarios([Scenario(name="unused_project")]),
+        )
+
+    assert "do not change any ParameterValue" in str(caught[0].message)
+    assert "unused_project" in str(caught[0].message)
+
+
+def test_group_day_trips_rejects_unknown_requested_scenario(monkeypatch):
+    _patch_group_day_trips_wrapper(monkeypatch)
+    wrapper = PopulationGroupDayTrips(
+        population=_make_population("fr"),
+        modes=[object()],
+        activities=[object()],
+        surveys=[_FakeSurvey("fr")],
+    )
+
+    with pytest.raises(ValueError, match="Missing scenarios: \\['typo'\\]"):
+        wrapper.run("weekday", scenario="typo")
+
+
+def test_group_day_trips_run_can_select_scenario_and_replication(monkeypatch):
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
+    monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
+    monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
+
+    wrapper = PopulationGroupDayTrips(
+        population=_make_population("fr"),
+        modes=[ParameterValue.by_scenario(baseline="base", saleve_jura="project")],
+        activities=[object()],
+        surveys=[_FakeSurvey("fr")],
+        scenarios=Scenarios([
+            Scenario(name="baseline"),
+            Scenario(name="saleve_jura"),
+        ]),
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(n_replications=4, seeds=[0, 1, 3, 4]),
+        ),
+    )
+
+    default_run = wrapper.run("weekday", replication=2)
+
+    weekday_run = wrapper.run("weekday", scenario="saleve_jura", replication=2)
+
+    assert default_run.scenario == DEFAULT_SCENARIO
+    assert weekday_run.parameters.run.seed == 3
+    assert weekday_run.parameters.run.n_replications == 1
+    assert weekday_run.parameters.run.seeds is None
+    assert weekday_run.scenario == "saleve_jura"
+
+
+def test_group_day_trips_remove_clears_all_known_scenario_replications(monkeypatch):
+    _FakeRun.removed_runs = []
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_modes", lambda self, modes: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_activities", lambda self, activities: None)
+    monkeypatch.setattr(PopulationGroupDayTrips, "_validate_surveys", lambda self, surveys: None)
+    monkeypatch.setattr(group_day_trips_module, "Run", _FakeRun)
+    monkeypatch.setattr(group_day_trips_module, "TransportCosts", lambda modes: SimpleNamespace(modes=modes))
+    monkeypatch.setattr(group_day_trips_module, "SurveyPlanAssets", _FakeSurveyPlanAssets)
+
+    wrapper = PopulationGroupDayTrips(
+        population=_make_population("fr"),
+        modes=[ParameterValue.by_scenario(default="base", saleve_jura="project")],
+        activities=[object()],
+        surveys=[_FakeSurvey("fr")],
+        scenarios=Scenarios([Scenario(name="saleve_jura")]),
+        parameters=GroupDayTripsParameters(
+            run=GroupDayTripsRunParameters(n_replications=2, seeds=[0, 10]),
+            periods=GroupDayTripsPeriodParameters(simulate_weekend=True),
+        ),
+    )
+
+    wrapper.remove()
+
+    assert set(_FakeRun.removed_runs) == {
+        ("default", 0, True),
+        ("default", 0, False),
+        ("default", 10, True),
+        ("default", 10, False),
+        ("saleve_jura", 0, True),
+        ("saleve_jura", 0, False),
+        ("saleve_jura", 10, True),
+        ("saleve_jura", 10, False),
+    }

--- a/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
+++ b/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
@@ -9,7 +9,8 @@ from mobility.trips.group_day_trips.core.diagnostics import RunDiagnostics
 from mobility.trips.group_day_trips.core.parameters import (
     BehaviorChangePhase,
     BehaviorChangeScope,
-    Parameters,
+    GroupDayTripsBehaviorChangeParameters,
+    GroupDayTripsParameters,
 )
 from mobility.trips.group_day_trips.core.metrics import RunMetrics
 from mobility.trips.group_day_trips.core.results import RunResults
@@ -303,7 +304,7 @@ def test_travel_costs_plot_uses_report_style_and_mode_colors(monkeypatch, tmp_pa
         return FakeFigure()
 
     results = SimpleNamespace(
-        parameters=SimpleNamespace(n_iterations=3),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=3)),
         run=SimpleNamespace(transport_costs=FakeTransportCosts()),
         transport_zones=SimpleNamespace(get=lambda: pd.DataFrame()),
     )
@@ -708,7 +709,7 @@ def test_modal_share_evolution_by_iteration_returns_share_table(monkeypatch, tmp
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=2),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=2)),
         run=SimpleNamespace(
             inputs_hash="runhash",
             is_weekday=True,
@@ -767,7 +768,7 @@ def test_modal_share_evolution_by_iteration_groups_public_transport(monkeypatch,
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=1),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=1)),
         run=SimpleNamespace(
             inputs_hash="runhash",
             is_weekday=True,
@@ -832,7 +833,7 @@ def test_modal_share_evolution_by_iteration_can_use_inner_zones_only(monkeypatch
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=1),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=1)),
         run=SimpleNamespace(
             inputs_hash="runhash",
             is_weekday=True,
@@ -892,7 +893,7 @@ def test_modal_share_evolution_by_iteration_can_plot_and_save_svg(monkeypatch, t
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=1),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=1)),
         run=SimpleNamespace(
             inputs_hash="runhash",
             is_weekday=True,
@@ -996,7 +997,7 @@ def test_modal_share_delta_evolution_by_iteration_compares_two_scenarios(monkeyp
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=2),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=2)),
         run=current_run,
     )
 
@@ -1075,7 +1076,7 @@ def test_modal_share_delta_evolution_by_iteration_can_plot_and_save_svg(monkeypa
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=SimpleNamespace(n_iterations=1),
+        parameters=SimpleNamespace(run=SimpleNamespace(n_iterations=1)),
         run=current_run,
     )
     seen = {}
@@ -1291,13 +1292,15 @@ def test_modal_share_by_iteration_plots_one_scenario(monkeypatch, tmp_path):
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=Parameters(
-            behavior_change_phases=[
-                BehaviorChangePhase(
-                    start_iteration=2,
-                    scope=BehaviorChangeScope.MODE_REPLANNING,
-                )
-            ]
+        parameters=GroupDayTripsParameters(
+            behavior_change=GroupDayTripsBehaviorChangeParameters(
+                phases=[
+                    BehaviorChangePhase(
+                        start_iteration=2,
+                        scope=BehaviorChangeScope.MODE_REPLANNING,
+                    )
+                ]
+            )
         ),
         run=run,
     )
@@ -2516,13 +2519,15 @@ def test_modal_share_delta_gif_frame_adds_iteration_counter(monkeypatch, tmp_pat
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=Parameters(
-            behavior_change_phases=[
-                BehaviorChangePhase(
-                    start_iteration=5,
-                    scope=BehaviorChangeScope.MODE_REPLANNING,
-                )
-            ]
+        parameters=GroupDayTripsParameters(
+            behavior_change=GroupDayTripsBehaviorChangeParameters(
+                phases=[
+                    BehaviorChangePhase(
+                        start_iteration=5,
+                        scope=BehaviorChangeScope.MODE_REPLANNING,
+                    )
+                ]
+            )
         ),
         run=SimpleNamespace(population=None),
     )
@@ -2579,7 +2584,7 @@ def test_modal_share_delta_frame_can_plot_trip_count_delta(monkeypatch, tmp_path
         transitions=pl.DataFrame().lazy(),
         surveys=[],
         modes=[],
-        parameters=Parameters(),
+        parameters=GroupDayTripsParameters(),
         run=SimpleNamespace(population=None),
     )
     seen = {}
@@ -2736,8 +2741,17 @@ def test_metric_per_person_compare_with_and_plot_delta(tmp_path, monkeypatch):
         run=SimpleNamespace(),
     )
 
+    demand_groups_path = tmp_path / "demand_groups.parquet"
     weekday_plan_steps = tmp_path / "weekday_plan_steps.parquet"
     weekday_costs = tmp_path / "weekday_costs.parquet"
+    pl.DataFrame(
+        {
+            "home_zone_id": ["z1"],
+            "csp": ["A"],
+            "n_cars": ["1"],
+            "n_persons": [4.0],
+        }
+    ).write_parquet(demand_groups_path)
     pl.DataFrame(
         {
             "activity_seq_id": [1],
@@ -2764,6 +2778,8 @@ def test_metric_per_person_compare_with_and_plot_delta(tmp_path, monkeypatch):
 
     compare_with = SimpleNamespace(
         cache_path={
+            "demand_groups": demand_groups_path,
+            "plan_steps": weekday_plan_steps,
             "weekday_plan_steps": weekday_plan_steps,
             "weekday_costs": weekday_costs,
         },

--- a/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
+++ b/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 
 import polars as pl
 
-from mobility.trips.group_day_trips import Parameters
+from mobility.trips.group_day_trips import (
+    GroupDayTripsDestinationSequenceParameters,
+    GroupDayTripsParameters,
+    GroupDayTripsPlanUpdateParameters,
+)
 from mobility.trips.group_day_trips.plans.destination_sequences import DestinationSequences
 
 
@@ -65,7 +69,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(),
+        parameters=GroupDayTripsParameters(),
         seed=123,
     )
 
@@ -159,7 +163,11 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(refresh_active_mode_alternatives=True),
+        parameters=GroupDayTripsParameters(
+            destination_sequences=GroupDayTripsDestinationSequenceParameters(
+                refresh_active_mode_alternatives=True,
+            ),
+        ),
         seed=123,
         resolved_activity_parameters={},
     )
@@ -214,7 +222,7 @@ def test_refresh_active_mode_alternatives_default_keeps_sampled_destinations_onl
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(),
+        parameters=GroupDayTripsParameters(),
         seed=123,
         resolved_activity_parameters={},
     )
@@ -250,7 +258,7 @@ def test_destination_probability_inputs_use_cost_and_sink_even_without_destinati
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(),
+        parameters=GroupDayTripsParameters(),
         seed=123,
         resolved_activity_parameters={},
         current_plans=pl.DataFrame(),
@@ -302,7 +310,9 @@ def test_destination_probability_inputs_use_shadow_attraction_when_enabled(tmp_p
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(use_destination_shadow_prices=True),
+        parameters=GroupDayTripsParameters(
+            plan_update=GroupDayTripsPlanUpdateParameters(use_destination_shadow_prices=True),
+        ),
         seed=123,
         resolved_activity_parameters={},
         current_plans=pl.DataFrame(),
@@ -351,7 +361,7 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
         destination_saturation=pl.DataFrame(),
         demand_groups=pl.DataFrame(),
         costs=pl.DataFrame(),
-        parameters=Parameters(),
+        parameters=GroupDayTripsParameters(),
         seed=123,
         resolved_activity_parameters={},
         current_plans=pl.DataFrame(),

--- a/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
+++ b/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
@@ -53,7 +53,8 @@ def test_congested_graph_iteration_asset_resolves_latest_active_refresh(monkeypa
     run = SimpleNamespace(
         inputs_hash="run-key",
         is_weekday=True,
-        parameters=SimpleNamespace(n_iter_per_cost_update=2, n_iterations=3),
+        n_iter_per_cost_update=2,
+        n_iterations=3,
     )
 
     assert graph.get_flow_asset_for_iteration(run, 1) is None

--- a/tests/back/unit/test_901_quickstart_drift_guard.py
+++ b/tests/back/unit/test_901_quickstart_drift_guard.py
@@ -6,8 +6,9 @@ REQUIRED_SNIPPETS = [
     "mobility.EMPMobilitySurvey()",
     "mobility.Population(",
     "mobility.PopulationGroupDayTrips(",
-    'population_trips.get()["weekday_plan_steps"].collect()',
-    "population_trips.weekday_run.results().metrics.aggregate()",
+    'weekday_run = population_trips.run("weekday")',
+    'weekday_run.get()["plan_steps"].collect()',
+    "weekday_run.results().metrics.aggregate()",
 ]
 
 


### PR DESCRIPTION
### Motivation

This PR updates the grouped day-trip setup to use the new public scenario API added in https://github.com/mobility-team/mobility/pull/340.

It makes the run selection clearer for users. A modeller can now create one `PopulationGroupDayTrips` setup, then choose a day type, scenario, and stochastic replication when they ask for a run. It also replaces the old flat grouped day-trip parameters with smaller parameter sections, so settings are easier to find and explain.

### Changes

This PR changes the grouped day-trip public API:

- Adds `PopulationGroupDayTrips.run(day_type, scenario=..., replication=...)`.
- Uses `GroupDayTripsParameters` as the grouped day-trip parameter root.
- Splits grouped day-trip settings into smaller classes:
  - `GroupDayTripsRunParameters`
  - `GroupDayTripsPeriodParameters`
  - `GroupDayTripsOutputParameters`
  - `GroupDayTripsBehaviorChangeParameters`
  - `GroupDayTripsActivitySequenceParameters`
  - `GroupDayTripsDestinationSequenceParameters`
  - `GroupDayTripsModeSequenceParameters`
  - `GroupDayTripsPlanUpdateParameters`
- Adds stochastic replications with one seed per replication.
- Resolves scenario-varying activity and transport values inside the selected run.
- Validates requested scenarios through `Scenarios`.
- Moves survey-country selection into `mobility.surveys.select_surveys_for_population`.
- Keeps transport helpers independent from the nested grouped day-trip parameter shape by exposing run-level `n_iterations` and `n_iter_per_cost_update`.
- Updates quickstart docs and examples to use `population_trips.run(weekday)`.
- Renames parameter-value integration tests so they no longer refer to old profiles.

This is a breaking change for the old grouped day-trip constructor shortcuts such as `n_iterations=...` or `simulate_weekend=...`. Users now pass these through `GroupDayTripsParameters`.

### Example (if relevant)

```python
population_trips = mobility.PopulationGroupDayTrips(
    population=population,
    modes=[car_mode, walk_mode],
    activities=[
        mobility.HomeActivity(),
        mobility.WorkActivity(),
        mobility.OtherActivity(population=population),
    ],
    surveys=[survey],
    parameters=mobility.GroupDayTripsParameters(
        run=mobility.GroupDayTripsRunParameters(
            n_iterations=2,
            n_replications=3,
            seeds=[0, 10, 20],
        ),
        periods=mobility.GroupDayTripsPeriodParameters(
            simulate_weekend=False,
        ),
        mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
            mode_sequence_search_parallel=False,
        ),
    ),
)

weekday_run = population_trips.run(
    weekday,
    scenario=default,
    replication=1,
)

plan_steps = weekday_run.get()[plan_steps].collect()
metrics = weekday_run.results().metrics.aggregate()
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Helped split this change from a larger dirty branch, simplify the PR scope, update grouped day-trip API code, update tests, and update quickstart documentation.
- What you reviewed or changed: Reviewed the selected files, removed later results/comparison work from this PR, kept transport helpers separate from grouped day-trip parameter internals, and checked the new public parameter names and docs.
- How you validated it (tests, checks, manual verification): Ran compile checks, focused unit tests, changed integration tests, adjacent transport/congestion unit tests, and `git diff --check`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior