### PR TITLE
Use run parameters for iteration settings

### DIFF
--- a/mobility/transport/costs/path/path_travel_costs.py
+++ b/mobility/transport/costs/path/path_travel_costs.py
@@ -224,9 +224,10 @@ class PathTravelCosts(TravelCostsAsset):
         """Return the travel-cost asset instance corresponding to one simulation iteration."""
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.n_iterations):
+        n_iterations = int(run.parameters.run.n_iterations)
+        if iteration > n_iterations:
             raise ValueError(
-                f"Iteration should be <= {int(run.n_iterations)} for this run."
+                f"Iteration should be <= {n_iterations} for this run."
             )
 
         flow_asset = self.inputs["congested_path_graph"].get_flow_asset_for_iteration(run, iteration)

--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -176,9 +176,10 @@ class TransportCosts(FileAsset):
         """
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.n_iterations):
+        n_iterations = int(run.parameters.run.n_iterations)
+        if iteration > n_iterations:
             raise ValueError(
-                f"Iteration should be <= {int(run.n_iterations)} for this run."
+                f"Iteration should be <= {n_iterations} for this run."
             )
 
         asset = self.for_iteration(
@@ -190,7 +191,7 @@ class TransportCosts(FileAsset):
             run_key=run.inputs_hash,
             is_weekday=run.is_weekday,
             last_completed_iteration=iteration - 1,
-            cost_update_interval=run.n_iter_per_cost_update,
+            cost_update_interval=run.parameters.run.n_iter_per_cost_update,
         )
         logging.info(
             "TransportCosts asset_for_iteration: run_key=%s is_weekday=%s iteration=%s "
@@ -478,11 +479,11 @@ class TransportCosts(FileAsset):
         if self.has_enabled_congestion() is False:
             return
 
-        update_interval = run.n_iter_per_cost_update
+        update_interval = run.parameters.run.n_iter_per_cost_update
         if update_interval == 0:
             return
 
-        for completed_iteration in range(1, int(run.n_iterations) + 1):
+        for completed_iteration in range(1, int(run.parameters.run.n_iterations) + 1):
             if self.should_recompute_congested_costs(completed_iteration, update_interval) is False:
                 continue
 

--- a/mobility/transport/graphs/congested/congested_path_graph.py
+++ b/mobility/transport/graphs/congested/congested_path_graph.py
@@ -115,9 +115,10 @@ class CongestedPathGraph(FileAsset):
         """Return the graph instance corresponding to the congestion active at one iteration."""
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.n_iterations):
+        n_iterations = int(run.parameters.run.n_iterations)
+        if iteration > n_iterations:
             raise ValueError(
-                f"Iteration should be <= {int(run.n_iterations)} for this run."
+                f"Iteration should be <= {n_iterations} for this run."
             )
 
         flow_asset = self.get_flow_asset_for_iteration(run, iteration)
@@ -145,7 +146,7 @@ class CongestedPathGraph(FileAsset):
         if self.inputs["handles_congestion"] is False:
             return None
 
-        cost_update_interval = int(run.n_iter_per_cost_update)
+        cost_update_interval = int(run.parameters.run.n_iter_per_cost_update)
         if cost_update_interval <= 0 or iteration <= 1:
             return None
 

--- a/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
+++ b/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
@@ -147,9 +147,10 @@ class DetailedCarpoolTravelCosts(TravelCostsAsset):
     def asset_for_iteration(self, run, iteration: int):
         if iteration < 1:
             raise ValueError("Iteration should be >= 1.")
-        if iteration > int(run.n_iterations):
+        n_iterations = int(run.parameters.run.n_iterations)
+        if iteration > n_iterations:
             raise ValueError(
-                f"Iteration should be <= {int(run.n_iterations)} for this run."
+                f"Iteration should be <= {n_iterations} for this run."
             )
 
         flow_asset = self.inputs["car_travel_costs"].inputs["congested_path_graph"].get_flow_asset_for_iteration(

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -98,16 +98,6 @@ class Run(FileAsset):
         }
         super().__init__(inputs, cache_path)
 
-    @property
-    def n_iterations(self) -> int:
-        """Return the number of simulation iterations for this run."""
-        return self.parameters.run.n_iterations
-
-    @property
-    def n_iter_per_cost_update(self) -> int:
-        """Return how often this run refreshes travel costs."""
-        return self.parameters.run.n_iter_per_cost_update
-
     def create_and_get_asset(self) -> dict[str, pl.LazyFrame]:
         """Run the simulation for this day type and materialize cached outputs."""
         self._raise_if_disabled()
@@ -125,7 +115,7 @@ class Run(FileAsset):
             resume_from_iteration=resume_from_iteration,
         )
         self._log_state_memory_checkpoint("state:initialized", state)
-        for iteration_index in range(state.start_iteration, self.n_iterations + 1):
+        for iteration_index in range(state.start_iteration, self.parameters.run.n_iterations + 1):
             iteration = iterations.iteration(iteration_index)
             self._run_model_iteration(
                 state=state,
@@ -231,7 +221,7 @@ class Run(FileAsset):
             base_folder=self.cache_path["plan_steps"].parent,
         )
         if self.parameters.outputs.persist_iteration_artifacts:
-            resume_from_iteration = iterations.get_resume_iteration(self.n_iterations)
+            resume_from_iteration = iterations.get_resume_iteration(self.parameters.run.n_iterations)
             iterations.prepare(resume=(resume_from_iteration is not None))
         else:
             resume_from_iteration = None
@@ -520,7 +510,7 @@ class Run(FileAsset):
         state.costs = self.updater.get_new_costs(
             state.costs,
             iteration.iteration,
-            self.n_iter_per_cost_update,
+            self.parameters.run.n_iter_per_cost_update,
             state.current_plan_steps,
             self.transport_costs.for_iteration(iteration.iteration + 1),
             run=self,
@@ -549,7 +539,7 @@ class Run(FileAsset):
         """Compute the final OD costs to attach to the written outputs."""
         return self.transport_costs.asset_for_iteration(
             self,
-            self.n_iterations,
+            self.parameters.run.n_iterations,
         ).get_costs_by_od_and_mode(
             ["cost", "distance", "time", "ghg_emissions_per_trip"]
         )

--- a/mobility/trips/group_day_trips/results/results.py
+++ b/mobility/trips/group_day_trips/results/results.py
@@ -100,9 +100,11 @@ class GroupDayTripsResults:
     def last_iteration(self) -> int:
         """Return the configured last model iteration."""
         try:
-            return int(self.first_run.n_iterations)
+            return int(self.first_run.parameters.run.n_iterations)
         except AttributeError as exc:
-            raise TypeError("Iteration-scoped results need runs with n_iterations.") from exc
+            raise TypeError(
+                "Iteration-scoped results need runs with parameters.run.n_iterations."
+            ) from exc
 
     def has_multiple_iterations(self, iterations: IterationSelector = "last") -> bool:
         """Return whether one result query contains several iterations."""

--- a/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
+++ b/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
@@ -41,6 +41,34 @@ class _RemovableVariant:
         self.remove_calls += 1
 
 
+class _IterationTransportCosts:
+    def __init__(self):
+        self.load_calls = []
+        self.congestion_states = []
+
+    def load_congestion_state(
+        self,
+        *,
+        run_key,
+        is_weekday,
+        last_completed_iteration,
+        cost_update_interval,
+    ):
+        self.load_calls.append(
+            {
+                "run_key": run_key,
+                "is_weekday": is_weekday,
+                "last_completed_iteration": last_completed_iteration,
+                "cost_update_interval": cost_update_interval,
+            }
+        )
+        return SimpleNamespace(iteration=last_completed_iteration)
+
+    def asset_for_congestion_state(self, congestion_state):
+        self.congestion_states.append(congestion_state)
+        return self
+
+
 def _make_mode(*, name: str, congestion: bool, travel_costs=None):
     return SimpleNamespace(
         inputs={
@@ -160,4 +188,59 @@ def test_iter_run_congestion_artifacts_yields_existing_flow_assets_on_refresh_it
     assert congestion_state.run_key == "run-key"
     assert congestion_state.is_weekday is False
     assert flow_assets_by_mode["car"].cache_path == existing_path
+
+
+def test_asset_for_iteration_uses_run_parameters(project_dir, monkeypatch):
+    """Check one run iteration reads its bounds and cost interval from parameters.run."""
+    aggregator = TransportCosts(modes=[_make_mode(name="car", congestion=True)])
+    iteration_asset = _IterationTransportCosts()
+    requested_iterations = []
+
+    def fake_for_iteration(iteration: int, *, scenario=None):
+        requested_iterations.append((iteration, scenario))
+        return iteration_asset
+
+    monkeypatch.setattr(aggregator, "for_iteration", fake_for_iteration)
+    run = SimpleNamespace(
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=2,
+                n_iterations=3,
+            ),
+        ),
+        inputs_hash="run-key",
+        is_weekday=True,
+        scenario="baseline",
+    )
+
+    assert aggregator.asset_for_iteration(run, 3) is iteration_asset
+    assert requested_iterations == [(3, "baseline")]
+    assert iteration_asset.load_calls == [
+        {
+            "run_key": "run-key",
+            "is_weekday": True,
+            "last_completed_iteration": 2,
+            "cost_update_interval": 2,
+        }
+    ]
+    assert len(iteration_asset.congestion_states) == 1
+    assert iteration_asset.congestion_states[0].iteration == 2
+
+
+def test_asset_for_iteration_rejects_iteration_after_run_end(project_dir):
+    """Check the upper iteration bound comes from parameters.run."""
+    aggregator = TransportCosts(modes=[_make_mode(name="car", congestion=True)])
+    run = SimpleNamespace(
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=1,
+                n_iterations=2,
+            ),
+        ),
+        inputs_hash="run-key",
+        is_weekday=True,
+    )
+
+    with pytest.raises(ValueError, match="<= 2"):
+        aggregator.asset_for_iteration(run, 3)
 

--- a/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
+++ b/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
@@ -91,8 +91,12 @@ def test_iter_run_congestion_artifacts_returns_nothing_when_disabled(
 ):
     aggregator = TransportCosts(modes=modes)
     run = SimpleNamespace(
-        n_iter_per_cost_update=update_interval,
-        n_iterations=2,
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=update_interval,
+                n_iterations=2,
+            ),
+        ),
         inputs_hash="run-key",
         is_weekday=True,
     )
@@ -134,8 +138,12 @@ def test_iter_run_congestion_artifacts_yields_existing_flow_assets_on_refresh_it
     )
 
     run = SimpleNamespace(
-        n_iter_per_cost_update=2,
-        n_iterations=3,
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=2,
+                n_iterations=3,
+            ),
+        ),
         inputs_hash="run-key",
         is_weekday=False,
     )

--- a/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
+++ b/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
@@ -4,6 +4,9 @@ import pytest
 
 from mobility.transport.costs.path.path_travel_costs import PathTravelCosts
 from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.modes.carpool.detailed.detailed_carpool_travel_costs import (
+    DetailedCarpoolTravelCosts,
+)
 from mobility.transport.modes.public_transport.public_transport_travel_costs import (
     PublicTransportTravelCosts,
 )
@@ -147,4 +150,76 @@ def test_path_remove_congestion_artifacts_removes_owned_graph_chain():
     assert variant.remove_calls == 1
     assert contracted_graph.remove_calls == 1
     assert congested_graph.remove_calls == 1
+
+
+class _FlowByIteration:
+    def __init__(self, flow_asset=None):
+        self.flow_asset = flow_asset
+        self.calls = []
+
+    def get_flow_asset_for_iteration(self, run, iteration: int):
+        self.calls.append((run, iteration))
+        return self.flow_asset
+
+
+def _run_parameters(*, n_iterations: int):
+    return SimpleNamespace(
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(n_iterations=n_iterations)
+        )
+    )
+
+
+def test_path_asset_for_iteration_uses_run_parameters_for_bounds():
+    """Check path costs validate iterations from parameters.run."""
+    asset = _make_path_travel_costs()
+    asset.inputs["congested_path_graph"] = _FlowByIteration()
+
+    with pytest.raises(ValueError, match="<= 2"):
+        asset.asset_for_iteration(_run_parameters(n_iterations=2), 3)
+
+
+def test_path_asset_for_iteration_returns_flow_variant():
+    """Check path costs ask the congested graph for the active flow."""
+    flow_asset = object()
+    variant = object()
+    graph = _FlowByIteration(flow_asset)
+    asset = _make_path_travel_costs()
+    asset.inputs["congested_path_graph"] = graph
+    asset.asset_for_flow_asset = lambda flow: variant
+    run = _run_parameters(n_iterations=3)
+
+    assert asset.asset_for_iteration(run, 2) is variant
+    assert graph.calls == [(run, 2)]
+
+
+def test_carpool_asset_for_iteration_uses_run_parameters_for_bounds():
+    """Check carpool costs validate iterations from parameters.run."""
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.inputs = {
+        "car_travel_costs": SimpleNamespace(
+            inputs={"congested_path_graph": _FlowByIteration()}
+        )
+    }
+
+    with pytest.raises(ValueError, match="<= 1"):
+        asset.asset_for_iteration(_run_parameters(n_iterations=1), 2)
+
+
+def test_carpool_asset_for_iteration_returns_flow_variant():
+    """Check carpool costs reuse the car congestion flow for one iteration."""
+    flow_asset = object()
+    variant = object()
+    graph = _FlowByIteration(flow_asset)
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.inputs = {
+        "car_travel_costs": SimpleNamespace(
+            inputs={"congested_path_graph": graph}
+        )
+    }
+    asset.asset_for_flow_asset = lambda flow: variant
+    run = _run_parameters(n_iterations=3)
+
+    assert asset.asset_for_iteration(run, 2) is variant
+    assert graph.calls == [(run, 2)]
 

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -51,7 +51,6 @@ class _FakeRun(FileAsset):
         self.parameters = SimpleNamespace(
             run=SimpleNamespace(n_iterations=max(self._iteration_plan_steps, default=1))
         )
-        self.n_iterations = self.parameters.run.n_iterations
         self.population = SimpleNamespace(transport_zones=transport_zones)
         self.surveys = surveys or []
         cache_path = {

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -406,6 +406,13 @@ def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
     assert plan_steps["distance"].to_list() == pytest.approx([5.0, 2.5, 10.0, 5.0])
 
 
+def test_results_last_iteration_uses_run_parameters(tmp_path, monkeypatch):
+    """Check the last iteration comes from parameters.run."""
+    results = _results(tmp_path, replication=0)
+
+    assert results.last_iteration == 2
+
+
 def test_trip_count_metrics_keep_selected_iterations(tmp_path, monkeypatch):
     """Check that metric tables keep iteration when several iterations are selected."""
     results = _results(tmp_path, replication=0)

--- a/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
+++ b/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
@@ -53,8 +53,12 @@ def test_congested_graph_iteration_asset_resolves_latest_active_refresh(monkeypa
     run = SimpleNamespace(
         inputs_hash="run-key",
         is_weekday=True,
-        n_iter_per_cost_update=2,
-        n_iterations=3,
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=2,
+                n_iterations=3,
+            ),
+        ),
     )
 
     assert graph.get_flow_asset_for_iteration(run, 1) is None

--- a/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
+++ b/tests/back/unit/test_012_congested_path_graph_iteration_asset.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 from mobility.runtime.assets.in_memory_asset import InMemoryAsset
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
@@ -75,3 +76,29 @@ def test_congested_graph_iteration_asset_resolves_latest_active_refresh(monkeypa
     assert iter_graph.inputs["congestion_assignment_max_iterations"] == 3
     assert iter_graph.inputs["congestion_assignment_max_gap"] == 0.2
     assert iter_graph.inputs["congestion_assignment_retained_volume_share"] == 0.9
+
+
+def test_congested_graph_iteration_asset_rejects_iteration_after_run_end(
+    monkeypatch,
+    tmp_path,
+):
+    """Check the upper iteration bound comes from parameters.run."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    graph = CongestedPathGraph(
+        modified_graph=FakeUpstreamAsset(name="modified", mode_name="car"),
+        transport_zones=FakeUpstreamAsset(name="zones"),
+        handles_congestion=True,
+    )
+    run = SimpleNamespace(
+        inputs_hash="run-key",
+        is_weekday=True,
+        parameters=SimpleNamespace(
+            run=SimpleNamespace(
+                n_iter_per_cost_update=1,
+                n_iterations=2,
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="<= 2"):
+        graph.asset_for_iteration(run, 3)


### PR DESCRIPTION
﻿### Motivation

This PR is the next small split after https://github.com/mobility-team/mobility/pull/345.

Grouped day-trip run settings now live in `run.parameters.run`. Some transport-cost and result helpers still used shortcut attributes on `Run`, such as `run.n_iterations` and `run.n_iter_per_cost_update`.

Those shortcuts duplicate the public parameter API and make fake runs in tests different from real runs. This PR removes the shortcuts and makes all callers use the same nested run parameters.

### Changes

- Remove `Run.n_iterations`.
- Remove `Run.n_iter_per_cost_update`.
- Update `Run` internals to read `self.parameters.run.n_iterations` and `self.parameters.run.n_iter_per_cost_update` directly.
- Update transport-cost helpers to read iteration settings from `run.parameters.run`.
- Update congested path graph, path travel costs, and detailed carpool travel costs to use the same run parameter path.
- Update grouped day-trip results so `last_iteration` comes from `first_run.parameters.run.n_iterations`.
- Update test fake runs so they match the real public API and no longer expose the removed shortcut attributes.

### Example (if relevant)

Before this PR, some code read run settings like this:

```python
run.n_iterations
run.n_iter_per_cost_update
```

After this PR, code reads the public parameter object directly:

```python
run.parameters.run.n_iterations
run.parameters.run.n_iter_per_cost_update
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: helped split this API cleanup out of a larger worktree and update the focused callers and tests.
- What you reviewed or changed: reviewed all remaining shortcut-property usages, removed the duplicate `Run` properties, and updated test fakes to match the real run object shape.
- How you validated it (tests, checks, manual verification): ran focused unit tests for transport-cost cleanup, congested graph iteration assets, and grouped day-trip results; compiled the touched Python files; checked the diff for whitespace issues.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
