### PR TITLE
Merge sparse transport zones during preparation

### DIFF
--- a/mobility/spatial/prepare_transport_zones.R
+++ b/mobility/spatial/prepare_transport_zones.R
@@ -24,6 +24,11 @@ study_area_fp <- args[2]
 osm_buildings_fp <- args[3]
 level_of_detail <- as.integer(args[4])
 output_fp <- args[5]
+min_buildings_per_zone <- as.integer(args[6])
+
+if (is.na(min_buildings_per_zone) || min_buildings_per_zone < 1L) {
+  stop("min_buildings_per_zone should be a positive integer.")
+}
 
 clusters_fp <- file.path(
   dirname(output_fp),
@@ -159,7 +164,186 @@ kmeans_with_nearest_building_centers <- function(buildings_dt, k, iter_max = 10L
 }
 
 
-clusters_to_voronoi <- function(lau_id, lau_geom, level_of_detail, buildings_area_threshold, n_buildings_sample, minimum_building_area) {
+union_geometries <- function(geometries) {
+
+  if (length(geometries) == 1) {
+    return(geometries)
+  }
+
+  return(geos_unary_union(geos_make_collection(geometries)))
+
+}
+
+
+find_merge_target_zone_id <- function(sparse_zone, zones) {
+
+  sparse_id <- sparse_zone$transport_zone_id
+  sparse_geometry <- sparse_zone$geometry
+  candidates <- zones[transport_zone_id != sparse_id]
+
+  if (nrow(candidates) == 0) {
+    return(NA_integer_)
+  }
+
+  shared_borders <- vapply(
+    seq_len(nrow(candidates)),
+    FUN = function(i) {
+      shared_border <- geos_intersection(
+        geos_boundary(sparse_geometry),
+        geos_boundary(candidates$geometry[i])
+      )
+      return(as.numeric(geos_length(shared_border)))
+    },
+    FUN.VALUE = numeric(1)
+  )
+
+  candidates <- copy(candidates[, list(transport_zone_id, building_count, geometry)])
+  candidates[, shared_border := shared_borders]
+  candidates[, distance := as.numeric(geos_distance(sparse_geometry, geometry))]
+
+  touching_candidates <- candidates[shared_border > 0]
+  if (nrow(touching_candidates) > 0) {
+    setorder(touching_candidates, -shared_border, -building_count, transport_zone_id)
+    return(touching_candidates$transport_zone_id[1])
+  }
+
+  setorder(candidates, distance, -building_count, transport_zone_id)
+  return(candidates$transport_zone_id[1])
+
+}
+
+
+merge_sparse_lau_zones <- function(transport_zones, buildings_dt, min_buildings_per_zone) {
+
+  min_buildings_per_zone <- as.integer(min_buildings_per_zone)
+  if (min_buildings_per_zone <= 1L || nrow(transport_zones) <= 1L) {
+    return(list(transport_zones = transport_zones, buildings_dt = buildings_dt))
+  }
+
+  buildings_dt <- copy(buildings_dt)
+  zones <- copy(transport_zones[, list(transport_zone_id, geometry)])
+
+  building_counts <- buildings_dt[, list(building_count = .N), by = cluster]
+  setnames(building_counts, "cluster", "transport_zone_id")
+  zones <- merge(zones, building_counts, by = "transport_zone_id", all.x = TRUE)
+  zones[is.na(building_count), building_count := 0L]
+
+  if (nrow(buildings_dt) < min_buildings_per_zone) {
+    buildings_dt[, cluster := 1L]
+    zones <- data.table(
+      transport_zone_id = 1L,
+      geometry = union_geometries(zones$geometry)
+    )
+    return(list(transport_zones = zones, buildings_dt = buildings_dt))
+  }
+
+  setorder(zones, transport_zone_id)
+  while (nrow(zones) > 1L) {
+    sparse_zones <- zones[building_count < min_buildings_per_zone]
+    if (nrow(sparse_zones) == 0L) {
+      break
+    }
+
+    setorder(sparse_zones, building_count, transport_zone_id)
+    sparse_zone <- sparse_zones[1]
+    sparse_id <- sparse_zone$transport_zone_id
+    target_id <- find_merge_target_zone_id(sparse_zone, zones)
+
+    if (is.na(target_id)) {
+      break
+    }
+
+    buildings_dt[cluster == sparse_id, cluster := target_id]
+
+    merge_ids <- c(sparse_id, target_id)
+    merged_geometry <- union_geometries(zones[transport_zone_id %in% merge_ids, geometry])
+    merged_count <- zones[transport_zone_id %in% merge_ids, sum(building_count)]
+
+    zones[transport_zone_id == target_id, geometry := merged_geometry]
+    zones[transport_zone_id == target_id, building_count := merged_count]
+    zones <- zones[transport_zone_id != sparse_id]
+    setorder(zones, transport_zone_id)
+  }
+
+  zone_id_map <- zones[, list(
+    transport_zone_id,
+    new_transport_zone_id = seq_len(.N)
+  )]
+
+  buildings_dt <- merge(
+    buildings_dt,
+    zone_id_map,
+    by.x = "cluster",
+    by.y = "transport_zone_id"
+  )
+  buildings_dt[, cluster := new_transport_zone_id]
+  buildings_dt[, new_transport_zone_id := NULL]
+
+  zones <- merge(zones, zone_id_map, by = "transport_zone_id")
+  zones[, transport_zone_id := new_transport_zone_id]
+  zones[, new_transport_zone_id := NULL]
+  zones[, building_count := NULL]
+  setorder(zones, transport_zone_id)
+
+  return(list(transport_zones = zones, buildings_dt = buildings_dt))
+
+}
+
+
+compute_cluster_center_attributes <- function(buildings_dt) {
+
+  centers <- buildings_dt[, {
+    coords <- as.matrix(.SD[, list(X, Y)])
+    weights <- area / sum(area)
+    center <- matrix(c(sum(X * weights), sum(Y * weights)), nrow = 1)
+    nearest <- get.knnx(data = coords, query = center, k = 1)$nn.index[1, 1]
+    list(
+      area = sum(area),
+      x = coords[nearest, 1],
+      y = coords[nearest, 2]
+    )
+  }, by = cluster]
+
+  centers[, weight := area / sum(area)]
+  setnames(centers, "cluster", "transport_zone_id")
+
+  return(centers[, list(transport_zone_id, weight, x, y)])
+
+}
+
+
+finalize_clustered_transport_zones <- function(transport_zones, buildings_dt) {
+
+  zone_attributes <- compute_cluster_center_attributes(buildings_dt)
+  internal_distances <- compute_cluster_internal_distance(buildings_dt)
+  setnames(internal_distances, "cluster", "transport_zone_id")
+
+  transport_zones <- merge(
+    transport_zones,
+    zone_attributes,
+    by = "transport_zone_id"
+  )
+  transport_zones <- merge(
+    transport_zones,
+    internal_distances,
+    by = "transport_zone_id"
+  )
+  transport_zones <- transport_zones[,
+    list(transport_zone_id, weight, internal_distance, x, y, geometry)
+  ]
+
+  k_medoids <- buildings_dt[
+    ,
+    compute_k_medoids(.SD),
+    by = list(transport_zone_id = cluster)
+  ]
+
+  return(list(transport_zones = transport_zones, k_medoids = k_medoids))
+
+}
+
+
+clusters_to_voronoi <- function(lau_id, lau_geom, level_of_detail, buildings_area_threshold, n_buildings_sample, minimum_building_area, min_buildings_per_zone) {
   
   # Get the coordinates and area of all buildings in the area
   # Keep only buildings with footprints larger than 20 m²
@@ -198,18 +382,9 @@ clusters_to_voronoi <- function(lau_id, lau_geom, level_of_detail, buildings_are
 
     buildings_dt[, cluster := kmeans_result$cluster]
     
-    cluster_area <- buildings_dt[, list(area = sum(area)), by = cluster]
-    clusters <- merge(clusters, cluster_area, by = "cluster")
-
     transport_zones <- clusters[, list(
-      transport_zone_id = cluster,
-      weight = area/sum(area),
-      x = X,
-      y = Y
+      transport_zone_id = cluster
     )]
-    
-    internal_distances <- compute_cluster_internal_distance(buildings_dt)
-    transport_zones <- merge(transport_zones, internal_distances, by.x  = "transport_zone_id", by.y = "cluster")
     
     # Create a voronoi tesselation around the cluster centers
     env <- geos_create_rectangle(
@@ -235,11 +410,24 @@ clusters_to_voronoi <- function(lau_id, lau_geom, level_of_detail, buildings_are
     )
 
     transport_zones[, geometry := voronoi[unlist(v_order)]]
-    
-    k_medoids <- buildings_dt[, compute_k_medoids(.SD), by = list(transport_zone_id = cluster)]
+
+    merge_result <- merge_sparse_lau_zones(
+      transport_zones = transport_zones,
+      buildings_dt = buildings_dt,
+      min_buildings_per_zone = min_buildings_per_zone
+    )
+    transport_zones <- merge_result$transport_zones
+    buildings_dt <- merge_result$buildings_dt
+
+    finalized <- finalize_clustered_transport_zones(
+      transport_zones = transport_zones,
+      buildings_dt = buildings_dt
+    )
+    transport_zones <- finalized$transport_zones
+    k_medoids <- finalized$k_medoids
 
 
-    
+
   } else {
     
     
@@ -294,7 +482,8 @@ transport_zones_buildings <- lapply(
       level_of_detail = level_of_detail,
       buildings_area_threshold = buildings_area_threshold,
       n_buildings_sample = n_buildings_sample,
-      minimum_building_area = min_building_area
+      minimum_building_area = min_building_area,
+      min_buildings_per_zone = min_buildings_per_zone
     )
     
     return(result)

--- a/mobility/spatial/prepare_transport_zones.py
+++ b/mobility/spatial/prepare_transport_zones.py
@@ -35,6 +35,8 @@ def prepare_transport_zones(
     osm_buildings_fp: str | pathlib.Path,
     level_of_detail: int,
     output_fp: str | pathlib.Path,
+    *,
+    min_buildings_per_zone: int,
     max_workers: int | None = None,
 ) -> None:
     """Create transport zones and building cluster files.
@@ -43,6 +45,10 @@ def prepare_transport_zones(
     clusters building centroids, snaps cluster centers to real buildings, builds
     Voronoi polygons, and clips them to each local admin unit.
     """
+    min_buildings_per_zone = int(min_buildings_per_zone)
+    if min_buildings_per_zone < 1:
+        raise ValueError("min_buildings_per_zone should be a positive integer.")
+
     output_fp = pathlib.Path(output_fp)
     clusters_fp, clusters_geoms_fp = _get_sidecar_paths(output_fp)
 
@@ -57,6 +63,7 @@ def prepare_transport_zones(
             study_area_row.geometry,
             pathlib.Path(osm_buildings_fp),
             level_of_detail,
+            min_buildings_per_zone,
         )
         for lau_position, study_area_row in enumerate(study_area.itertuples(index=False))
     ]
@@ -133,7 +140,14 @@ def _resolve_max_workers(task_count: int, max_workers: int | None) -> int:
 
 
 def _create_lau_transport_zones_worker(task: tuple) -> dict:
-    lau_position, lau_id, lau_geom, osm_buildings_fp, level_of_detail = task
+    (
+        lau_position,
+        lau_id,
+        lau_geom,
+        osm_buildings_fp,
+        level_of_detail,
+        min_buildings_per_zone,
+    ) = task
 
     rng = np.random.default_rng(_seed_for_lau(lau_id, lau_position))
     transport_zones, clusters = _create_lau_transport_zones(
@@ -141,6 +155,7 @@ def _create_lau_transport_zones_worker(task: tuple) -> dict:
         lau_geom=lau_geom,
         osm_buildings_fp=osm_buildings_fp,
         level_of_detail=level_of_detail,
+        min_buildings_per_zone=min_buildings_per_zone,
         rng=rng,
     )
     return {
@@ -184,6 +199,7 @@ def _create_lau_transport_zones(
     osm_buildings_fp: pathlib.Path,
     level_of_detail: int,
     rng: np.random.Generator,
+    min_buildings_per_zone: int,
 ) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
     buildings = _read_lau_buildings(osm_buildings_fp, lau_id)
     buildings = _prepare_building_centroids(buildings, lau_geom)
@@ -202,35 +218,30 @@ def _create_lau_transport_zones(
         buildings = buildings.copy()
         buildings["cluster"] = labels
 
-        cluster_area = buildings.groupby("cluster", as_index=False)["area"].sum()
-        medoids = medoids.merge(cluster_area, on="cluster", how="left")
-
-        transport_zones = medoids.rename(
-            columns={"cluster": "transport_zone_id", "X": "x", "Y": "y"}
+        transport_zones = medoids[["cluster"]].rename(
+            columns={"cluster": "transport_zone_id"}
         )
-        transport_zones["weight"] = transport_zones["area"] / transport_zones["area"].sum()
-        transport_zones = transport_zones.drop(columns=["area"])
-
-        internal_distances = _compute_cluster_internal_distance(buildings, rng)
-        transport_zones = transport_zones.merge(
-            internal_distances,
-            left_on="transport_zone_id",
-            right_on="cluster",
-            how="left",
-        ).drop(columns=["cluster"])
-
         transport_zones["geometry"] = _create_voronoi_geometries(
             medoids[["cluster", "X", "Y"]],
             lau_geom,
             buildings,
         )
-
-        k_medoids = buildings.groupby("cluster", group_keys=True).apply(
-            lambda group: _compute_k_medoids(group, _rng_integer(rng)),
-            include_groups=False,
+        transport_zones = gpd.GeoDataFrame(
+            transport_zones,
+            geometry="geometry",
+            crs=TARGET_CRS,
         )
-        k_medoids = k_medoids.reset_index(level=0).rename(
-            columns={"cluster": "transport_zone_id"}
+
+        transport_zones, buildings = _merge_sparse_lau_zones(
+            transport_zones=transport_zones,
+            buildings=buildings,
+            min_buildings_per_zone=min_buildings_per_zone,
+        )
+
+        transport_zones, k_medoids = _finalize_clustered_transport_zones(
+            transport_zones=transport_zones,
+            buildings=buildings,
+            rng=rng,
         )
     else:
         buildings = buildings.copy()
@@ -266,6 +277,175 @@ def _create_lau_transport_zones(
     ]
 
     return transport_zones, k_medoids
+
+
+def _finalize_clustered_transport_zones(
+    transport_zones: gpd.GeoDataFrame,
+    buildings: pd.DataFrame,
+    rng: np.random.Generator,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    """Recompute zone weights, medoids, and internal distances after merging."""
+    transport_zones = transport_zones[["transport_zone_id", "geometry"]].copy()
+
+    rows = []
+    for cluster, group in buildings.groupby("cluster", sort=True):
+        medoid_idx = _nearest_to_weighted_center(group)
+        medoid = group.iloc[medoid_idx]
+        rows.append(
+            {
+                "transport_zone_id": cluster,
+                "x": float(medoid["X"]),
+                "y": float(medoid["Y"]),
+                "area": float(group["area"].sum()),
+            }
+        )
+    medoids = pd.DataFrame(rows)
+    medoids["weight"] = medoids["area"] / medoids["area"].sum()
+    medoids = medoids.drop(columns=["area"])
+
+    internal_distances = _compute_cluster_internal_distance(buildings, rng).rename(
+        columns={"cluster": "transport_zone_id"}
+    )
+    transport_zones = transport_zones.merge(
+        medoids,
+        on="transport_zone_id",
+        how="left",
+        validate="one_to_one",
+    ).merge(
+        internal_distances,
+        on="transport_zone_id",
+        how="left",
+        validate="one_to_one",
+    )
+    transport_zones = transport_zones[
+        ["transport_zone_id", "weight", "internal_distance", "x", "y", "geometry"]
+    ]
+
+    k_medoids = buildings.groupby("cluster", group_keys=True).apply(
+        lambda group: _compute_k_medoids(group, _rng_integer(rng)),
+        include_groups=False,
+    )
+    k_medoids = k_medoids.reset_index(level=0).rename(
+        columns={"cluster": "transport_zone_id"}
+    )
+    return transport_zones, k_medoids
+
+
+def _merge_sparse_lau_zones(
+    transport_zones: gpd.GeoDataFrame,
+    buildings: pd.DataFrame,
+    min_buildings_per_zone: int,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    """Merge sparse zones inside one local admin unit.
+
+    The input already belongs to one LAU, so this helper cannot merge across
+    LAU boundaries. Sparse zones are merged into the neighboring zone with the
+    longest shared border.
+    """
+    min_buildings_per_zone = int(min_buildings_per_zone)
+    if min_buildings_per_zone <= 1 or len(transport_zones) <= 1:
+        return transport_zones, buildings
+
+    buildings = buildings.copy()
+    zones = transport_zones[["transport_zone_id", "geometry"]].copy()
+    zones["building_count"] = zones["transport_zone_id"].map(
+        buildings.groupby("cluster").size()
+    ).fillna(0).astype(int)
+
+    if len(buildings) < min_buildings_per_zone:
+        buildings["cluster"] = 1
+        merged_geometry = shapely.union_all(zones.geometry.to_numpy())
+        merged_zones = gpd.GeoDataFrame(
+            {"transport_zone_id": [1], "geometry": [merged_geometry]},
+            geometry="geometry",
+            crs=transport_zones.crs,
+        )
+        return merged_zones, buildings
+
+    zones = zones.sort_values("transport_zone_id").reset_index(drop=True)
+    while len(zones) > 1:
+        sparse_zones = zones.loc[zones["building_count"] < min_buildings_per_zone]
+        if sparse_zones.empty:
+            break
+
+        sparse_zone = sparse_zones.sort_values(
+            ["building_count", "transport_zone_id"]
+        ).iloc[0]
+        target_id = _find_merge_target_zone_id(sparse_zone, zones)
+        if target_id is None:
+            break
+
+        sparse_id = int(sparse_zone["transport_zone_id"])
+        buildings.loc[buildings["cluster"] == sparse_id, "cluster"] = target_id
+
+        sparse_mask = zones["transport_zone_id"] == sparse_id
+        target_mask = zones["transport_zone_id"] == target_id
+        merged_geometry = shapely.union_all(
+            zones.loc[sparse_mask | target_mask, "geometry"].to_numpy()
+        )
+        merged_count = int(zones.loc[sparse_mask | target_mask, "building_count"].sum())
+
+        zones.loc[target_mask, "geometry"] = [merged_geometry]
+        zones.loc[target_mask, "building_count"] = merged_count
+        zones = zones.loc[~sparse_mask].sort_values("transport_zone_id").reset_index(
+            drop=True
+        )
+
+    zone_id_map = {
+        old_id: new_id
+        for new_id, old_id in enumerate(zones["transport_zone_id"].to_list(), start=1)
+    }
+    buildings["cluster"] = buildings["cluster"].map(zone_id_map).astype(int)
+    zones["transport_zone_id"] = zones["transport_zone_id"].map(zone_id_map).astype(int)
+    zones = zones.drop(columns=["building_count"])
+
+    return gpd.GeoDataFrame(zones, geometry="geometry", crs=transport_zones.crs), buildings
+
+
+def _find_merge_target_zone_id(
+    sparse_zone: pd.Series,
+    zones: gpd.GeoDataFrame,
+) -> int | None:
+    """Return the best same-LAU merge target for one sparse zone."""
+    sparse_id = int(sparse_zone["transport_zone_id"])
+    sparse_geometry = sparse_zone["geometry"]
+
+    rows = []
+    for candidate in zones.itertuples(index=False):
+        candidate_id = int(candidate.transport_zone_id)
+        if candidate_id == sparse_id:
+            continue
+
+        shared_border = float(
+            sparse_geometry.boundary.intersection(candidate.geometry.boundary).length
+        )
+        distance = float(sparse_geometry.distance(candidate.geometry))
+        rows.append(
+            {
+                "transport_zone_id": candidate_id,
+                "building_count": int(candidate.building_count),
+                "shared_border": shared_border,
+                "distance": distance,
+            }
+        )
+
+    if not rows:
+        return None
+
+    candidates = pd.DataFrame(rows)
+    touching = candidates.loc[candidates["shared_border"] > 0]
+    if not touching.empty:
+        best = touching.sort_values(
+            ["shared_border", "building_count", "transport_zone_id"],
+            ascending=[False, False, True],
+        ).iloc[0]
+        return int(best["transport_zone_id"])
+
+    best = candidates.sort_values(
+        ["distance", "building_count", "transport_zone_id"],
+        ascending=[True, False, True],
+    ).iloc[0]
+    return int(best["transport_zone_id"])
 
 
 def _read_lau_buildings(osm_buildings_fp: pathlib.Path, lau_id: str) -> gpd.GeoDataFrame:

--- a/mobility/spatial/transport_zones.py
+++ b/mobility/spatial/transport_zones.py
@@ -68,6 +68,7 @@ class TransportZones(FileAsset):
             inner_local_admin_unit_id: List[str] | None = None,
             backend: Literal["r", "python"] | None = None,
             backend_workers: int | None = None,
+            min_buildings_per_zone: int | None = None,
             cutout_geometries: gpd.GeoDataFrame = None,
             parameters: "TransportZonesParameters" | None = None,
         ):
@@ -83,6 +84,7 @@ class TransportZones(FileAsset):
                 "inner_local_admin_unit_id": inner_local_admin_unit_id,
                 "backend": backend,
                 "backend_workers": backend_workers,
+                "min_buildings_per_zone": min_buildings_per_zone,
             },
             required_fields=["local_admin_unit_id"],
             owner_name="TransportZones",
@@ -203,7 +205,8 @@ class TransportZones(FileAsset):
                 str(study_area_fp),
                 str(osm_buildings_fp),
                 str(self.inputs["parameters"].level_of_detail),
-                str(self.cache_path)
+                str(self.cache_path),
+                str(self.inputs["parameters"].min_buildings_per_zone),
             ]
         )
 
@@ -214,6 +217,7 @@ class TransportZones(FileAsset):
             osm_buildings_fp=osm_buildings_fp,
             level_of_detail=self.inputs["parameters"].level_of_detail,
             output_fp=self.cache_path,
+            min_buildings_per_zone=self.inputs["parameters"].min_buildings_per_zone,
             max_workers=self.inputs["parameters"].backend_workers,
         )
     
@@ -338,6 +342,20 @@ class TransportZonesParameters(BaseModel):
                 "Number of workers used by the Python backend. If omitted, "
                 "the Python backend chooses a conservative default. This "
                 "setting is ignored by the R backend."
+            ),
+        ),
+    ]
+
+    min_buildings_per_zone: Annotated[
+        int,
+        Field(
+            default=20,
+            ge=1,
+            title="Minimum buildings per transport zone",
+            description=(
+                "Minimum number of valid buildings kept in each "
+                "transport zone. Sparse zones are merged inside their local "
+                "admin unit before final zone IDs are written."
             ),
         ),
     ]

--- a/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
+++ b/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
@@ -10,6 +10,7 @@ from shapely.geometry import box
 from mobility.spatial.prepare_transport_zones import (
     _create_lau_transport_zones,
     _get_sidecar_paths,
+    _merge_sparse_lau_zones,
     _resolve_max_workers,
     prepare_transport_zones,
 )
@@ -138,13 +139,21 @@ def test_init_builds_inputs_and_cache_path(project_dir, dependency_fakes):
 def test_python_backend_dispatches_to_python_preparation(dependency_fakes, monkeypatch, tmp_path):
     calls = []
 
-    def _prepare_transport_zones_spy(study_area_fp, osm_buildings_fp, level_of_detail, output_fp, max_workers):
+    def _prepare_transport_zones_spy(
+        study_area_fp,
+        osm_buildings_fp,
+        level_of_detail,
+        output_fp,
+        min_buildings_per_zone,
+        max_workers,
+    ):
         calls.append(
             {
                 "study_area_fp": pathlib.Path(study_area_fp),
                 "osm_buildings_fp": pathlib.Path(osm_buildings_fp),
                 "level_of_detail": level_of_detail,
                 "output_fp": pathlib.Path(output_fp),
+                "min_buildings_per_zone": min_buildings_per_zone,
                 "max_workers": max_workers,
             }
         )
@@ -164,6 +173,7 @@ def test_python_backend_dispatches_to_python_preparation(dependency_fakes, monke
         radius=30,
         backend="python",
         backend_workers=8,
+        min_buildings_per_zone=12,
     )
 
     transport_zones.create_transport_zones_with_python(
@@ -177,8 +187,55 @@ def test_python_backend_dispatches_to_python_preparation(dependency_fakes, monke
             "osm_buildings_fp": tmp_path / "osm_buildings",
             "level_of_detail": 1,
             "output_fp": transport_zones.cache_path,
+            "min_buildings_per_zone": 12,
             "max_workers": 8,
         }
+    ]
+
+
+def test_r_backend_passes_min_buildings_per_zone_to_script(
+    dependency_fakes,
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+
+    class _FakeRScriptRunner:
+        def __init__(self, script_path):
+            self.script_path = script_path
+
+        def run(self, args):
+            calls.append(
+                {
+                    "script_path": self.script_path,
+                    "args": list(args),
+                }
+            )
+
+    import mobility.spatial.transport_zones as tz_module
+
+    monkeypatch.setattr(tz_module, "RScriptRunner", _FakeRScriptRunner, raising=True)
+
+    transport_zones = TransportZones(
+        local_admin_unit_id="fr-09122",
+        level_of_detail=1,
+        radius=30,
+        backend="r",
+        min_buildings_per_zone=12,
+    )
+
+    transport_zones.create_transport_zones_with_r(
+        study_area_fp=tmp_path / "study_area_polygons.gpkg",
+        osm_buildings_fp=tmp_path / "osm_buildings",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["args"] == [
+        str(tmp_path / "study_area_polygons.gpkg"),
+        str(tmp_path / "osm_buildings"),
+        "1",
+        str(transport_zones.cache_path),
+        "12",
     ]
 
 
@@ -276,6 +333,78 @@ def test_resolve_max_workers_uses_task_count_as_upper_bound():
     assert _resolve_max_workers(task_count=3, max_workers=None) == 3
 
 
+def test_python_backend_rejects_invalid_min_buildings_per_zone(tmp_path):
+    with pytest.raises(ValueError, match="positive integer"):
+        prepare_transport_zones(
+            study_area_fp=tmp_path / "study_area.gpkg",
+            osm_buildings_fp=tmp_path / "osm_buildings",
+            level_of_detail=1,
+            output_fp=tmp_path / "transport_zones.gpkg",
+            min_buildings_per_zone=0,
+            max_workers=1,
+        )
+
+
+def test_python_backend_merges_sparse_zone_to_longest_shared_border():
+    zones = gpd.GeoDataFrame(
+        {"transport_zone_id": [1, 2, 3]},
+        geometry=[
+            box(0, 0, 1, 1),
+            box(1, 0, 2, 1),
+            box(0, 1, 0.5, 2),
+        ],
+        crs="EPSG:3035",
+    )
+    buildings = pd.DataFrame(
+        {
+            "cluster": [1] * 5 + [2] * 30 + [3] * 30,
+            "area": [100.0] * 65,
+            "X": np.arange(65, dtype=float),
+            "Y": np.zeros(65),
+            "building_id": np.arange(1, 66),
+        }
+    )
+
+    merged_zones, merged_buildings = _merge_sparse_lau_zones(
+        zones,
+        buildings,
+        min_buildings_per_zone=20,
+    )
+
+    building_counts = merged_buildings.groupby("cluster").size().sort_values().to_list()
+
+    assert len(merged_zones) == 2
+    assert merged_zones.crs == "EPSG:3035"
+    assert building_counts == [30, 35]
+    assert merged_zones.area.sort_values().to_list() == [0.5, 2.0]
+
+
+def test_python_backend_merges_whole_sparse_lau_to_one_zone():
+    zones = gpd.GeoDataFrame(
+        {"transport_zone_id": [1, 2]},
+        geometry=[box(0, 0, 1, 1), box(1, 0, 2, 1)],
+        crs="EPSG:3035",
+    )
+    buildings = pd.DataFrame(
+        {
+            "cluster": [1] * 5 + [2] * 6,
+            "area": [100.0] * 11,
+            "X": np.arange(11, dtype=float),
+            "Y": np.zeros(11),
+            "building_id": np.arange(1, 12),
+        }
+    )
+
+    merged_zones, merged_buildings = _merge_sparse_lau_zones(
+        zones,
+        buildings,
+        min_buildings_per_zone=20,
+    )
+
+    assert merged_zones["transport_zone_id"].to_list() == [1]
+    assert merged_buildings["cluster"].unique().tolist() == [1]
+
+
 def test_python_backend_builds_one_zone_when_lau_has_no_buildings(monkeypatch):
     monkeypatch.setattr(
         "mobility.spatial.prepare_transport_zones._read_lau_buildings",
@@ -288,6 +417,7 @@ def test_python_backend_builds_one_zone_when_lau_has_no_buildings(monkeypatch):
         osm_buildings_fp=pathlib.Path("unused"),
         level_of_detail=1,
         rng=np.random.default_rng(0),
+        min_buildings_per_zone=20,
     )
 
     assert zones["transport_zone_id"].to_list() == [1]
@@ -330,6 +460,7 @@ def test_python_backend_writes_transport_zones_and_building_sidecars(
         osm_buildings_fp=tmp_path / "osm_buildings",
         level_of_detail=1,
         output_fp=output_fp,
+        min_buildings_per_zone=1,
         max_workers=1,
     )
 


### PR DESCRIPTION
### Motivation
This PR avoids creating very small transport zones when a local admin unit is split from building footprints.

Some generated zones can contain only a few valid buildings. These sparse zones are fragile for later modelling steps because small counts can make indicators noisy and less useful. Merging them during transport-zone preparation gives users more stable zones while keeping merges inside the same local admin unit.

This PR builds on https://github.com/mobility-team/mobility/pull/343.

### Changes
This PR adds a new `TransportZones` parameter:

- `min_buildings_per_zone`

The default is `20`. When `level_of_detail=1`, sparse zones with fewer valid buildings are merged inside their local admin unit before final zone IDs are written.

The same parameter is passed to both transport-zone preparation backends:

- the reference R backend,
- the Python backend.

The merge rule is deterministic. The smallest sparse zone is merged first. It is merged into the neighbouring zone with the longest shared border. If no zone touches it, it is merged into the closest zone. Ties prefer the target with more buildings, then the lowest zone id.

After merging, the backends recompute final zone attributes:

- zone weights,
- center coordinates,
- internal distances,
- routing medoids.

This PR also keeps direct Python backend calls guarded by validating `min_buildings_per_zone >= 1`.

### Example (if relevant)
```python
transport_zones = mobility.TransportZones(
    local_admin_unit_id=fr-09122,
    level_of_detail=1,
    min_buildings_per_zone=20,
)
```

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: helped split this transport-zone preparation change from a larger branch and reviewed it for scope.
- What you reviewed or changed: removed unrelated study-area country helper work from this PR, removed wasted pre-merge metric work in the Python backend, and added direct validation for `min_buildings_per_zone`.
- How you validated it (tests, checks, manual verification): ran focused transport-zone unit tests, a Python compile check, and an R parse check.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior