### PR TITLE
Expose transport-zone study area countries

### DIFF
--- a/mobility/spatial/transport_zones.py
+++ b/mobility/spatial/transport_zones.py
@@ -279,6 +279,22 @@ class TransportZones(FileAsset):
             
         return transport_zones
 
+    def get_study_area_countries(self) -> list[str]:
+        """Return the country codes present in the study area."""
+        study_area = self.study_area.get()
+
+        if "country" in study_area.columns:
+            countries = study_area["country"]
+        elif "local_admin_unit_id" in study_area.columns:
+            countries = study_area["local_admin_unit_id"].dropna().astype(str).str.slice(0, 2)
+        else:
+            raise ValueError(
+                "TransportZones study area should contain a `country` or "
+                "`local_admin_unit_id` column."
+            )
+
+        return sorted(countries.dropna().astype(str).unique().tolist())
+
 
 class TransportZonesParameters(BaseModel):
 

--- a/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
+++ b/tests/back/unit/domain/transport_zones/test_041_init_builds_inputs_and_cache.py
@@ -318,6 +318,43 @@ def test_create_and_get_asset_dispatches_to_selected_python_backend(
     assert result["is_inner_zone"].to_list() == [True]
 
 
+def test_get_study_area_countries_uses_explicit_country_column(dependency_fakes, monkeypatch):
+    transport_zones = TransportZones(local_admin_unit_id="fr-09122")
+    monkeypatch.setattr(
+        transport_zones.study_area,
+        "get",
+        lambda: pd.DataFrame({"country": ["ch", "fr", "fr", None]}),
+        raising=False,
+    )
+
+    assert transport_zones.get_study_area_countries() == ["ch", "fr"]
+
+
+def test_get_study_area_countries_can_infer_from_local_admin_units(dependency_fakes, monkeypatch):
+    transport_zones = TransportZones(local_admin_unit_id="fr-09122")
+    monkeypatch.setattr(
+        transport_zones.study_area,
+        "get",
+        lambda: pd.DataFrame({"local_admin_unit_id": ["fr-09122", "ch-6621", None]}),
+        raising=False,
+    )
+
+    assert transport_zones.get_study_area_countries() == ["ch", "fr"]
+
+
+def test_get_study_area_countries_requires_country_information(dependency_fakes, monkeypatch):
+    transport_zones = TransportZones(local_admin_unit_id="fr-09122")
+    monkeypatch.setattr(
+        transport_zones.study_area,
+        "get",
+        lambda: pd.DataFrame({"name": ["Foix"]}),
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="country"):
+        transport_zones.get_study_area_countries()
+
+
 def test_sidecar_paths_use_transport_zone_output_stem(tmp_path):
     clusters_path, cluster_geometries_path = _get_sidecar_paths(
         tmp_path / "transport_zones.gpkg"


### PR DESCRIPTION
﻿### Motivation

This PR is the next small split after https://github.com/mobility-team/mobility/pull/344.

Group day trips need to select the surveys that match the countries present in the population. That country list comes from the population transport zones, but the code should not have to know how the transport-zone study area stores this information.

This PR adds a small public helper on `TransportZones` so later code can ask for the study-area countries directly.

### Changes

- Add `TransportZones.get_study_area_countries()`.
- Read countries from the study area `country` column when it exists.
- Keep a fallback for older or simpler study areas that only have `local_admin_unit_id`.
- Ignore missing values before building the country list.
- Return a sorted list of unique country codes.
- Raise a clear `ValueError` if the study area has neither `country` nor `local_admin_unit_id`.
- Add focused unit tests for the explicit country column, the fallback path, and the error path.

### Example (if relevant)

```python
countries = transport_zones.get_study_area_countries()
```

For a study area covering France and Switzerland, this returns:

```python
["ch", "fr"]
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: helped split this small transport-zone API change out of a larger worktree and add focused tests.
- What you reviewed or changed: reviewed the helper location, kept the legacy `local_admin_unit_id` fallback, and fixed null handling in that fallback.
- How you validated it (tests, checks, manual verification): ran the focused transport-zone unit tests, compiled the touched Python files, and checked the diff.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
