### PR TITLE
Add group day trip result tables API

### DIFF
--- a/mobility/trips/group_day_trips/__init__.py
+++ b/mobility/trips/group_day_trips/__init__.py
@@ -12,6 +12,7 @@ from .core.parameters import (
     GroupDayTripsRunParameters,
 )
 from .core.group_day_trips import PopulationGroupDayTrips
+from .results import GroupDayTripsResults
 
 __all__ = [
     "BehaviorChangePhase",
@@ -25,5 +26,6 @@ __all__ = [
     "GroupDayTripsPeriodParameters",
     "GroupDayTripsPlanUpdateParameters",
     "GroupDayTripsRunParameters",
+    "GroupDayTripsResults",
     "PopulationGroupDayTrips",
 ]

--- a/mobility/trips/group_day_trips/core/__init__.py
+++ b/mobility/trips/group_day_trips/core/__init__.py
@@ -1,4 +1,5 @@
 from .diagnostics import RunDiagnostics
+from ..results import GroupDayTripsResults
 from .parameters import (
     BehaviorChangePhase,
     BehaviorChangeScope,
@@ -31,6 +32,7 @@ __all__ = [
     "GroupDayTripsPeriodParameters",
     "GroupDayTripsPlanUpdateParameters",
     "GroupDayTripsRunParameters",
+    "GroupDayTripsResults",
     "PopulationGroupDayTrips",
     "RunDiagnostics",
     "RunMetrics",

--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -3,6 +3,7 @@ from enum import StrEnum
 from mobility.runtime.parameter_values import DEFAULT_SCENARIO
 from mobility.runtime.scenarios import Scenarios
 from mobility.transport.costs.transport_costs import TransportCosts
+from ..results import GroupDayTripsResults
 from .parameters import GroupDayTripsParameters
 from .run import Run
 from mobility.activities import Activity, HomeActivity, OtherActivity
@@ -139,6 +140,32 @@ class PopulationGroupDayTrips:
                 scenario=scenario,
             )
         return self._runs[key]
+
+    def results(
+        self,
+        day_type: str | DayType = DayType.WEEKDAY,
+        *,
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        replication: int | None = None,
+        replications: list[int] | range | None = None,
+    ) -> GroupDayTripsResults:
+        """Return result helpers for one day type, scenario set, and replication set.
+
+        Omitting `scenarios` selects the default scenario named `"default"`.
+        Omitting `replication` and `replications` selects all stochastic
+        replications declared in `parameters.run`.
+        """
+        day_type = DayType(day_type)
+        self.scenarios.validate_requested(Scenarios.selected_names(scenarios))
+        return GroupDayTripsResults(
+            run=self.run,
+            day_type=day_type.value,
+            scenarios=scenarios,
+            scenario_manifest=self.scenarios,
+            n_replications=self.parameters.run.n_replications,
+            replication=replication,
+            replications=replications,
+        )
 
     def remove(self):
         """Remove cached run outputs for this setup.

--- a/mobility/trips/group_day_trips/results/__init__.py
+++ b/mobility/trips/group_day_trips/results/__init__.py
@@ -1,0 +1,6 @@
+from .results import GroupDayTripsResults, ResultRun
+
+__all__ = [
+    "GroupDayTripsResults",
+    "ResultRun",
+]

--- a/mobility/trips/group_day_trips/results/assets/__init__.py
+++ b/mobility/trips/group_day_trips/results/assets/__init__.py
@@ -1,0 +1,5 @@
+from .scoped_tables import ScopedRunTable
+
+__all__ = [
+    "ScopedRunTable",
+]

--- a/mobility/trips/group_day_trips/results/assets/scoped_tables.py
+++ b/mobility/trips/group_day_trips/results/assets/scoped_tables.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.trips.group_day_trips.iterations import Iterations
+
+if TYPE_CHECKING:
+    from mobility.trips.group_day_trips.results import (
+        GroupDayTripsResults,
+        ResultRun,
+    )
+
+IterationSelector = str | int | list[int] | range
+
+
+class ScopedRunTable(FileAsset):
+    """Persist one run output table with scenario, day type, iteration, and replication."""
+
+    def __init__(
+        self,
+        *,
+        results: "GroupDayTripsResults",
+        table_name: str,
+        iterations: IterationSelector = "last",
+    ) -> None:
+        run_contexts = results.run_contexts
+        if not run_contexts:
+            raise ValueError("ScopedRunTable needs at least one run context.")
+
+        self.results = results
+        self.run_contexts = list(run_contexts)
+        self.table_name = table_name
+        self.iterations = results._validate_iterations(iterations)
+        self.selected_iterations = results.selected_iterations(iterations)
+        self.uses_last_iteration = self.iterations == "last"
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        if self.uses_last_iteration:
+            iteration_suffix = "last"
+        else:
+            iteration_suffix = "-".join(str(iteration) for iteration in self.selected_iterations)
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / f"{table_name}_{iteration_suffix}.parquet"
+        )
+        inputs = {
+            "version": 3,
+            "table_name": table_name,
+            "iterations": tuple(self.selected_iterations),
+            "uses_last_iteration": self.uses_last_iteration,
+            "runs": tuple(run_context.run for run_context in self.run_contexts),
+            "scope": tuple(
+                (
+                    run_context.scenario,
+                    run_context.day_type,
+                    run_context.replication,
+                )
+                for run_context in self.run_contexts
+            ),
+        }
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pl.LazyFrame:
+        """Return the cached scoped table as a lazy parquet scan."""
+        return pl.scan_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.LazyFrame:
+        """Build and cache the scoped table."""
+        if not self.uses_last_iteration:
+            return self._create_saved_iteration_asset()
+
+        scoped_tables: list[pl.LazyFrame] = []
+        for run_context in self.run_contexts:
+            run_context.run.get()
+            cached = run_context.run.get_cached_asset()
+            if self.table_name not in cached:
+                raise KeyError(
+                    f"Run output table `{self.table_name}` is not available. "
+                    f"Available tables: {sorted(cached)}."
+                )
+
+            table = cached[self.table_name]
+            if isinstance(table, pl.DataFrame):
+                table = table.lazy()
+            if self.table_name == "iteration_metrics":
+                table = table.filter(pl.col("iteration") == self.results.last_iteration)
+                iteration_expr = pl.col("iteration").cast(pl.Int32)
+            else:
+                iteration_expr = pl.lit(self.results.last_iteration, dtype=pl.Int32)
+            scoped_tables.append(
+                table.with_columns(
+                    scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                    day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                    iteration=iteration_expr,
+                    replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                )
+            )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        pl.concat(scoped_tables, how="vertical_relaxed").collect(engine="streaming").write_parquet(
+            self.cache_path
+        )
+        return self.get_cached_asset()
+
+    def _create_saved_iteration_asset(self) -> pl.LazyFrame:
+        """Build and cache a table for selected saved iterations."""
+        if self.table_name == "plan_steps":
+            scoped_tables = self._iteration_plan_steps()
+        elif self.table_name == "demand_groups":
+            scoped_tables = self._iteration_demand_groups()
+        elif self.table_name == "iteration_metrics":
+            scoped_tables = self._iteration_metrics()
+        else:
+            raise ValueError(
+                f'iterations={self.iterations!r} is not available for '
+                f"`{self.table_name}` yet. Saved iteration artifacts currently "
+                "support plan_steps, demand_groups, and iteration_metrics."
+            )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        pl.concat(scoped_tables, how="vertical_relaxed").collect(engine="streaming").write_parquet(
+            self.cache_path
+        )
+        return self.get_cached_asset()
+
+    def _iteration_plan_steps(self) -> list[pl.LazyFrame]:
+        """Return selected saved current plan steps with result scope columns."""
+        scoped_tables = []
+        for run_context in self.run_contexts:
+            run_context.run.get()
+            for iteration in self.selected_iterations:
+                current_plan_steps = self._iteration_table_for_run(
+                    run_context,
+                    table_name="plan_steps",
+                    iteration=iteration,
+                )
+                scoped_tables.append(
+                    current_plan_steps.with_columns(
+                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                        iteration=pl.lit(iteration, dtype=pl.Int32),
+                    )
+                )
+        return scoped_tables
+
+    def _iteration_table_for_run(
+        self,
+        run_context: "ResultRun",
+        *,
+        table_name: str,
+        iteration: int,
+    ) -> pl.LazyFrame:
+        """Return one saved iteration table for a run."""
+        run = run_context.run
+        if callable(getattr(run, "iteration_table", None)):
+            table = run.iteration_table(table_name, iteration)
+            if isinstance(table, pl.DataFrame):
+                return table.lazy()
+            return table
+
+        if table_name == "plan_steps":
+            return self._iterations_for_run(run_context).iteration(iteration).load_state().current_plan_steps.lazy()
+
+        raise ValueError(
+            f"Saved iteration table `{table_name}` is not available for this run."
+        )
+
+    def _iteration_demand_groups(self) -> list[pl.LazyFrame]:
+        """Return demand groups repeated for each selected iteration."""
+        scoped_tables = []
+        for run_context in self.run_contexts:
+            run_context.run.get()
+            cached = run_context.run.get_cached_asset()
+            if "demand_groups" not in cached:
+                raise KeyError("Run output table `demand_groups` is not available.")
+            table = cached["demand_groups"]
+            if isinstance(table, pl.DataFrame):
+                table = table.lazy()
+            for iteration in self.selected_iterations:
+                scoped_tables.append(
+                    table.with_columns(
+                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                        iteration=pl.lit(iteration, dtype=pl.Int32),
+                    )
+                )
+        return scoped_tables
+
+    def _iteration_metrics(self) -> list[pl.LazyFrame]:
+        """Return iteration diagnostics filtered to the selected iterations."""
+        scoped_tables = []
+        for run_context in self.run_contexts:
+            run_context.run.get()
+            cached = run_context.run.get_cached_asset()
+            if "iteration_metrics" not in cached:
+                raise KeyError("Run output table `iteration_metrics` is not available.")
+            table = cached["iteration_metrics"]
+            if isinstance(table, pl.DataFrame):
+                table = table.lazy()
+            scoped_tables.append(
+                table
+                .filter(pl.col("iteration").is_in(self.selected_iterations))
+                .with_columns(
+                    scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                    day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                    replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                    iteration=pl.col("iteration").cast(pl.Int32),
+                )
+            )
+        return scoped_tables
+
+    def _iterations_for_run(self, run_context: "ResultRun") -> Iterations:
+        """Return persisted iteration access for one run context."""
+        run = run_context.run
+        try:
+            base_folder = pathlib.Path(run.cache_path["plan_steps"]).parent
+            run_inputs_hash = run.inputs_hash
+            is_weekday = bool(run.is_weekday)
+        except (AttributeError, KeyError) as exc:
+            raise TypeError(
+                "Iteration-scoped results need runs with cache_path['plan_steps'], "
+                "inputs_hash, and is_weekday."
+            ) from exc
+        return Iterations(
+            run_inputs_hash=run_inputs_hash,
+            is_weekday=is_weekday,
+            base_folder=base_folder,
+        )

--- a/mobility/trips/group_day_trips/results/diagnostics.py
+++ b/mobility/trips/group_day_trips/results/diagnostics.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import polars as pl
+
+IterationSelector = str | int | list[int] | range
+
+
+class GroupDayTripsResultDiagnostics:
+    """Model diagnostics for one or more scenarios and replications."""
+
+    def __init__(self, results) -> None:
+        self.results = results
+
+    def iteration_metrics(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return the persisted per-iteration diagnostics table."""
+        return self.results.tables.iteration_metrics(iterations=iterations)

--- a/mobility/trips/group_day_trips/results/results.py
+++ b/mobility/trips/group_day_trips/results/results.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from mobility.runtime.parameter_values import DEFAULT_SCENARIO
+from mobility.runtime.scenarios import Scenarios
+
+from .diagnostics import GroupDayTripsResultDiagnostics
+from .tables import GroupDayTripsResultTables
+
+IterationSelector = str | int | list[int] | range
+
+
+@dataclass(frozen=True)
+class ResultRun:
+    """One concrete run included in a result set."""
+
+    run: object
+    scenario: str
+    day_type: str
+    replication: int
+
+
+class GroupDayTripsResults:
+    """Analysis entry point for one or more scenarios, one day type, and one or more runs."""
+
+    def __init__(
+        self,
+        *,
+        run: Callable,
+        day_type: str,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+        n_replications: int,
+        scenario_manifest: Scenarios | None = None,
+        replication: int | None = None,
+        replications: list[int] | range | None = None,
+    ) -> None:
+        """Store the selected result scope and expose analysis namespaces."""
+        if replication is not None and replications is not None:
+            raise ValueError("Use either `replication` or `replications`, not both.")
+
+        self._run = run
+        self.day_type = str(day_type)
+        self.scenarios = self._validate_scenarios(scenarios)
+        self.scenario_manifest = scenario_manifest
+        if self.scenario_manifest is not None:
+            self.scenario_manifest.validate_requested(self.scenarios)
+        self.n_replications = int(n_replications)
+        self.replications = self._validate_replications(
+            replication=replication,
+            replications=replications,
+        )
+        self._run_contexts: list[ResultRun] | None = None
+
+        self.tables = GroupDayTripsResultTables(self)
+        self.diagnostics = GroupDayTripsResultDiagnostics(self)
+
+    @property
+    def run_contexts(self) -> list[ResultRun]:
+        """Return the concrete runs included in this result set."""
+        if self._run_contexts is None:
+            self._run_contexts = [
+                ResultRun(
+                    run=self._run(
+                        self.day_type,
+                        scenario=scenario,
+                        replication=replication,
+                    ),
+                    scenario=scenario,
+                    day_type=self.day_type,
+                    replication=replication,
+                )
+                for scenario in self.scenarios
+                for replication in self.replications
+            ]
+        return self._run_contexts
+
+    @property
+    def first_run(self):
+        """Return the first concrete run in the result set."""
+        return self.run_contexts[0].run
+
+    def uses_last_iteration(self, iterations: IterationSelector = "last") -> bool:
+        """Return whether a result query uses normal final run outputs."""
+        return self._validate_iterations(iterations) == "last"
+
+    def selected_iterations(self, iterations: IterationSelector = "last") -> list[int]:
+        """Return concrete iteration numbers for one result query."""
+        parsed_iterations = self._validate_iterations(iterations)
+        if parsed_iterations == "last":
+            return [self.last_iteration]
+        if parsed_iterations == "all":
+            return list(range(1, self.last_iteration + 1))
+        return list(parsed_iterations)
+
+    @property
+    def last_iteration(self) -> int:
+        """Return the configured last model iteration."""
+        try:
+            return int(self.first_run.n_iterations)
+        except AttributeError as exc:
+            raise TypeError("Iteration-scoped results need runs with n_iterations.") from exc
+
+    def has_multiple_iterations(self, iterations: IterationSelector = "last") -> bool:
+        """Return whether one result query contains several iterations."""
+        return len(self.selected_iterations(iterations)) > 1
+
+    @property
+    def is_weekday(self) -> bool:
+        """Return whether this result scope is for weekday runs."""
+        return self.day_type == "weekday"
+
+    def _validate_replications(
+        self,
+        *,
+        replication: int | None,
+        replications: list[int] | range | None,
+    ) -> list[int]:
+        """Return a validated list of replication indices."""
+        if replication is not None:
+            replications = [replication]
+        if replications is None:
+            replications = range(self.n_replications)
+
+        selected_replications = [int(replication) for replication in replications]
+        invalid_replications = [
+            replication
+            for replication in selected_replications
+            if replication < 0 or replication >= self.n_replications
+        ]
+        if invalid_replications:
+            raise ValueError(
+                "GroupDayTripsResults.replications should contain replication "
+                "indices between 0 and n_replications - 1. "
+                f"Received {invalid_replications} with "
+                f"n_replications={self.n_replications}."
+            )
+        if not selected_replications:
+            raise ValueError("GroupDayTripsResults needs at least one replication.")
+        return selected_replications
+
+    def _validate_scenarios(
+        self,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+    ) -> list[str]:
+        """Return validated scenario names included in this result set."""
+        if scenarios is None:
+            selected_scenarios = [DEFAULT_SCENARIO]
+        elif isinstance(scenarios, str):
+            selected_scenarios = [scenarios]
+        elif isinstance(scenarios, (list, tuple)):
+            selected_scenarios = list(scenarios)
+        else:
+            raise TypeError(
+                "GroupDayTripsResults.scenarios should be None, one scenario name, "
+                "or a list of scenario names."
+            )
+
+        if not selected_scenarios:
+            raise ValueError("GroupDayTripsResults needs at least one scenario.")
+        if not all(isinstance(scenario, str) for scenario in selected_scenarios):
+            raise TypeError("GroupDayTripsResults.scenarios should only contain scenario names.")
+
+        duplicate_scenarios = sorted(
+            scenario
+            for scenario in set(selected_scenarios)
+            if selected_scenarios.count(scenario) > 1
+        )
+        if duplicate_scenarios:
+            raise ValueError(
+                "GroupDayTripsResults.scenarios should not contain duplicate names. "
+                f"Received duplicates: {duplicate_scenarios}."
+            )
+
+        return selected_scenarios
+
+    def _validate_iterations(
+        self,
+        iterations: IterationSelector,
+    ) -> str | list[int]:
+        """Return a validated iteration selector."""
+        if isinstance(iterations, str):
+            if iterations in {"last", "all"}:
+                return iterations
+            raise ValueError(
+                'iterations should be "last", "all", one iteration number, '
+                "or a list/range of iteration numbers."
+            )
+        if isinstance(iterations, int):
+            selected_iterations = [iterations]
+        elif isinstance(iterations, range):
+            selected_iterations = list(iterations)
+        elif isinstance(iterations, list):
+            selected_iterations = list(iterations)
+        else:
+            raise TypeError(
+                'iterations should be "last", "all", one iteration number, '
+                "or a list/range of iteration numbers."
+            )
+
+        if not selected_iterations:
+            raise ValueError("GroupDayTripsResults needs at least one iteration.")
+        if not all(isinstance(iteration, int) for iteration in selected_iterations):
+            raise TypeError("iterations should only contain integer iteration numbers.")
+        invalid_iterations = [
+            iteration
+            for iteration in selected_iterations
+            if iteration < 1
+        ]
+        if invalid_iterations:
+            raise ValueError(
+                "iterations should contain positive iteration numbers. "
+                f"Received {invalid_iterations}."
+            )
+        duplicate_iterations = sorted(
+            iteration
+            for iteration in set(selected_iterations)
+            if selected_iterations.count(iteration) > 1
+        )
+        if duplicate_iterations:
+            raise ValueError(
+                "iterations should not contain duplicate values. "
+                f"Received duplicates: {duplicate_iterations}."
+            )
+        return selected_iterations

--- a/mobility/trips/group_day_trips/results/tables.py
+++ b/mobility/trips/group_day_trips/results/tables.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import polars as pl
+
+from .assets.scoped_tables import ScopedRunTable
+
+IterationSelector = str | int | list[int] | range
+
+
+class GroupDayTripsResultTables:
+    """Raw result tables for one or more scenarios and replications."""
+
+    def __init__(self, results) -> None:
+        self.results = results
+
+    def plan_steps(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return final plan steps with scenario, day type, and replication columns."""
+        return self._table("plan_steps", iterations=iterations).get()
+
+    def demand_groups(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return demand groups with scenario, day type, and replication columns."""
+        return self._table("demand_groups", iterations=iterations).get()
+
+    def costs(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return final transport costs with scenario, day type, and replication columns."""
+        return self._table("costs", iterations=iterations).get()
+
+    def transitions(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return transition events with scenario, day type, and replication columns."""
+        return self._table("transitions", iterations=iterations).get()
+
+    def iteration_metrics(self, *, iterations: IterationSelector = "last") -> pl.LazyFrame:
+        """Return per-iteration diagnostics with scenario, day type, and replication columns."""
+        return self._table("iteration_metrics", iterations=iterations).get()
+
+    def _table(self, table_name: str, *, iterations: IterationSelector) -> ScopedRunTable:
+        """Build the cached scoped table asset for one run output."""
+        return ScopedRunTable(
+            results=self.results,
+            table_name=table_name,
+            iterations=iterations,
+        )

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from mobility.runtime import Scenarios
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.trips.group_day_trips.core.group_day_trips import PopulationGroupDayTrips
+from mobility.trips.group_day_trips.results import GroupDayTripsResults
+
+
+class _FakeRun(FileAsset):
+    """Small run asset that writes the tables needed by result table tests."""
+
+    def __init__(
+        self,
+        *,
+        base_folder: Path,
+        name: str,
+        plan_steps: pl.DataFrame,
+        demand_groups: pl.DataFrame,
+        iteration_metrics: pl.DataFrame,
+        iteration_plan_steps: dict[int, pl.DataFrame] | None = None,
+    ) -> None:
+        self.frames = {
+            "plan_steps": plan_steps,
+            "demand_groups": demand_groups,
+            "costs": pl.DataFrame({"from": ["z1"], "to": ["z2"], "cost": [1.0]}),
+            "opportunities": pl.DataFrame(),
+            "transitions": pl.DataFrame(),
+            "iteration_metrics": iteration_metrics,
+        }
+        self._iteration_plan_steps = iteration_plan_steps or {}
+        self.n_iterations = max(self._iteration_plan_steps, default=1)
+        self.population = SimpleNamespace(transport_zones=None)
+        cache_path = {
+            table_name: base_folder / name / f"{table_name}.parquet"
+            for table_name in self.frames
+        }
+        super().__init__({"version": 1, "name": name}, cache_path)
+
+    def get_cached_asset(self):
+        """Return lazy parquet readers for the fake run tables."""
+        return {
+            table_name: pl.scan_parquet(path)
+            for table_name, path in self.cache_path.items()
+        }
+
+    def create_and_get_asset(self):
+        """Write all fake run tables."""
+        for table_name, frame in self.frames.items():
+            path = self.cache_path[table_name]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            frame.write_parquet(path)
+        return self.get_cached_asset()
+
+    def iteration_table(self, table_name: str, iteration: int):
+        """Return one fake saved iteration table."""
+        if table_name != "plan_steps":
+            raise ValueError(f"Fake run has no saved iteration table `{table_name}`.")
+        return self._iteration_plan_steps[iteration].lazy()
+
+
+def _run_factory(base_folder: Path):
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        scenario = "default" if scenario is None else scenario
+        distance_shift = 3.0 if scenario == "test" else 0.0
+        plan_steps = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "activity_seq_id": [1, 1],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "distance": [
+                    10.0 + 10.0 * replication + distance_shift,
+                    5.0 + 2.0 * replication + distance_shift,
+                ],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        demand_groups = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        iteration_metrics = pl.DataFrame(
+            {
+                "iteration": [1, 2],
+                "model_loss": [0.5 + replication, 0.25 + replication],
+            }
+        )
+        iteration_plan_steps = {
+            1: plan_steps.with_columns(distance=pl.col("distance") * 0.5),
+            2: plan_steps,
+        }
+        return _FakeRun(
+            base_folder=base_folder,
+            name=f"{day_type}-{scenario}-{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            iteration_metrics=iteration_metrics,
+            iteration_plan_steps=iteration_plan_steps,
+        )
+
+    return run
+
+
+def test_population_group_day_trips_results_selects_all_replications(tmp_path, monkeypatch):
+    """Check that wrapper.results() selects all configured replications by default."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    wrapper = PopulationGroupDayTrips.__new__(PopulationGroupDayTrips)
+    wrapper.parameters = SimpleNamespace(run=SimpleNamespace(n_replications=2))
+    wrapper.scenarios = Scenarios()
+    wrapper.run = _run_factory(tmp_path)
+
+    results = wrapper.results("weekday")
+
+    assert [(context.scenario, context.replication) for context in results.run_contexts] == [
+        ("default", 0),
+        ("default", 1),
+    ]
+
+
+def test_results_rejects_invalid_scope(tmp_path, monkeypatch):
+    """Check scenario and replication validation at the public entry point."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    with pytest.raises(ValueError, match="at least one scenario"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios=[],
+            n_replications=1,
+        )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios=["a", "a"],
+            n_replications=1,
+        )
+
+    with pytest.raises(ValueError, match="n_replications=1"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios=None,
+            n_replications=1,
+            replication=1,
+        )
+
+
+def test_results_rejects_scenarios_missing_from_manifest(tmp_path, monkeypatch):
+    """Check that direct result objects still use the scenario manifest."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    with pytest.raises(ValueError, match="Missing scenarios"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios=["unknown"],
+            n_replications=1,
+            scenario_manifest=Scenarios(),
+        )
+
+
+def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
+    """Check raw tables include scenario, day type, iteration, and replication."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios="default",
+        n_replications=2,
+    )
+
+    table = results.tables.plan_steps().collect()
+
+    assert {
+        "scenario",
+        "day_type",
+        "iteration",
+        "replication",
+    }.issubset(set(table.columns))
+    assert table["scenario"].unique().to_list() == ["default"]
+    assert set(table["replication"].unique().to_list()) == {0, 1}
+    assert table["iteration"].unique().to_list() == [2]
+
+
+def test_result_tables_can_include_multiple_scenarios(tmp_path, monkeypatch):
+    """Check scenario selection fans out to all requested concrete runs."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios=["default", "test"],
+        n_replications=1,
+    )
+
+    table = results.tables.plan_steps().collect()
+
+    assert set(table["scenario"].unique().to_list()) == {"default", "test"}
+    assert table.filter(pl.col("scenario") == "test")["distance"].sum() > table.filter(
+        pl.col("scenario") == "default"
+    )["distance"].sum()
+
+
+def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
+    """Check saved iteration selection for plan steps, demand groups, and diagnostics."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios=None,
+        n_replications=1,
+    )
+
+    plan_steps = results.tables.plan_steps(iterations=[1, 2]).collect()
+    demand_groups = results.tables.demand_groups(iterations=[1, 2]).collect()
+    diagnostics = results.diagnostics.iteration_metrics(iterations=[1, 2]).collect()
+
+    assert set(plan_steps["iteration"].unique().to_list()) == {1, 2}
+    assert set(demand_groups["iteration"].unique().to_list()) == {1, 2}
+    assert diagnostics.select("iteration").to_series().to_list() == [1, 2]
+
+
+def test_result_tables_reject_unavailable_saved_iteration_table(tmp_path, monkeypatch):
+    """Check non-persisted tables fail clearly for saved iteration queries."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios=None,
+        n_replications=1,
+    )
+
+    with pytest.raises(ValueError, match="Saved iteration artifacts"):
+        results.tables.costs(iterations=[1]).collect()


### PR DESCRIPTION
﻿### Motivation

This PR is the next small split after https://github.com/mobility-team/mobility/pull/341.

Grouped day-trip runs now support scenarios and replications. We need a simple public entry point to read result tables across those scenarios and replications without manually calling each run and adding scope columns by hand.

This PR intentionally keeps the scope small. It adds the result object and raw scoped tables only. Metric calculations, plots, and transport-zone map helpers are moved to follow-up PRs.

### Changes

- Add `PopulationGroupDayTrips.results(...)`.
- Add `GroupDayTripsResults` to represent one day type, a set of scenarios, and a set of replications.
- Add raw result table helpers under `results.tables`.
- Add `ScopedRunTable`, which caches result tables with `scenario`, `day_type`, `iteration`, and `replication` columns.
- Support final result tables and selected saved iterations for persisted `plan_steps`, `demand_groups`, and `iteration_metrics`.
- Add a small diagnostics namespace for persisted iteration metrics.
- Add focused tests for scope validation, scenario validation, replication selection, final tables, and saved iteration tables.

### Example (if relevant)

```python
results = population_trips.results(
    "weekday",
    scenarios=["default", "project"],
    replications=[0, 1],
)

plan_steps = results.tables.plan_steps().collect()
iteration_metrics = results.diagnostics.iteration_metrics(iterations="all").collect()
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: helped split the original large result-analysis PR into a smaller table-focused PR.
- What you reviewed or changed: kept only the result scope, scoped table cache, diagnostics table access, and focused tests in this PR.
- How you validated it (tests, checks, manual verification): ran focused group-day-trip result API tests and public API forwarding tests, then reran the focused cross-stack test set after rebasing the stack.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
