### PR TITLE
Add group day trip result metrics

### DIFF
--- a/mobility/trips/group_day_trips/results/assets/__init__.py
+++ b/mobility/trips/group_day_trips/results/assets/__init__.py
@@ -1,5 +1,16 @@
+from .final_state_metrics import Immobility, TripCountByDemandGroup
 from .scoped_tables import ScopedRunTable
+from .survey_diagnostics import SurveyReferenceComparison, SurveyReferenceMarginal
+from .survey_time_diagnostics import ActivityDurationDistribution, ActivityTimeSeries
+from .trip_metrics import TripCountMetric
 
 __all__ = [
+    "ActivityDurationDistribution",
+    "ActivityTimeSeries",
+    "Immobility",
     "ScopedRunTable",
+    "SurveyReferenceComparison",
+    "SurveyReferenceMarginal",
+    "TripCountMetric",
+    "TripCountByDemandGroup",
 ]

--- a/mobility/trips/group_day_trips/results/assets/final_state_metrics.py
+++ b/mobility/trips/group_day_trips/results/assets/final_state_metrics.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import polars as pl
+
+from mobility.runtime.assets.file_asset import FileAsset
+
+from .person_metrics import RESULT_COLUMNS, SCOPE_COLUMNS, add_demand_group_columns
+
+
+class TripCountByDemandGroup(FileAsset):
+    """Persist trip counts by demand group across selected replications."""
+
+    def __init__(self, *, plan_steps: FileAsset, demand_groups: FileAsset) -> None:
+        self.plan_steps = plan_steps
+        self.demand_groups = demand_groups
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / "trip_count_by_demand_group.parquet"
+        )
+        super().__init__(
+            {
+                "version": 2,
+                "plan_steps": plan_steps,
+                "demand_groups": demand_groups,
+            },
+            cache_path,
+        )
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached metric table."""
+        return pl.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the metric table."""
+        plan_steps = self.plan_steps.get()
+        demand_groups = self.demand_groups.get()
+        dimensions = _demand_group_dimensions(demand_groups)
+        plan_steps = add_demand_group_columns(plan_steps, demand_groups, dimensions)
+        group_columns = SCOPE_COLUMNS + dimensions
+
+        trip_count = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(group_columns)
+            .agg(n_trips=pl.col("n_persons").cast(pl.Float64).sum())
+        )
+        per_replication = (
+            demand_groups
+            .select(group_columns + ["n_persons"])
+            .join(trip_count, on=group_columns, how="left")
+            .with_columns(
+                n_trips=pl.col("n_trips").fill_null(0.0),
+                n_trips_per_person=pl.col("n_trips") / pl.col("n_persons").clip(1e-12),
+            )
+        )
+        output_columns = RESULT_COLUMNS + dimensions
+        metric = (
+            per_replication
+            .group_by(output_columns)
+            .agg(
+                pl.col("n_persons").mean().alias("n_persons"),
+                pl.col("n_trips").mean().alias("n_trips"),
+                pl.col("n_trips").std().alias("n_trips_std"),
+                pl.col("n_trips_per_person").mean().alias("n_trips_per_person"),
+                pl.col("n_trips_per_person").std().alias("n_trips_per_person_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        metric.write_parquet(self.cache_path)
+        return metric
+
+
+class Immobility(FileAsset):
+    """Persist immobility by country and socio-professional category."""
+
+    def __init__(
+        self,
+        *,
+        plan_steps: FileAsset,
+        demand_groups: FileAsset,
+        transport_zones: FileAsset,
+        survey_immobility: pl.DataFrame | None = None,
+    ) -> None:
+        self.plan_steps = plan_steps
+        self.demand_groups = demand_groups
+        self.transport_zones = transport_zones
+        self.survey_immobility = survey_immobility
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        cache_path = project_folder / "group_day_trips" / "results" / "immobility.parquet"
+        survey_immobility_rows = None
+        if survey_immobility is not None:
+            survey_immobility_rows = (
+                survey_immobility
+                .sort(["country", "csp"])
+                .to_dict(as_series=False)
+            )
+        super().__init__(
+            {
+                "version": 2,
+                "plan_steps": plan_steps,
+                "demand_groups": demand_groups,
+                "transport_zones": transport_zones,
+                "survey_immobility_rows": survey_immobility_rows,
+            },
+            cache_path,
+        )
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached metric table."""
+        return pl.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the immobility table."""
+        plan_steps = self.plan_steps.get()
+        demand_groups = self.demand_groups.get()
+        zones = _transport_zones_with_country(self.transport_zones)
+        demand_keys = _demand_group_dimensions(demand_groups)
+        plan_steps = add_demand_group_columns(plan_steps, demand_groups, demand_keys)
+        join_keys = SCOPE_COLUMNS + demand_keys
+        if "home_zone_id" in demand_keys:
+            plan_steps = plan_steps.with_columns(pl.col("home_zone_id").cast(pl.String))
+            demand_groups = demand_groups.with_columns(pl.col("home_zone_id").cast(pl.String))
+
+        immobile_population = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") == 0)
+            .group_by(join_keys)
+            .agg(n_persons_imm=pl.col("n_persons").cast(pl.Float64).sum())
+        )
+        per_replication = (
+            demand_groups
+            .select(join_keys + ["n_persons"])
+            .join(immobile_population, on=join_keys, how="left")
+            .with_columns(pl.col("n_persons_imm").fill_null(0.0))
+            .join(zones.lazy(), on="home_zone_id", how="inner")
+            .with_columns(csp=pl.col("csp").cast(pl.String))
+            .group_by(SCOPE_COLUMNS + ["country", "csp"])
+            .agg(
+                n_persons_imm=pl.col("n_persons_imm").sum(),
+                n_persons=pl.col("n_persons").sum(),
+            )
+            .with_columns(p_immobility=pl.col("n_persons_imm") / pl.col("n_persons").clip(1e-12))
+        )
+        output_columns = RESULT_COLUMNS + ["country", "csp"]
+        metric = (
+            per_replication
+            .group_by(output_columns)
+            .agg(
+                pl.col("n_persons_imm").mean().alias("n_persons_imm"),
+                pl.col("n_persons_imm").std().alias("n_persons_imm_std"),
+                pl.col("n_persons").mean().alias("n_persons"),
+                pl.col("p_immobility").mean().alias("p_immobility"),
+                pl.col("p_immobility").std().alias("p_immobility_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .collect(engine="streaming")
+            .sort(output_columns)
+        )
+        if self.survey_immobility is not None:
+            metric = (
+                metric
+                .join(self.survey_immobility, on=["country", "csp"], how="left")
+                .with_columns(
+                    reference_source=pl.lit("survey"),
+                    p_immobility_reference=pl.col("p_immobility_ref"),
+                    n_persons_imm_reference=pl.col("n_persons") * pl.col("p_immobility_ref"),
+                )
+                .with_columns(
+                    gap=pl.col("p_immobility") - pl.col("p_immobility_reference"),
+                    gap_std=pl.col("p_immobility_std"),
+                    relative_gap=(
+                        (pl.col("p_immobility") - pl.col("p_immobility_reference"))
+                        / pl.col("p_immobility_reference")
+                    ),
+                )
+                .drop("p_immobility_ref")
+            )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        metric.write_parquet(self.cache_path)
+        return metric
+
+
+def _demand_group_dimensions(demand_groups: pl.LazyFrame) -> list[str]:
+    """Return stable demand group dimensions present in the table."""
+    schema = demand_groups.collect_schema().names()
+    preferred_columns = ["home_zone_id", "csp", "n_cars"]
+    return [column for column in preferred_columns if column in schema]
+
+
+def _transport_zones_with_country(transport_zones: FileAsset) -> pl.DataFrame:
+    """Return inner transport zones with their country."""
+    zones = transport_zones.get()
+    if "geometry" in zones.columns:
+        zones = zones.drop(columns="geometry")
+    study_area = transport_zones.study_area.get()
+    if "geometry" in study_area.columns:
+        study_area = study_area.drop(columns="geometry")
+    return (
+        pl.from_pandas(zones)
+        .filter(pl.col("is_inner_zone"))
+        .join(
+            pl.from_pandas(study_area).select(["local_admin_unit_id", "country"]),
+            on="local_admin_unit_id",
+            how="left",
+        )
+        .select([
+            pl.col("transport_zone_id").cast(pl.String).alias("home_zone_id"),
+            pl.col("country").cast(pl.String),
+        ])
+    )

--- a/mobility/trips/group_day_trips/results/assets/person_metrics.py
+++ b/mobility/trips/group_day_trips/results/assets/person_metrics.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import polars as pl
+from mobility.trips.group_day_trips.evaluation.calibration_plan_steps import (
+    distance_bin_expr,
+    time_bin_expr,
+)
+
+
+RESULT_COLUMNS = ["scenario", "day_type", "iteration"]
+SCOPE_COLUMNS = RESULT_COLUMNS + ["replication"]
+DEMAND_GROUP_COLUMNS = ["home_zone_id", "csp", "n_cars"]
+
+
+def add_demand_group_columns(
+    plan_steps: pl.LazyFrame,
+    demand_groups: pl.LazyFrame,
+    columns: list[str],
+) -> pl.LazyFrame:
+    """Add demand-group columns, such as home zone, when plan steps only carry ids."""
+    plan_schema = plan_steps.collect_schema().names()
+    demand_schema = demand_groups.collect_schema().names()
+    missing_columns = [
+        column
+        for column in columns
+        if column not in plan_schema and column in demand_schema
+    ]
+    if not missing_columns:
+        return plan_steps
+
+    join_columns = SCOPE_COLUMNS + ["demand_group_id"]
+    missing_join_columns = [
+        column
+        for column in join_columns
+        if column not in plan_schema or column not in demand_schema
+    ]
+    if missing_join_columns:
+        return plan_steps
+
+    return plan_steps.join(
+        demand_groups
+        .select(join_columns + missing_columns)
+        .unique(),
+        on=join_columns,
+        how="left",
+    )
+
+
+def with_analysis_dimensions(plan_steps: pl.LazyFrame, group_columns: list[str]) -> pl.LazyFrame:
+    """Add and normalize optional analysis dimensions requested by a result table."""
+    schema = plan_steps.collect_schema().names()
+    expressions: list[pl.Expr] = []
+
+    if "home_zone_id" in group_columns and "home_zone_id" in schema:
+        expressions.append(pl.col("home_zone_id").cast(pl.String))
+    if "origin_zone_id" in group_columns and "from" in schema:
+        expressions.append(pl.col("from").cast(pl.String).alias("origin_zone_id"))
+    if "destination_zone_id" in group_columns and "to" in schema:
+        expressions.append(pl.col("to").cast(pl.String).alias("destination_zone_id"))
+
+    for column in ("activity", "mode"):
+        if column in group_columns and column in schema:
+            expressions.append(pl.col(column).cast(pl.String))
+
+    if "distance_bin" in group_columns:
+        if "distance_bin" in schema:
+            expressions.append(pl.col("distance_bin").cast(pl.String))
+        elif "distance" in schema:
+            expressions.append(distance_bin_expr("distance").alias("distance_bin"))
+
+    if "time_bin" in group_columns:
+        if "time_bin" in schema:
+            expressions.append(pl.col("time_bin").cast(pl.String))
+        elif "time" in schema:
+            expressions.append(time_bin_expr("time").alias("time_bin"))
+
+    if not expressions:
+        return plan_steps
+    return plan_steps.with_columns(expressions)
+
+
+def inner_zone_ids(transport_zones) -> pl.DataFrame:
+    """Return transport-zone ids marked as inner zones."""
+    return (
+        pl.DataFrame(transport_zones.get().drop("geometry", axis=1, errors="ignore"))
+        .filter(pl.col("is_inner_zone"))
+        .select(pl.col("transport_zone_id").cast(pl.String))
+        .unique()
+    )
+
+
+def filter_plan_steps_to_inner_zone_residents(
+    plan_steps: pl.LazyFrame,
+    transport_zones,
+) -> pl.LazyFrame:
+    """Keep only plan steps whose home zone is an inner zone."""
+    return (
+        plan_steps
+        .with_columns(pl.col("home_zone_id").cast(pl.String))
+        .join(
+            inner_zone_ids(transport_zones).lazy(),
+            left_on="home_zone_id",
+            right_on="transport_zone_id",
+            how="inner",
+        )
+    )
+
+
+def filter_demand_groups_to_inner_zone_residents(
+    demand_groups: pl.LazyFrame,
+    transport_zones,
+) -> pl.LazyFrame:
+    """Keep only demand groups whose home zone is an inner zone."""
+    return (
+        demand_groups
+        .with_columns(pl.col("home_zone_id").cast(pl.String))
+        .join(
+            inner_zone_ids(transport_zones).lazy(),
+            left_on="home_zone_id",
+            right_on="transport_zone_id",
+            how="inner",
+        )
+    )
+
+
+def complete_missing_replication_groups(
+    values: pl.LazyFrame,
+    *,
+    group_columns: list[str],
+    value_column: str,
+) -> pl.LazyFrame:
+    """Fill missing seed/group rows with zero before averaging over seeds."""
+    if not group_columns:
+        return values
+    scope_index = values.select(SCOPE_COLUMNS).unique()
+    group_index_columns = RESULT_COLUMNS + list(group_columns)
+    group_index = values.select(group_index_columns).unique()
+    full_index = scope_index.join(group_index, on=RESULT_COLUMNS, how="inner")
+    return (
+        full_index
+        .join(values, on=SCOPE_COLUMNS + list(group_columns), how="left")
+        .with_columns(pl.col(value_column).fill_null(0.0))
+    )

--- a/mobility/trips/group_day_trips/results/assets/survey_diagnostics.py
+++ b/mobility/trips/group_day_trips/results/assets/survey_diagnostics.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import polars as pl
+
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.trips.group_day_trips.evaluation.calibration_plan_steps import (
+    distance_bin_expr,
+    time_bin_expr,
+)
+
+from .person_metrics import RESULT_COLUMNS, SCOPE_COLUMNS
+
+JOINT_DIMENSIONS = ["country", "activity", "mode", "distance_bin", "time_bin"]
+
+
+def _with_string_dimensions(table: pl.DataFrame | pl.LazyFrame) -> pl.DataFrame | pl.LazyFrame:
+    """Cast survey-reference dimensions to strings before joins and caches."""
+    if isinstance(table, pl.LazyFrame):
+        columns = table.collect_schema().names()
+    else:
+        columns = table.columns
+    expressions = [
+        pl.col(column).cast(pl.String)
+        for column in JOINT_DIMENSIONS
+        if column in columns
+    ]
+    if not expressions:
+        return table
+    return table.with_columns(expressions)
+
+
+class SurveyReferenceComparison(FileAsset):
+    """Persist the joint model-vs-survey comparison table."""
+
+    def __init__(
+        self,
+        *,
+        plan_steps: FileAsset,
+        reference_plan_steps: FileAsset,
+        transport_zones: FileAsset,
+    ) -> None:
+        self.plan_steps = plan_steps
+        self.reference_plan_steps = reference_plan_steps
+        self.transport_zones = transport_zones
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / "survey_reference_comparison.parquet"
+        )
+        inputs = {
+            "version": 3,
+            "plan_steps": plan_steps,
+            "reference_plan_steps": reference_plan_steps,
+            "transport_zones": transport_zones,
+        }
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pl.LazyFrame:
+        """Return the cached joint comparison as a lazy parquet scan."""
+        return _with_string_dimensions(pl.scan_parquet(self.cache_path))
+
+    def create_and_get_asset(self) -> pl.LazyFrame:
+        """Build and cache the joint comparison table."""
+        plan_steps = self._model_plan_steps()
+        reference_plan_steps = self._reference_plan_steps()
+
+        model_values = self._indicator_values(
+            plan_steps,
+            group_columns=SCOPE_COLUMNS + JOINT_DIMENSIONS,
+            value_column="model_value",
+        )
+        reference_values = self._indicator_values(
+            reference_plan_steps,
+            group_columns=JOINT_DIMENSIONS,
+            value_column="reference_value",
+        )
+        scope = plan_steps.select(SCOPE_COLUMNS).unique()
+        reference_by_scope = scope.join(reference_values, how="cross")
+
+        comparison = (
+            model_values
+            .join(
+                reference_by_scope,
+                on=SCOPE_COLUMNS + JOINT_DIMENSIONS + ["indicator"],
+                how="full",
+                coalesce=True,
+            )
+            .with_columns(
+                reference_source=pl.lit("survey"),
+                country=pl.col("country").cast(pl.String),
+                activity=pl.col("activity").cast(pl.String),
+                mode=pl.col("mode").cast(pl.String),
+                distance_bin=pl.col("distance_bin").cast(pl.String),
+                time_bin=pl.col("time_bin").cast(pl.String),
+                model_value=pl.col("model_value").fill_null(0.0),
+                reference_value=pl.col("reference_value").fill_null(0.0),
+            )
+            .select(
+                [
+                    "reference_source",
+                    *SCOPE_COLUMNS,
+                    *JOINT_DIMENSIONS,
+                    "indicator",
+                    "model_value",
+                    "reference_value",
+                ]
+            )
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        comparison.collect(engine="streaming").write_parquet(self.cache_path)
+        return self.get_cached_asset()
+
+    def _model_plan_steps(self) -> pl.LazyFrame:
+        """Return model plan steps with country and calibration bins."""
+        plan_steps = self.plan_steps.get()
+        required_columns = {
+            "activity_seq_id",
+            "home_zone_id",
+            "activity",
+            "mode",
+            "distance",
+            "time",
+            "n_persons",
+            *SCOPE_COLUMNS,
+        }
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            raise ValueError(
+                "Survey diagnostics model plan steps are missing columns: "
+                f"{sorted(missing_columns)}."
+            )
+
+        transport_zones = self._transport_zone_countries()
+        return (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .rename({"home_zone_id": "transport_zone_id"})
+            .join(transport_zones, on="transport_zone_id", how="inner")
+            .with_columns(
+                country=pl.col("country").cast(pl.String),
+                activity=pl.col("activity").cast(pl.String),
+                mode=pl.col("mode").cast(pl.String),
+                distance=pl.col("distance").cast(pl.Float64),
+                time=pl.col("time").cast(pl.Float64),
+                n_persons=pl.col("n_persons").cast(pl.Float64),
+                distance_bin=distance_bin_expr("distance"),
+                time_bin=time_bin_expr("time"),
+            )
+        )
+
+    def _reference_plan_steps(self) -> pl.LazyFrame:
+        """Return survey-weighted reference plan steps with calibration bins."""
+        reference_plan_steps = self.reference_plan_steps.get()
+        if "travel_time" in reference_plan_steps.collect_schema().names():
+            reference_plan_steps = reference_plan_steps.rename({"travel_time": "time"})
+        required_columns = {
+            "activity_seq_id",
+            "home_zone_id",
+            "country",
+            "activity",
+            "mode",
+            "distance",
+            "time",
+            "n_persons",
+        }
+        missing_columns = required_columns.difference(reference_plan_steps.collect_schema().names())
+        if missing_columns:
+            raise ValueError(
+                "Survey diagnostics reference plan steps are missing columns: "
+                f"{sorted(missing_columns)}."
+            )
+
+        inner_zones = self._transport_zone_countries().select("transport_zone_id")
+        return (
+            reference_plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .rename({"home_zone_id": "transport_zone_id"})
+            .join(inner_zones, on="transport_zone_id", how="inner")
+            .with_columns(
+                country=pl.col("country").cast(pl.String),
+                activity=pl.col("activity").cast(pl.String),
+                mode=pl.col("mode").cast(pl.String),
+                distance=pl.col("distance").cast(pl.Float64),
+                time=pl.col("time").cast(pl.Float64),
+                n_persons=pl.col("n_persons").cast(pl.Float64),
+                distance_bin=distance_bin_expr("distance"),
+                time_bin=time_bin_expr("time"),
+            )
+        )
+
+    def _transport_zone_countries(self) -> pl.LazyFrame:
+        """Return inner transport zones and their country."""
+        transport_zones = self.transport_zones.get().drop("geometry", axis=1, errors="ignore")
+        study_area = self.transport_zones.study_area.get().drop("geometry", axis=1, errors="ignore")
+        return (
+            pl.DataFrame(transport_zones)
+            .lazy()
+            .filter(pl.col("is_inner_zone"))
+            .select(["transport_zone_id", "local_admin_unit_id"])
+            .join(
+                pl.DataFrame(study_area)
+                .lazy()
+                .select([
+                    "local_admin_unit_id",
+                    pl.col("country").cast(pl.String),
+                ]),
+                on="local_admin_unit_id",
+                how="left",
+            )
+            .select(["transport_zone_id", "country"])
+        )
+
+    @staticmethod
+    def _indicator_values(
+        plan_steps: pl.LazyFrame,
+        *,
+        group_columns: list[str],
+        value_column: str,
+    ) -> pl.LazyFrame:
+        """Aggregate trip count, travel time, and travel distance."""
+        return (
+            plan_steps
+            .group_by(group_columns)
+            .agg(
+                trip_count=pl.col("n_persons").sum(),
+                travel_time=(pl.col("time") * pl.col("n_persons")).sum(),
+                travel_distance=(pl.col("distance") * pl.col("n_persons")).sum(),
+            )
+            .unpivot(
+                index=group_columns,
+                on=["trip_count", "travel_time", "travel_distance"],
+                variable_name="indicator",
+                value_name=value_column,
+            )
+        )
+
+
+class SurveyReferenceMarginal(FileAsset):
+    """Persist one marginal view of the survey reference comparison."""
+
+    def __init__(
+        self,
+        *,
+        comparison: FileAsset,
+        marginal_columns: list[str],
+    ) -> None:
+        self.comparison = comparison
+        self.marginal_columns = list(marginal_columns)
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        marginal_part = "overall" if not self.marginal_columns else "-".join(self.marginal_columns)
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / f"survey_reference_{marginal_part}.parquet"
+        )
+        inputs = {
+            "version": 3,
+            "comparison": comparison,
+            "marginal_columns": tuple(self.marginal_columns),
+        }
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached marginal comparison."""
+        return _with_string_dimensions(pl.read_parquet(self.cache_path))
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the marginal comparison."""
+        comparison = self.comparison.get()
+        group_columns = ["country"] + list(self.marginal_columns)
+        for column in self.marginal_columns:
+            if column not in JOINT_DIMENSIONS:
+                raise ValueError(
+                    "Survey diagnostic marginals should use one of: "
+                    f"{JOINT_DIMENSIONS}. Received `{column}`."
+                )
+
+        per_replication = (
+            comparison
+            .group_by(["reference_source", *SCOPE_COLUMNS, *group_columns, "indicator"])
+            .agg(
+                model_value=pl.col("model_value").sum(),
+                reference_value=pl.col("reference_value").sum(),
+            )
+            .with_columns(
+                gap=pl.col("model_value") - pl.col("reference_value"),
+                relative_gap=(
+                    (pl.col("model_value") - pl.col("reference_value"))
+                    / pl.col("reference_value").abs().clip(1e-12)
+                ),
+            )
+        )
+        output_columns = ["reference_source", *RESULT_COLUMNS, *group_columns, "indicator"]
+        marginal = (
+            per_replication
+            .pipe(_with_string_dimensions)
+            .group_by(output_columns)
+            .agg(
+                pl.col("model_value").mean(),
+                pl.col("model_value").std().alias("model_value_std"),
+                pl.col("reference_value").mean(),
+                pl.col("gap").mean(),
+                pl.col("gap").std().alias("gap_std"),
+                pl.col("relative_gap").mean(),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        marginal.write_parquet(self.cache_path)
+        return marginal

--- a/mobility/trips/group_day_trips/results/assets/survey_time_diagnostics.py
+++ b/mobility/trips/group_day_trips/results/assets/survey_time_diagnostics.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import numpy as np
+import polars as pl
+
+from mobility.runtime.assets.file_asset import FileAsset
+
+from .person_metrics import RESULT_COLUMNS, SCOPE_COLUMNS
+
+
+class ActivityDurationDistribution(FileAsset):
+    """Persist model-vs-survey activity duration distributions."""
+
+    def __init__(
+        self,
+        *,
+        plan_steps: FileAsset,
+        reference_plan_steps: FileAsset | None = None,
+        scenarios: list[str],
+        day_type: str,
+        iterations: list[int],
+        replications: list[int],
+        bin_width_minutes: int,
+    ) -> None:
+        if bin_width_minutes <= 0:
+            raise ValueError("bin_width_minutes must be positive.")
+
+        self.plan_steps = plan_steps
+        self.reference_plan_steps = reference_plan_steps
+        self.scenarios = list(scenarios)
+        self.day_type = day_type
+        self.iterations = list(iterations)
+        self.replications = list(replications)
+        self.bin_width_minutes = bin_width_minutes
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / f"activity_duration_distribution_{bin_width_minutes}min.parquet"
+        )
+        super().__init__(
+            {
+                "version": 1,
+                "plan_steps": plan_steps,
+                "reference_plan_steps": reference_plan_steps,
+                "scenarios": tuple(scenarios),
+                "day_type": day_type,
+                "iterations": tuple(iterations),
+                "replications": tuple(replications),
+                "bin_width_minutes": bin_width_minutes,
+            },
+            cache_path,
+        )
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached distribution table."""
+        return pl.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the distribution table."""
+        duration_tables = [_activity_duration_samples(self.plan_steps.get(), source="model")]
+        if self.reference_plan_steps is not None:
+            survey_steps = _with_result_scope(
+                self.reference_plan_steps.get(),
+                scenarios=self.scenarios,
+                day_type=self.day_type,
+                iterations=self.iterations,
+                replications=self.replications,
+            )
+            duration_tables.append(_activity_duration_samples(survey_steps, source="survey"))
+        durations = pl.concat(duration_tables, how="vertical_relaxed")
+        bin_width_hours = self.bin_width_minutes / 60.0
+        distribution = (
+            durations.lazy()
+            .with_columns(
+                duration_bin_start=(pl.col("duration") / bin_width_hours).floor() * bin_width_hours,
+            )
+            .with_columns(
+                duration_bin_end=pl.col("duration_bin_start") + bin_width_hours,
+                duration_bin_mid=pl.col("duration_bin_start") + bin_width_hours / 2.0,
+                duration_label=pl.format(
+                    "{}-{} h",
+                    pl.col("duration_bin_start").round(2),
+                    (pl.col("duration_bin_start") + bin_width_hours).round(2),
+                ),
+            )
+            .group_by(
+                SCOPE_COLUMNS
+                + [
+                    "source",
+                    "activity",
+                    "duration_bin_start",
+                    "duration_bin_end",
+                    "duration_bin_mid",
+                    "duration_label",
+                ]
+            )
+            .agg(
+                weighted_visits=pl.col("weight").sum(),
+                person_hours=(pl.col("duration") * pl.col("weight")).sum(),
+            )
+            .with_columns(
+                probability=pl.col("weighted_visits")
+                / pl.col("weighted_visits").sum().over(SCOPE_COLUMNS + ["source", "activity"])
+            )
+        )
+        output_columns = RESULT_COLUMNS + [
+            "source",
+            "activity",
+            "duration_bin_start",
+            "duration_bin_end",
+            "duration_bin_mid",
+            "duration_label",
+        ]
+        result = (
+            distribution
+            .group_by(output_columns)
+            .agg(
+                pl.col("weighted_visits").mean().alias("weighted_visits"),
+                pl.col("person_hours").mean().alias("person_hours"),
+                pl.col("probability").mean().alias("probability"),
+                pl.col("probability").std().alias("probability_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        result.write_parquet(self.cache_path)
+        return result
+
+
+class ActivityTimeSeries(FileAsset):
+    """Persist model-vs-survey activity occupancy over time."""
+
+    def __init__(
+        self,
+        *,
+        plan_steps: FileAsset,
+        demand_groups: FileAsset,
+        reference_plan_steps: FileAsset | None = None,
+        scenarios: list[str],
+        day_type: str,
+        iterations: list[int],
+        replications: list[int],
+        interval_minutes: int,
+    ) -> None:
+        if interval_minutes <= 0 or 1440 % interval_minutes != 0:
+            raise ValueError("interval_minutes must be a positive divisor of 1440.")
+
+        self.plan_steps = plan_steps
+        self.demand_groups = demand_groups
+        self.reference_plan_steps = reference_plan_steps
+        self.scenarios = list(scenarios)
+        self.day_type = day_type
+        self.iterations = list(iterations)
+        self.replications = list(replications)
+        self.interval_minutes = interval_minutes
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / f"activity_time_series_{interval_minutes}min.parquet"
+        )
+        super().__init__(
+            {
+                "version": 1,
+                "plan_steps": plan_steps,
+                "demand_groups": demand_groups,
+                "reference_plan_steps": reference_plan_steps,
+                "scenarios": tuple(scenarios),
+                "day_type": day_type,
+                "iterations": tuple(iterations),
+                "replications": tuple(replications),
+                "interval_minutes": interval_minutes,
+            },
+            cache_path,
+        )
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached time series table."""
+        return pl.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the time series table."""
+        bins = _time_bins(interval_minutes=self.interval_minutes)
+        total_population = (
+            self.demand_groups.get()
+            .group_by(SCOPE_COLUMNS)
+            .agg(total_population=pl.col("n_persons").cast(pl.Float64).sum())
+        )
+        model_series = _add_residual_home_time(
+            _time_series_from_plan_steps(self.plan_steps.get(), interval_minutes=self.interval_minutes),
+            bins=bins,
+            total_population=total_population,
+        ).with_columns(source=pl.lit("model"))
+        series_tables = [model_series]
+        if self.reference_plan_steps is not None:
+            survey_steps = _with_result_scope(
+                self.reference_plan_steps.get(),
+                scenarios=self.scenarios,
+                day_type=self.day_type,
+                iterations=self.iterations,
+                replications=self.replications,
+            )
+            survey_series = _add_residual_home_time(
+                _time_series_from_plan_steps(survey_steps, interval_minutes=self.interval_minutes),
+                bins=bins,
+                total_population=total_population,
+            ).with_columns(source=pl.lit("survey"))
+            series_tables.append(survey_series)
+        per_replication = pl.concat(series_tables, how="vertical_relaxed")
+        output_columns = RESULT_COLUMNS + ["source", "time_bin_start", "time_label", "label"]
+        result = (
+            per_replication
+            .lazy()
+            .group_by(output_columns)
+            .agg(
+                pl.col("n_persons").mean().alias("n_persons"),
+                pl.col("n_persons").std().alias("n_persons_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        result.write_parquet(self.cache_path)
+        return result
+
+
+def _with_result_scope(
+    plan_steps: pl.LazyFrame,
+    *,
+    scenarios: list[str],
+    day_type: str,
+    iterations: list[int],
+    replications: list[int],
+) -> pl.LazyFrame:
+    """Duplicate a reference table for each result scope."""
+    scoped_tables = []
+    for scenario in scenarios:
+        for iteration in iterations:
+            for replication in replications:
+                scoped_tables.append(
+                    plan_steps.with_columns(
+                        scenario=pl.lit(scenario, dtype=pl.String),
+                        day_type=pl.lit(day_type, dtype=pl.String),
+                        iteration=pl.lit(iteration, dtype=pl.Int32),
+                        replication=pl.lit(replication, dtype=pl.Int64),
+                    )
+                )
+    return pl.concat(scoped_tables, how="vertical_relaxed")
+
+
+def _activity_duration_samples(plan_steps: pl.LazyFrame, *, source: str) -> pl.DataFrame:
+    """Extract weighted activity-duration samples from plan steps."""
+    column_names = set(plan_steps.collect_schema().names())
+    required_columns = set(SCOPE_COLUMNS + ["activity", "n_persons"])
+    missing_columns = required_columns.difference(column_names)
+    if missing_columns:
+        raise ValueError(f"Plan steps are missing duration-distribution columns: {sorted(missing_columns)}.")
+
+    if "duration_per_pers" in column_names:
+        duration_expr = pl.col("duration_per_pers").cast(pl.Float64)
+    elif {"duration", "n_persons"} <= column_names:
+        duration_expr = pl.col("duration").cast(pl.Float64) / pl.col("n_persons").cast(pl.Float64)
+    else:
+        raise ValueError("Plan steps need either duration_per_pers or duration and n_persons.")
+
+    samples = plan_steps.with_columns(
+        source=pl.lit(source),
+        activity=pl.col("activity").cast(pl.String),
+        duration=duration_expr,
+        weight=pl.col("n_persons").cast(pl.Float64),
+    )
+    samples = _filter_terminal_home_steps(samples, column_names)
+    return (
+        samples
+        .filter(
+            pl.col("duration").is_not_null()
+            & pl.col("duration").is_finite()
+            & (pl.col("duration") >= 0.0)
+            & pl.col("weight").is_not_null()
+            & pl.col("weight").is_finite()
+            & (pl.col("weight") > 0.0)
+        )
+        .select(SCOPE_COLUMNS + ["source", "activity", "duration", "weight"])
+        .collect(engine="streaming")
+    )
+
+
+def _filter_terminal_home_steps(plan_steps: pl.LazyFrame, column_names: set[str]) -> pl.LazyFrame:
+    """Remove the final home stay and keep home stops reached during the day."""
+    if "seq_step_index" in column_names:
+        plan_key_candidates = [
+            "country",
+            "home_zone_id",
+            "city_category",
+            "csp",
+            "n_cars",
+            "activity_seq_id",
+            "time_seq_id",
+            "dest_seq_id",
+            "mode_seq_id",
+        ]
+        plan_keys = [column for column in plan_key_candidates if column in column_names]
+        if plan_keys:
+            return (
+                plan_steps
+                .with_columns(is_terminal_step=pl.col("seq_step_index") == pl.col("seq_step_index").max().over(plan_keys))
+                .filter(~((pl.col("activity") == "home") & pl.col("is_terminal_step")))
+                .drop("is_terminal_step")
+            )
+
+    if "next_departure_time" in column_names:
+        return plan_steps.filter(~((pl.col("activity") == "home") & (pl.col("next_departure_time") >= 24.0)))
+
+    return plan_steps
+
+
+def _time_series_from_plan_steps(
+    plan_steps: pl.LazyFrame,
+    *,
+    interval_minutes: int,
+) -> pl.DataFrame:
+    """Aggregate explicit states stored in plan steps over time bins."""
+    bins = _time_bins(interval_minutes=interval_minutes)
+    bin_duration_hours = interval_minutes / 60.0
+    n_bins = bins.height
+    required_columns = set(
+        SCOPE_COLUMNS
+        + [
+            "activity",
+            "mode",
+            "n_persons",
+            "departure_time",
+            "arrival_time",
+            "next_departure_time",
+        ]
+    )
+    missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+    if missing_columns:
+        raise ValueError(f"Plan steps are missing activity-time-series columns: {sorted(missing_columns)}.")
+
+    plan_steps = plan_steps.select(list(required_columns)).with_columns(
+        activity=pl.col("activity").cast(pl.String),
+        mode=pl.col("mode").cast(pl.String),
+    )
+    activity_intervals = plan_steps.select(
+        SCOPE_COLUMNS
+        + [
+            pl.col("activity").alias("label"),
+            pl.col("arrival_time").alias("interval_start"),
+            pl.col("next_departure_time").alias("interval_end"),
+            "n_persons",
+        ]
+    )
+    transit_intervals = plan_steps.select(
+        SCOPE_COLUMNS
+        + [
+            pl.format("in_transit:{}", pl.col("mode")).alias("label"),
+            pl.col("departure_time").alias("interval_start"),
+            pl.col("arrival_time").alias("interval_end"),
+            "n_persons",
+        ]
+    )
+    intervals = pl.concat([activity_intervals, transit_intervals], how="vertical_relaxed")
+    return (
+        intervals.lazy()
+        .filter(pl.col("interval_end") > pl.col("interval_start"))
+        .with_columns(
+            start_bin_index=(
+                (pl.col("interval_start") / pl.lit(bin_duration_hours))
+                .floor()
+                .clip(0, n_bins - 1)
+                .cast(pl.UInt32)
+            ),
+            end_bin_index=(
+                (pl.col("interval_end") / pl.lit(bin_duration_hours))
+                .ceil()
+                .clip(0, n_bins)
+                .cast(pl.UInt32)
+            ),
+        )
+        .with_columns(bin_index=pl.int_ranges("start_bin_index", "end_bin_index", step=1, dtype=pl.UInt32))
+        .explode("bin_index")
+        .join(bins.with_row_index("bin_index").lazy(), on="bin_index", how="inner")
+        .with_columns(
+            overlap_start=pl.max_horizontal("interval_start", "time_bin_start"),
+            overlap_end=pl.min_horizontal("interval_end", "time_bin_end"),
+        )
+        .with_columns(
+            overlap_hours=(pl.col("overlap_end") - pl.col("overlap_start")).clip(0.0, bin_duration_hours),
+        )
+        .filter(pl.col("overlap_hours") > 0.0)
+        .with_columns(
+            n_persons=(pl.col("n_persons") * pl.col("overlap_hours") / pl.lit(bin_duration_hours)),
+        )
+        .group_by(SCOPE_COLUMNS + ["time_bin_start", "time_label", "label"])
+        .agg(n_persons=pl.col("n_persons").sum())
+        .sort(SCOPE_COLUMNS + ["time_bin_start", "label"])
+        .collect(engine="streaming")
+    )
+
+
+def _add_residual_home_time(
+    time_series: pl.DataFrame,
+    *,
+    bins: pl.DataFrame,
+    total_population: pl.LazyFrame,
+) -> pl.DataFrame:
+    """Fill missing occupancy in each bin as home time."""
+    scope_bins = (
+        total_population
+        .select(SCOPE_COLUMNS + ["total_population"])
+        .join(bins.lazy(), how="cross")
+    )
+    residual_home = (
+        scope_bins
+        .join(
+            time_series.lazy()
+            .group_by(SCOPE_COLUMNS + ["time_bin_start", "time_label"])
+            .agg(stacked_total=pl.col("n_persons").sum()),
+            on=SCOPE_COLUMNS + ["time_bin_start", "time_label"],
+            how="left",
+        )
+        .with_columns(
+            stacked_total=pl.col("stacked_total").fill_null(0.0),
+            label=pl.lit("home"),
+            n_persons=pl.col("total_population") - pl.col("stacked_total"),
+        )
+        .filter(pl.col("n_persons") != 0.0)
+        .select(SCOPE_COLUMNS + ["time_bin_start", "time_label", "label", "n_persons"])
+        .collect(engine="streaming")
+    )
+    return (
+        pl.concat([time_series, residual_home], how="vertical_relaxed")
+        .group_by(SCOPE_COLUMNS + ["time_bin_start", "time_label", "label"])
+        .agg(n_persons=pl.col("n_persons").sum())
+        .sort(SCOPE_COLUMNS + ["time_bin_start", "label"])
+    )
+
+
+def _time_bins(*, interval_minutes: int) -> pl.DataFrame:
+    """Return one full-day time-bin table."""
+    bin_duration_hours = interval_minutes / 60.0
+    bin_starts = np.arange(0.0, 24.0, bin_duration_hours, dtype=float)
+    return pl.DataFrame(
+        {
+            "time_bin_start": bin_starts,
+            "time_bin_end": bin_starts + bin_duration_hours,
+            "time_label": [
+                f"{int(hour):02d}:{int(round((hour * 60.0) % 60.0)):02d}"
+                for hour in bin_starts
+            ],
+        }
+    )

--- a/mobility/trips/group_day_trips/results/assets/trip_metrics.py
+++ b/mobility/trips/group_day_trips/results/assets/trip_metrics.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import polars as pl
+
+from mobility.runtime.assets.file_asset import FileAsset
+
+from .person_metrics import (
+    DEMAND_GROUP_COLUMNS,
+    RESULT_COLUMNS,
+    SCOPE_COLUMNS,
+    add_demand_group_columns,
+    complete_missing_replication_groups,
+    filter_demand_groups_to_inner_zone_residents,
+    filter_plan_steps_to_inner_zone_residents,
+    with_analysis_dimensions,
+)
+
+
+class TripCountMetric(FileAsset):
+    """Persist weighted trip counts across selected replications."""
+
+    def __init__(
+        self,
+        *,
+        plan_steps: FileAsset,
+        demand_groups: FileAsset,
+        transport_zones,
+        output_column: str,
+        group_columns: list[str],
+        per_person: bool,
+        inner_zone_residents_only: bool = False,
+    ) -> None:
+        self.plan_steps = plan_steps
+        self.demand_groups = demand_groups
+        self.transport_zones = transport_zones
+        self.output_column = output_column
+        self.group_columns = list(group_columns)
+        self.per_person = per_person
+        self.inner_zone_residents_only = inner_zone_residents_only
+
+        project_folder = pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+        group_part = "all" if not self.group_columns else "-".join(self.group_columns)
+        scope_part = "inner-zone-residents" if inner_zone_residents_only else "all-residents"
+        cache_path = (
+            project_folder
+            / "group_day_trips"
+            / "results"
+            / f"{output_column}_by_{group_part}_{scope_part}.parquet"
+        )
+        inputs = {
+            "version": 4,
+            "plan_steps": plan_steps,
+            "demand_groups": demand_groups,
+            "transport_zones": transport_zones,
+            "output_column": output_column,
+            "group_columns": tuple(self.group_columns),
+            "per_person": per_person,
+            "inner_zone_residents_only": inner_zone_residents_only,
+        }
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pl.DataFrame:
+        """Return the cached metric table."""
+        return pl.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pl.DataFrame:
+        """Build and cache the trip-count table."""
+        needed_demand_columns = [
+            column
+            for column in self.group_columns
+            if column in DEMAND_GROUP_COLUMNS
+        ]
+        if self.inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        plan_steps = with_analysis_dimensions(
+            add_demand_group_columns(
+                self.plan_steps.get(),
+                self.demand_groups.get(),
+                needed_demand_columns,
+            ),
+            self.group_columns,
+        )
+        if self.inner_zone_residents_only:
+            plan_steps = filter_plan_steps_to_inner_zone_residents(
+                plan_steps,
+                self.transport_zones,
+            )
+        group_columns = SCOPE_COLUMNS + list(self.group_columns)
+        required_plan_columns = set(group_columns + ["activity_seq_id", "n_persons"])
+        missing_plan_columns = required_plan_columns.difference(plan_steps.collect_schema().names())
+        if missing_plan_columns:
+            raise ValueError(
+                "TripCountMetric plan steps are missing columns: "
+                f"{sorted(missing_plan_columns)}."
+            )
+
+        per_replication = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(group_columns)
+            .agg(value=pl.col("n_persons").cast(pl.Float64).sum())
+        )
+        per_replication = complete_missing_replication_groups(
+            per_replication,
+            group_columns=self.group_columns,
+            value_column="value",
+        )
+        if self.per_person:
+            per_replication = self._divide_by_population(per_replication)
+
+        output_columns = RESULT_COLUMNS + list(self.group_columns)
+        metric = (
+            per_replication
+            .group_by(output_columns)
+            .agg(
+                pl.col("value").mean().alias(self.output_column),
+                pl.col("value").std().alias(f"{self.output_column}_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        metric.write_parquet(self.cache_path)
+        return metric
+
+    def _divide_by_population(self, trips: pl.LazyFrame) -> pl.LazyFrame:
+        """Divide trip counts by the matching population denominator."""
+        demand_groups = self.demand_groups.get()
+        if self.inner_zone_residents_only:
+            demand_groups = filter_demand_groups_to_inner_zone_residents(
+                demand_groups,
+                self.transport_zones,
+            )
+        demand_schema = demand_groups.collect_schema().names()
+        population_group_columns = [
+            column
+            for column in self.group_columns
+            if column in demand_schema
+        ]
+        denominator_columns = SCOPE_COLUMNS + population_group_columns
+        missing_demand_columns = set(denominator_columns + ["n_persons"]).difference(demand_schema)
+        if missing_demand_columns:
+            raise ValueError(
+                "TripCountMetric demand groups are missing columns: "
+                f"{sorted(missing_demand_columns)}."
+            )
+
+        population = (
+            demand_groups
+            .group_by(denominator_columns)
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+        )
+        return (
+            trips
+            .join(population, on=denominator_columns, how="left")
+            .with_columns(value=pl.col("value") / pl.col("n_persons").clip(1e-12))
+            .select(denominator_columns + [
+                column
+                for column in self.group_columns
+                if column not in population_group_columns
+            ] + ["value"])
+        )

--- a/mobility/trips/group_day_trips/results/metrics.py
+++ b/mobility/trips/group_day_trips/results/metrics.py
@@ -1,0 +1,2121 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import polars as pl
+
+from mobility.reports import TransportZoneMaps
+
+from .assets.final_state_metrics import Immobility, TripCountByDemandGroup
+from .assets.person_metrics import (
+    DEMAND_GROUP_COLUMNS,
+    RESULT_COLUMNS,
+    SCOPE_COLUMNS,
+    add_demand_group_columns,
+    complete_missing_replication_groups,
+    filter_demand_groups_to_inner_zone_residents,
+    filter_plan_steps_to_inner_zone_residents,
+    with_analysis_dimensions,
+)
+from .assets.scoped_tables import ScopedRunTable
+from .assets.survey_diagnostics import SurveyReferenceComparison, SurveyReferenceMarginal
+from .assets.survey_time_diagnostics import ActivityDurationDistribution, ActivityTimeSeries
+from .assets.trip_metrics import TripCountMetric
+from .plots import (
+    plot_activity_duration_distribution,
+    plot_activity_time_series,
+    plot_metric_flows_by_zone,
+    plot_metric_by_dimension,
+    plot_metric_by_zone,
+    plot_metric_grid_by_zone,
+    plot_metric_over_iterations,
+    select_scenarios,
+    validate_output,
+)
+
+ZoneDimension = Literal["home_zone", "origin_zone", "destination_zone"]
+ZoneDimensions = ZoneDimension | list[ZoneDimension] | tuple[ZoneDimension, ...]
+VariableDimension = Literal["mode", "activity", "distance_bin", "time_bin", "csp"]
+MetricOutput = Literal["table", "plot"]
+NormalizeBy = Literal["person_count", "metric_total"]
+NormalizeScope = Literal["zone", "study_area"]
+IterationSelector = str | int | list[int] | range
+MetricReference = Literal["external"] | tuple[Literal["scenario"], str] | None
+ReferenceView = Literal["gap", "values"]
+
+REFERENCE_DIMENSIONS = {"mode", "activity", "distance_bin", "time_bin"}
+
+
+class GroupDayTripsResultMetrics:
+    """Transport indicators for one or more scenarios and replications."""
+
+    def __init__(self, results) -> None:
+        self.results = results
+        self._transport_zone_maps = None
+
+    def _table(self, table_name: str, *, iterations: IterationSelector = "last") -> ScopedRunTable:
+        """Return one scoped run output table for this result set."""
+        return ScopedRunTable(
+            results=self.results,
+            table_name=table_name,
+            iterations=iterations,
+        )
+
+    def trip_count(
+        self,
+        *,
+        by_zone: ZoneDimensions | None = None,
+        by_variable: VariableDimension | None = None,
+        normalize_by: NormalizeBy | None = None,
+        normalize_scope: NormalizeScope | None = None,
+        reference: MetricReference = None,
+        reference_view: ReferenceView = "gap",
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+        n_largest: int | None = None,
+        min_value: float | None = None,
+        min_share: float | None = None,
+        max_line_width: float = 8.0,
+        min_line_width: float = 0.1,
+    ) -> pl.DataFrame:
+        """Return trip counts, optionally split and normalized."""
+        return self._metric(
+            quantity="trip_count",
+            quantity_column=None,
+            indicator="trip_count",
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def travel_distance(
+        self,
+        *,
+        by_zone: ZoneDimensions | None = None,
+        by_variable: VariableDimension | None = None,
+        normalize_by: NormalizeBy | None = None,
+        normalize_scope: NormalizeScope | None = None,
+        reference: MetricReference = None,
+        reference_view: ReferenceView = "gap",
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+        n_largest: int | None = None,
+        min_value: float | None = None,
+        min_share: float | None = None,
+        max_line_width: float = 8.0,
+        min_line_width: float = 0.1,
+    ) -> pl.DataFrame:
+        """Return travelled distance, optionally split and normalized."""
+        return self._metric(
+            quantity="travel_distance",
+            quantity_column="distance",
+            indicator="travel_distance",
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def travel_time(
+        self,
+        *,
+        by_zone: ZoneDimensions | None = None,
+        by_variable: VariableDimension | None = None,
+        normalize_by: NormalizeBy | None = None,
+        normalize_scope: NormalizeScope | None = None,
+        reference: MetricReference = None,
+        reference_view: ReferenceView = "gap",
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+        n_largest: int | None = None,
+        min_value: float | None = None,
+        min_share: float | None = None,
+        max_line_width: float = 8.0,
+        min_line_width: float = 0.1,
+    ) -> pl.DataFrame:
+        """Return travelled time, optionally split and normalized."""
+        return self._metric(
+            quantity="travel_time",
+            quantity_column="time",
+            indicator="travel_time",
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def cost(
+        self,
+        *,
+        by_zone: ZoneDimensions | None = None,
+        by_variable: VariableDimension | None = None,
+        normalize_by: NormalizeBy | None = None,
+        normalize_scope: NormalizeScope | None = None,
+        reference: MetricReference = None,
+        reference_view: ReferenceView = "gap",
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+        n_largest: int | None = None,
+        min_value: float | None = None,
+        min_share: float | None = None,
+        max_line_width: float = 8.0,
+        min_line_width: float = 0.1,
+    ) -> pl.DataFrame:
+        """Return travelled cost, optionally split and normalized."""
+        return self._metric(
+            quantity="cost",
+            quantity_column="cost",
+            indicator=None,
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def ghg_emissions(
+        self,
+        *,
+        by_zone: ZoneDimensions | None = None,
+        by_variable: VariableDimension | None = None,
+        normalize_by: NormalizeBy | None = None,
+        normalize_scope: NormalizeScope | None = None,
+        reference: MetricReference = None,
+        reference_view: ReferenceView = "gap",
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+        n_largest: int | None = None,
+        min_value: float | None = None,
+        min_share: float | None = None,
+        max_line_width: float = 8.0,
+        min_line_width: float = 0.1,
+    ) -> pl.DataFrame:
+        """Return greenhouse gas emissions, optionally split and normalized."""
+        return self._metric(
+            quantity="ghg_emissions",
+            quantity_column="ghg_emissions_per_trip",
+            indicator=None,
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def immobility(
+        self,
+        *,
+        reference: MetricReference = None,
+        iterations: IterationSelector = "last",
+    ) -> pl.DataFrame:
+        """Return model immobility by country and socio-professional category."""
+        reference_kind = self._reference_kind(reference)
+        if reference_kind == "scenario":
+            raise ValueError("Scenario references are not available for immobility yet.")
+        if reference_kind == "external" and not self.results.uses_last_iteration(iterations):
+            raise ValueError("External references are only available for iterations='last' for now.")
+        return Immobility(
+            plan_steps=self._table("plan_steps", iterations=iterations),
+            demand_groups=self._table("demand_groups", iterations=iterations),
+            transport_zones=self.results.transport_zones,
+            survey_immobility=self._survey_immobility() if reference_kind == "external" else None,
+        ).get()
+
+    def trip_count_by_demand_group(
+        self,
+        *,
+        iterations: IterationSelector = "last",
+    ) -> pl.DataFrame:
+        """Return trip count and trips per person by demand group."""
+        return TripCountByDemandGroup(
+            plan_steps=self._table("plan_steps", iterations=iterations),
+            demand_groups=self._table("demand_groups", iterations=iterations),
+        ).get()
+
+    def activity_duration_distribution(
+        self,
+        *,
+        reference: MetricReference = None,
+        iterations: IterationSelector = "last",
+        bin_width_minutes: int = 15,
+        output: MetricOutput = "table",
+        width: int = 900,
+        height: int = 520,
+    ) -> pl.DataFrame:
+        """Return model activity duration distributions."""
+        validate_output(output)
+        reference_kind = self._reference_kind(reference)
+        if reference_kind == "scenario":
+            raise ValueError("Scenario references are not available for activity duration distributions yet.")
+        if reference_kind == "external" and not self.results.uses_last_iteration(iterations):
+            raise ValueError("External references are only available for iterations='last' for now.")
+        if output == "plot" and self.results.has_multiple_iterations(iterations):
+            raise ValueError(
+                'output="plot" currently supports only one iteration. '
+                'Use iterations="last" or one iteration number, or use output="table".'
+            )
+        values = ActivityDurationDistribution(
+            plan_steps=self._table("plan_steps", iterations=iterations),
+            reference_plan_steps=self.results.survey_reference_plan_steps if reference_kind == "external" else None,
+            scenarios=self.results.scenarios,
+            day_type=self.results.day_type,
+            iterations=self.results.selected_iterations(iterations),
+            replications=self.results.replications,
+            bin_width_minutes=bin_width_minutes,
+        ).get()
+        if output == "plot":
+            return plot_activity_duration_distribution(
+                values,
+                scenario_titles=self.results.scenario_titles,
+                width=width,
+                height=height,
+            )
+        return values
+
+    def activity_time_series(
+        self,
+        *,
+        reference: MetricReference = None,
+        iterations: IterationSelector = "last",
+        interval_minutes: int = 15,
+        output: MetricOutput = "table",
+        width: int = 980,
+        height: int = 560,
+    ) -> pl.DataFrame:
+        """Return model average occupancy by activity and time bin."""
+        validate_output(output)
+        reference_kind = self._reference_kind(reference)
+        if reference_kind == "scenario":
+            raise ValueError("Scenario references are not available for activity time series yet.")
+        if reference_kind == "external" and not self.results.uses_last_iteration(iterations):
+            raise ValueError("External references are only available for iterations='last' for now.")
+        if output == "plot" and self.results.has_multiple_iterations(iterations):
+            raise ValueError(
+                'output="plot" currently supports only one iteration. '
+                'Use iterations="last" or one iteration number, or use output="table".'
+            )
+        values = ActivityTimeSeries(
+            plan_steps=self._table("plan_steps", iterations=iterations),
+            demand_groups=self._table("demand_groups", iterations=iterations),
+            reference_plan_steps=self.results.survey_reference_plan_steps if reference_kind == "external" else None,
+            scenarios=self.results.scenarios,
+            day_type=self.results.day_type,
+            iterations=self.results.selected_iterations(iterations),
+            replications=self.results.replications,
+            interval_minutes=interval_minutes,
+        ).get()
+        if output == "plot":
+            return plot_activity_time_series(
+                values,
+                scenario_titles=self.results.scenario_titles,
+                width=width,
+                height=height,
+            )
+        return values
+
+    def opportunity_occupation(
+        self,
+        *,
+        activity: str | None = None,
+        inner_zone_residents_only: bool = True,
+        iterations: IterationSelector = "last",
+        output: MetricOutput = "table",
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+        width: int = 760,
+        height: int = 460,
+        labels: bool = True,
+    ) -> pl.DataFrame:
+        """Return opportunity occupation by destination zone and activity."""
+        validate_output(output)
+        values = self._opportunity_occupation(
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+        )
+        values = self._filter_scenarios(values, scenarios=scenarios)
+        if activity is not None:
+            values = values.filter(pl.col("activity") == activity)
+        if output == "plot":
+            if activity is not None:
+                return plot_metric_by_zone(
+                    self._maps(),
+                    values,
+                    metric="opportunity_occupation",
+                    zone_column="transport_zone_id",
+                    title=f"Opportunity occupation for {activity}",
+                    scenario_titles=self.results.scenario_titles,
+                    width=width,
+                    height=height,
+                    labels=labels,
+                )
+            return plot_metric_grid_by_zone(
+                self._maps(),
+                values,
+                metric="opportunity_occupation",
+                zone_column="transport_zone_id",
+                variable_column="activity",
+                title="Opportunity occupation by destination zone and activity",
+                scenario_titles=self.results.scenario_titles,
+                width=width,
+                height=height,
+                labels=labels,
+            )
+        return values
+
+    def _metric(
+        self,
+        *,
+        quantity: str,
+        quantity_column: str | None,
+        indicator: str | None,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        reference: MetricReference,
+        reference_view: ReferenceView,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+        output: MetricOutput,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+        width: int,
+        height: int,
+        labels: bool,
+        n_largest: int | None,
+        min_value: float | None,
+        min_share: float | None,
+        max_line_width: float,
+        min_line_width: float,
+    ) -> pl.DataFrame:
+        """Return one compact metric query."""
+        validate_output(output)
+        self._validate_grouping(by_zone=by_zone, by_variable=by_variable)
+        self._validate_normalization(
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            by_zone=by_zone,
+            by_variable=by_variable,
+        )
+        reference_kind = self._reference_kind(reference)
+        self._validate_reference_view(reference_view, reference_kind=reference_kind)
+        if reference_kind == "external" and indicator is None:
+            raise ValueError(f"No reference is available for {quantity}.")
+        if reference_kind == "external" and not self.results.uses_last_iteration(iterations):
+            raise ValueError("External references are only available for iterations='last' for now.")
+        if reference_kind == "external" and by_zone is not None:
+            raise ValueError("External references are not available by zone.")
+        if reference_kind == "external" and by_variable not in REFERENCE_DIMENSIONS and by_variable is not None:
+            raise ValueError(
+                "External references are available by mode, activity, distance_bin, "
+                f"or time_bin. Received by_variable={by_variable!r}."
+            )
+        metric_column = self._metric_column(quantity, normalize_by)
+        zone_columns = self._zone_columns(by_zone)
+        zone_column = zone_columns[0] if len(zone_columns) == 1 else None
+        variable_column = self._variable_column(by_variable) if by_variable is not None else None
+        group_columns = zone_columns + ([variable_column] if variable_column is not None else [])
+
+        if quantity == "trip_count":
+            values = self._trip_count(
+                output_column=(
+                    "trip_count"
+                    if normalize_by in {"person_count", "metric_total"}
+                    else metric_column
+                ),
+                group_columns=group_columns,
+                per_person=False,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            ).get()
+            if normalize_by == "person_count":
+                values = self._with_person_count_normalization(
+                    values,
+                    normalize_scope=normalize_scope,
+                    zone_column=zone_column,
+                    group_columns=group_columns,
+                    value_column="trip_count",
+                    output_column=metric_column,
+                    inner_zone_residents_only=inner_zone_residents_only,
+                    iterations=iterations,
+                )
+            elif normalize_by == "metric_total":
+                values = self._with_metric_total_share(
+                    values,
+                    denominator_columns=self._denominator_columns(
+                        normalize_scope=normalize_scope,
+                        zone_column=zone_column,
+                    ),
+                    group_columns=group_columns,
+                    value_column="trip_count",
+                    output_column=metric_column,
+                )
+        else:
+            values = self._weighted_quantity(
+                quantity_column=quantity_column,
+                output_column=quantity,
+                group_columns=group_columns,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+            if normalize_by == "person_count":
+                values = self._with_person_count_normalization(
+                    values,
+                    normalize_scope=normalize_scope,
+                    zone_column=zone_column,
+                    group_columns=group_columns,
+                    value_column=quantity,
+                    output_column=metric_column,
+                    inner_zone_residents_only=inner_zone_residents_only,
+                    iterations=iterations,
+                )
+            elif normalize_by == "metric_total":
+                values = self._with_metric_total_share(
+                    values,
+                    denominator_columns=self._denominator_columns(
+                        normalize_scope=normalize_scope,
+                        zone_column=zone_column,
+                    ),
+                    group_columns=group_columns,
+                    value_column=quantity,
+                    output_column=metric_column,
+                )
+
+        if reference_kind == "scenario":
+            reference_scenario = self._reference_scenario(reference)
+            if reference_view == "gap":
+                per_replication_values = self._metric_by_replication(
+                    quantity=quantity,
+                    quantity_column=quantity_column,
+                    metric_column=metric_column,
+                    group_columns=group_columns,
+                    zone_column=zone_column,
+                    normalize_by=normalize_by,
+                    normalize_scope=normalize_scope,
+                    inner_zone_residents_only=inner_zone_residents_only,
+                    iterations=iterations,
+                )
+                values = self._with_scenario_reference(
+                    values,
+                    per_replication_values=per_replication_values,
+                    reference_scenario=reference_scenario,
+                    metric_column=metric_column,
+                    scenarios=scenarios,
+                )
+            else:
+                values = self._with_scenario_reference_values(
+                    values,
+                    reference_scenario=reference_scenario,
+                    scenarios=scenarios,
+                )
+        elif reference_kind == "external":
+            if reference_view == "gap":
+                values = self._with_external_reference(
+                    values,
+                    by_variable=by_variable,
+                    indicator=indicator,
+                    metric_column=metric_column,
+                    normalize_by=normalize_by,
+                    normalize_scope=normalize_scope,
+                    iterations=iterations,
+                )
+                values = self._filter_scenarios(values, scenarios=scenarios)
+            else:
+                values = self._with_external_reference_values(
+                    values,
+                    by_variable=by_variable,
+                    indicator=indicator,
+                    metric_column=metric_column,
+                    normalize_by=normalize_by,
+                    normalize_scope=normalize_scope,
+                    iterations=iterations,
+                    scenarios=scenarios,
+                )
+        else:
+            values = self._filter_scenarios(values, scenarios=scenarios)
+        if output == "plot":
+            plot_metric_column = (
+                "gap"
+                if reference_kind != "none" and reference_view == "gap"
+                else metric_column
+            )
+            plot_title = self._plot_title(
+                quantity,
+                by_zone=by_zone,
+                by_variable=by_variable,
+                normalize_by=normalize_by,
+                reference_kind=reference_kind,
+                reference_view=reference_view,
+            )
+            if "iteration" in values.columns and values["iteration"].n_unique() > 1:
+                return plot_metric_over_iterations(
+                    values,
+                    metric=plot_metric_column,
+                    title=plot_title,
+                    dimension_columns=group_columns + (
+                        ["series"] if "series" in values.columns else []
+                    ),
+                    scenario_titles=self.results.scenario_titles,
+                    width=width,
+                    height=height,
+                )
+            if by_zone is None and by_variable is None:
+                raise ValueError('output="plot" needs `by_zone` or `by_variable`.')
+            if len(zone_columns) > 1:
+                if by_variable is not None:
+                    raise ValueError("OD flow plots do not support `by_variable` yet.")
+                if zone_columns != ["origin_zone_id", "destination_zone_id"]:
+                    raise ValueError(
+                        'output="plot" with multiple zone dimensions only supports '
+                        'by_zone=["origin_zone", "destination_zone"].'
+                    )
+                return plot_metric_flows_by_zone(
+                    self._maps(),
+                    values,
+                    metric=plot_metric_column,
+                    origin_column="origin_zone_id",
+                    destination_column="destination_zone_id",
+                    title=plot_title,
+                    scenario_titles=self.results.scenario_titles,
+                    width=width,
+                    height=height,
+                    labels=labels,
+                    n_largest=100 if n_largest is None else n_largest,
+                    min_value=min_value,
+                    min_share=min_share,
+                    max_line_width=max_line_width,
+                    min_line_width=min_line_width,
+                )
+            if zone_column is not None and by_variable is not None:
+                return plot_metric_grid_by_zone(
+                    self._maps(),
+                    values,
+                    metric=plot_metric_column,
+                    zone_column=zone_column,
+                    variable_column=variable_column,
+                    title=plot_title,
+                    scenario_titles=self.results.scenario_titles,
+                    diverging_center=0.0 if plot_metric_column == "gap" else None,
+                    width=width,
+                    height=height,
+                    labels=labels,
+                )
+            if zone_column is not None:
+                return plot_metric_by_zone(
+                    self._maps(),
+                    values,
+                    metric=plot_metric_column,
+                    zone_column=zone_column,
+                    title=plot_title,
+                    scenario_titles=self.results.scenario_titles,
+                    diverging_center=0.0 if plot_metric_column == "gap" else None,
+                    width=width,
+                    height=height,
+                    labels=labels,
+                )
+            return plot_metric_by_dimension(
+                values,
+                dimension=variable_column,
+                metric=plot_metric_column,
+                yaxis_title=plot_metric_column.replace("_", " "),
+                title=plot_title,
+                scenarios=None if reference_kind != "none" else scenarios,
+                scenario_titles=self.results.scenario_titles,
+                width=width,
+                height=height,
+            )
+        return values
+
+    def _opportunity_occupation(
+        self,
+        *,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return opportunity occupation aggregated over selected replications."""
+        opportunities = self._table("opportunities", iterations=iterations).get()
+        plan_steps = self._table("plan_steps", iterations=iterations).get()
+        if inner_zone_residents_only:
+            plan_steps = filter_plan_steps_to_inner_zone_residents(
+                plan_steps,
+                self.results.transport_zones,
+            )
+
+        plan_schema = set(plan_steps.collect_schema().names())
+        duration_expr = self._activity_duration_expr(plan_schema)
+        if "activity_seq_id" in plan_schema:
+            plan_steps = plan_steps.filter(pl.col("activity_seq_id") != 0)
+
+        transport_zones = pl.DataFrame(
+            self.results.transport_zones.get().drop("geometry", axis=1, errors="ignore")
+        ).with_columns(pl.col("transport_zone_id").cast(pl.String))
+        destination_flags = transport_zones.select(
+            pl.col("transport_zone_id").alias("to"),
+            pl.col("is_inner_zone").alias("destination_is_inner_zone"),
+        ).lazy()
+
+        opportunity_schema = set(opportunities.collect_schema().names())
+        missing_columns = {"to", "activity", "opportunity_capacity"}.difference(
+            opportunity_schema
+        )
+        if missing_columns:
+            raise ValueError(
+                "Opportunity occupation needs these missing opportunity column(s): "
+                + ", ".join(sorted(missing_columns))
+                + "."
+            )
+
+        scoped_opportunities = (
+            opportunities
+            .select(SCOPE_COLUMNS + ["to", "activity", "opportunity_capacity"])
+            .with_columns(
+                pl.col("to").cast(pl.String),
+                pl.col("activity").cast(pl.String),
+                pl.col("opportunity_capacity").cast(pl.Float64),
+            )
+            .group_by(SCOPE_COLUMNS + ["to", "activity"])
+            .agg(opportunity_capacity=pl.col("opportunity_capacity").sum())
+        )
+        occupied_duration = (
+            plan_steps
+            .with_columns(
+                pl.col("to").cast(pl.String),
+                pl.col("activity").cast(pl.String),
+                duration=duration_expr,
+            )
+            .group_by(SCOPE_COLUMNS + ["to", "activity"])
+            .agg(duration=pl.col("duration").sum())
+        )
+        per_replication = (
+            scoped_opportunities
+            .join(destination_flags, on="to", how="left")
+            .join(occupied_duration, on=SCOPE_COLUMNS + ["to", "activity"], how="left")
+            .with_columns(
+                duration=pl.col("duration").fill_null(0.0),
+                opportunity_occupation=(
+                    pl.col("duration").fill_null(0.0)
+                    / pl.col("opportunity_capacity").clip(1e-12)
+                ),
+            )
+        )
+        output_columns = RESULT_COLUMNS + [
+            "transport_zone_id",
+            "activity",
+            "destination_is_inner_zone",
+        ]
+        return (
+            per_replication
+            .rename({"to": "transport_zone_id"})
+            .group_by(output_columns)
+            .agg(
+                opportunity_capacity=pl.col("opportunity_capacity").mean(),
+                duration=pl.col("duration").mean(),
+                opportunity_occupation=pl.col("opportunity_occupation").mean(),
+                opportunity_occupation_std=pl.col("opportunity_occupation").std(),
+                n_replications=pl.col("replication").n_unique().cast(pl.UInt32),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+    def _maps(self) -> TransportZoneMaps:
+        """Return cached transport-zone map helpers for this result set."""
+        if self._transport_zone_maps is None:
+            population = getattr(self.results.first_run, "population", None)
+            if not callable(getattr(population, "get", None)):
+                population = None
+            self._transport_zone_maps = TransportZoneMaps(
+                self.results.transport_zones,
+                population=population,
+            )
+        return self._transport_zone_maps
+
+    def _with_survey_reference(
+        self,
+        *,
+        by_variable: VariableDimension | None,
+        indicator: str,
+        metric_column: str,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return one metric with its natural external reference."""
+        if normalize_by == "metric_total":
+            if by_variable is None:
+                raise ValueError('normalize_by="metric_total" needs `by_variable` for references.')
+            return self._share_with_survey_reference(
+                by_variable=by_variable,
+                indicator=indicator,
+                metric_column=metric_column,
+                iterations=iterations,
+            )
+
+        if by_variable is None:
+            comparison = (
+                self._survey_reference_marginal([])
+                .get()
+                .filter(pl.col("indicator") == indicator)
+                .group_by(RESULT_COLUMNS + ["reference_source"])
+                .agg(
+                    model_value=pl.col("model_value").sum(),
+                    model_value_std=(pl.col("model_value_std").pow(2).sum()).sqrt(),
+                    reference_value=pl.col("reference_value").sum(),
+                    n_replications=pl.col("n_replications").max(),
+                )
+            )
+            join_columns = RESULT_COLUMNS
+        else:
+            group_column = self._variable_column(by_variable)
+            comparison = (
+                self._survey_reference_marginal([group_column])
+                .get()
+                .filter(pl.col("indicator") == indicator)
+            )
+            join_columns = RESULT_COLUMNS + ["country"]
+
+        if normalize_by == "person_count":
+            if normalize_scope != "study_area":
+                raise ValueError('External references only support normalize_scope="study_area".')
+            population = (
+                self._total_population(iterations=iterations)
+                if by_variable is None
+                else self._country_population(iterations=iterations)
+            )
+            comparison = (
+                comparison
+                .join(population, on=join_columns, how="left")
+                .with_columns(
+                    model_value=pl.col("model_value") / pl.col("n_persons").clip(1e-12),
+                    model_value_std=pl.col("model_value_std") / pl.col("n_persons").clip(1e-12),
+                    reference_value=pl.col("reference_value") / pl.col("n_persons").clip(1e-12),
+                )
+                .drop("n_persons")
+            )
+
+        return self._format_reference_table(
+            comparison,
+            by_variable=by_variable,
+            metric_column=metric_column,
+        )
+
+    def _share_with_survey_reference(
+        self,
+        *,
+        by_variable: VariableDimension,
+        indicator: str,
+        metric_column: str,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return one quantity share with its external reference share."""
+        group_column = self._variable_column(by_variable)
+        comparison = (
+            self._survey_reference_marginal([group_column])
+            .get()
+            .filter(pl.col("indicator") == indicator)
+        )
+        group_columns = RESULT_COLUMNS + ["country"]
+        return self._format_reference_table(
+            comparison
+            .with_columns(
+                model_total=pl.col("model_value").sum().over(group_columns),
+                reference_total=pl.col("reference_value").sum().over(group_columns),
+            )
+            .with_columns(
+                model_value=pl.col("model_value") / pl.col("model_total").clip(1e-12),
+                model_value_std=pl.col("model_value_std") / pl.col("model_total").clip(1e-12),
+                reference_value=pl.col("reference_value") / pl.col("reference_total").clip(1e-12),
+            ),
+            by_variable=by_variable,
+            metric_column=metric_column,
+        )
+
+    def _format_reference_table(
+        self,
+        comparison: pl.DataFrame,
+        *,
+        by_variable: VariableDimension | None,
+        metric_column: str,
+    ) -> pl.DataFrame:
+        """Rename model/reference columns to the public metric schema."""
+        reference_column = f"{metric_column}_reference"
+        columns = list(RESULT_COLUMNS)
+        sort_columns = list(RESULT_COLUMNS)
+        if by_variable is not None:
+            group_column = self._variable_column(by_variable)
+            columns.extend(["country", group_column])
+            sort_columns.extend(["country", group_column])
+
+        return (
+            comparison
+            .rename(
+                {
+                    "model_value": metric_column,
+                    "model_value_std": f"{metric_column}_std",
+                    "reference_value": reference_column,
+                }
+            )
+            .with_columns(
+                gap=pl.col(metric_column) - pl.col(reference_column),
+                gap_std=pl.col(f"{metric_column}_std"),
+                relative_gap=(
+                    (pl.col(metric_column) - pl.col(reference_column))
+                    / pl.col(reference_column).abs().clip(1e-12)
+                ),
+            )
+            .select(
+                columns
+                + [
+                    metric_column,
+                    f"{metric_column}_std",
+                    "reference_source",
+                    reference_column,
+                    "gap",
+                    "gap_std",
+                    "relative_gap",
+                    "n_replications",
+                ]
+            )
+            .sort(sort_columns)
+        )
+
+    def _with_scenario_reference(
+        self,
+        values: pl.DataFrame,
+        *,
+        per_replication_values: pl.DataFrame,
+        reference_scenario: str,
+        metric_column: str,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+    ) -> pl.DataFrame:
+        """Compare metric rows to one scenario from the same result set."""
+        if reference_scenario not in self.results.scenarios:
+            raise ValueError(
+                "Scenario references should be included in the result set. "
+                f"Missing scenario: {reference_scenario!r}."
+            )
+
+        selected_scenarios = select_scenarios(self.results, scenarios)
+        model_scenarios = [
+            scenario
+            for scenario in selected_scenarios
+            if scenario != reference_scenario
+        ]
+        if not model_scenarios:
+            raise ValueError(
+                "Scenario reference output needs at least one non-reference scenario."
+            )
+
+        std_column = f"{metric_column}_std"
+        reference_column = f"{metric_column}_reference"
+        non_key_columns = {"scenario", metric_column, std_column, "n_replications"}
+        join_columns = [
+            column
+            for column in values.columns
+            if column not in non_key_columns
+        ]
+        dimension_columns = [
+            column
+            for column in per_replication_values.columns
+            if column not in SCOPE_COLUMNS + [metric_column]
+        ]
+        pairing_columns = ["day_type", "iteration", "replication"] + dimension_columns
+        paired_output_columns = RESULT_COLUMNS + dimension_columns
+
+        reference_rows = (
+            values
+            .filter(pl.col("scenario") == reference_scenario)
+            .select(
+                join_columns
+                + [pl.col(metric_column).alias(reference_column)]
+            )
+        )
+        model_rows = values.filter(pl.col("scenario").is_in(model_scenarios))
+        output_columns = [
+            column
+            for column in model_rows.columns
+            if column not in {"n_replications"}
+        ]
+        if "n_replications" in model_rows.columns:
+            output_columns.append("n_replications")
+
+        reference_replications = (
+            per_replication_values
+            .filter(pl.col("scenario") == reference_scenario)
+            .select(
+                pairing_columns
+                + [pl.col(metric_column).alias(reference_column)]
+            )
+        )
+        model_replications = per_replication_values.filter(
+            pl.col("scenario").is_in(model_scenarios)
+        )
+        paired_gaps = (
+            model_replications
+            .join(reference_replications, on=pairing_columns, how="inner")
+            .with_columns(
+                paired_gap=pl.col(metric_column) - pl.col(reference_column),
+            )
+            .group_by(paired_output_columns)
+            .agg(
+                pl.col("paired_gap").mean().alias("gap"),
+                pl.col("paired_gap").std().alias("gap_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_paired_replications"),
+            )
+        )
+        joined = (
+            model_rows
+            .join(reference_rows, on=join_columns, how="left")
+            .join(paired_gaps, on=paired_output_columns, how="left")
+            .with_columns(
+                reference_source=pl.lit(f"scenario:{reference_scenario}"),
+                relative_gap=(
+                    pl.col("gap") / pl.col(reference_column).abs().clip(1e-12)
+                ),
+            )
+        )
+        if "n_replications" in joined.columns:
+            joined = (
+                joined
+                .with_columns(pl.col("n_paired_replications").alias("n_replications"))
+                .drop("n_paired_replications")
+            )
+
+        return (
+            joined
+            .select(
+                output_columns
+                + [
+                    "reference_source",
+                    reference_column,
+                    "gap",
+                    "gap_std",
+                    "relative_gap",
+                ]
+            )
+            .sort([column for column in output_columns if column != "n_replications"])
+        )
+
+    def _with_scenario_reference_values(
+        self,
+        values: pl.DataFrame,
+        *,
+        reference_scenario: str,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+    ) -> pl.DataFrame:
+        """Return model rows and the selected scenario reference as value rows."""
+        if reference_scenario not in self.results.scenarios:
+            raise ValueError(
+                "Scenario references should be included in the result set. "
+                f"Missing scenario: {reference_scenario!r}."
+            )
+
+        selected_scenarios = select_scenarios(self.results, scenarios)
+        model_scenarios = [
+            scenario
+            for scenario in selected_scenarios
+            if scenario != reference_scenario
+        ]
+        if not model_scenarios:
+            raise ValueError(
+                "Scenario reference output needs at least one non-reference scenario."
+            )
+
+        output_columns = list(values.columns)
+        model_rows = (
+            values
+            .filter(pl.col("scenario").is_in(model_scenarios))
+            .with_columns(
+                series=pl.lit("model"),
+                reference_source=pl.lit(None, dtype=pl.String),
+            )
+            .select(output_columns + ["series", "reference_source"])
+        )
+        reference_rows = (
+            values
+            .filter(pl.col("scenario") == reference_scenario)
+            .with_columns(
+                series=pl.lit("reference"),
+                reference_source=pl.lit(f"scenario:{reference_scenario}"),
+            )
+            .select(output_columns + ["series", "reference_source"])
+        )
+        return (
+            pl.concat([model_rows, reference_rows], how="vertical_relaxed")
+            .sort([column for column in output_columns if column != "n_replications"] + ["series"])
+        )
+
+    def _with_external_reference(
+        self,
+        values: pl.DataFrame,
+        *,
+        by_variable: VariableDimension | None,
+        indicator: str,
+        metric_column: str,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Add the natural external reference to a normal metric table."""
+        reference_values = self._external_reference_values(
+            by_variable=by_variable,
+            indicator=indicator,
+            metric_column=metric_column,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            iterations=iterations,
+        )
+        reference_column = f"{metric_column}_reference"
+        join_columns = list(RESULT_COLUMNS)
+        if by_variable is not None:
+            join_columns.append(self._variable_column(by_variable))
+        std_column = f"{metric_column}_std"
+        joined = (
+            values
+            .join(reference_values, on=join_columns, how="left")
+            .with_columns(
+                gap=pl.col(metric_column) - pl.col(reference_column),
+                relative_gap=(
+                    (pl.col(metric_column) - pl.col(reference_column))
+                    / pl.col(reference_column).abs().clip(1e-12)
+                ),
+            )
+        )
+        if std_column in joined.columns:
+            joined = joined.with_columns(gap_std=pl.col(std_column))
+        else:
+            joined = joined.with_columns(gap_std=pl.lit(None, dtype=pl.Float64))
+
+        output_columns = list(values.columns)
+        return (
+            joined
+            .select(
+                output_columns
+                + [
+                    "reference_source",
+                    reference_column,
+                    "gap",
+                    "gap_std",
+                    "relative_gap",
+                ]
+            )
+            .sort([column for column in output_columns if column != "n_replications"])
+        )
+
+    def _with_external_reference_values(
+        self,
+        values: pl.DataFrame,
+        *,
+        by_variable: VariableDimension | None,
+        indicator: str,
+        metric_column: str,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        iterations: IterationSelector,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+    ) -> pl.DataFrame:
+        """Return model rows and external reference rows in one value table."""
+        model_rows = self._filter_scenarios(values, scenarios=scenarios)
+        output_columns = list(model_rows.columns)
+        reference_column = f"{metric_column}_reference"
+        reference_rows = self._external_reference_values(
+            by_variable=by_variable,
+            indicator=indicator,
+            metric_column=metric_column,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            iterations=iterations,
+        )
+        reference_rows = self._filter_scenarios(reference_rows, scenarios=scenarios)
+        reference_rows = reference_rows.rename({reference_column: metric_column})
+
+        missing_expressions = []
+        if f"{metric_column}_std" in output_columns and f"{metric_column}_std" not in reference_rows.columns:
+            missing_expressions.append(pl.lit(None, dtype=pl.Float64).alias(f"{metric_column}_std"))
+        if "n_replications" in output_columns and "n_replications" not in reference_rows.columns:
+            missing_expressions.append(pl.lit(None, dtype=pl.UInt32).alias("n_replications"))
+        if missing_expressions:
+            reference_rows = reference_rows.with_columns(missing_expressions)
+
+        model_rows = (
+            model_rows
+            .with_columns(
+                series=pl.lit("model"),
+                reference_source=pl.lit(None, dtype=pl.String),
+            )
+            .select(output_columns + ["series", "reference_source"])
+        )
+        reference_rows = (
+            reference_rows
+            .with_columns(series=pl.lit("reference"))
+            .select(output_columns + ["series", "reference_source"])
+        )
+        return (
+            pl.concat([model_rows, reference_rows], how="vertical_relaxed")
+            .sort([column for column in output_columns if column != "n_replications"] + ["series"])
+        )
+
+    def _external_reference_values(
+        self,
+        *,
+        by_variable: VariableDimension | None,
+        indicator: str,
+        metric_column: str,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return external reference values with the same dimensions as metric values."""
+        if by_variable is None:
+            comparison = (
+                self._survey_reference_marginal([])
+                .get()
+                .filter(pl.col("indicator") == indicator)
+                .group_by(RESULT_COLUMNS + ["reference_source"])
+                .agg(reference_value=pl.col("reference_value").sum())
+            )
+            join_columns = RESULT_COLUMNS
+            group_columns = RESULT_COLUMNS + ["reference_source"]
+        else:
+            group_column = self._variable_column(by_variable)
+            comparison = (
+                self._survey_reference_marginal([group_column])
+                .get()
+                .filter(pl.col("indicator") == indicator)
+                .group_by(RESULT_COLUMNS + ["reference_source", group_column])
+                .agg(reference_value=pl.col("reference_value").sum())
+            )
+            join_columns = RESULT_COLUMNS
+            group_columns = RESULT_COLUMNS + ["reference_source", group_column]
+
+        if normalize_by == "person_count":
+            if normalize_scope != "study_area":
+                raise ValueError('External references only support normalize_scope="study_area".')
+            population = self._external_reference_population(iterations=iterations)
+            comparison = (
+                comparison
+                .join(population, on=join_columns, how="left")
+                .with_columns(
+                    reference_value=pl.col("reference_value") / pl.col("n_persons_reference").clip(1e-12),
+                )
+                .drop("n_persons_reference")
+            )
+        elif normalize_by == "metric_total":
+            if by_variable is None:
+                raise ValueError('normalize_by="metric_total" needs `by_variable` for references.')
+            comparison = comparison.with_columns(
+                reference_total=pl.col("reference_value").sum().over(RESULT_COLUMNS),
+            ).with_columns(
+                reference_value=pl.col("reference_value") / pl.col("reference_total").clip(1e-12),
+            )
+
+        reference_column = f"{metric_column}_reference"
+        return (
+            comparison
+            .with_columns(pl.col("reference_value").alias(reference_column))
+            .select(group_columns + [reference_column])
+            .sort(group_columns)
+        )
+
+    def _external_reference_population(
+        self,
+        *,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return the population represented by the natural external reference."""
+        reference_plan_steps = self.results.survey_reference_plan_steps.get()
+        reference_schema = reference_plan_steps.collect_schema().names()
+        if "home_zone_id" not in reference_schema or "n_persons" not in reference_schema:
+            raise ValueError(
+                "External references need reference plan steps with home_zone_id and n_persons."
+            )
+
+        zones = self.results.transport_zones.get()
+        if "geometry" in zones.columns:
+            zones = zones.drop(columns="geometry")
+        inner_zones = (
+            pl.from_pandas(zones)
+            .filter(pl.col("is_inner_zone"))
+            .select(pl.col("transport_zone_id").cast(pl.String).alias("home_zone_id"))
+            .lazy()
+        )
+        plan_columns = [
+            column
+            for column in [
+                "country",
+                "home_zone_id",
+                "city_category",
+                "csp",
+                "n_cars",
+                "activity_seq_id",
+                "time_seq_id",
+            ]
+            if column in reference_schema
+        ]
+        if not plan_columns:
+            raise ValueError("External reference population could not identify reference plans.")
+
+        reference_population = (
+            reference_plan_steps
+            .with_columns(pl.col("home_zone_id").cast(pl.String))
+            .join(inner_zones, on="home_zone_id", how="inner")
+            .select(plan_columns + ["n_persons"])
+            .unique()
+            .select(n_persons_reference=pl.col("n_persons").cast(pl.Float64).sum())
+            .collect(engine="streaming")
+        )
+        scope = (
+            self._table("plan_steps", iterations=iterations)
+            .get()
+            .select(RESULT_COLUMNS)
+            .unique()
+            .collect(engine="streaming")
+        )
+        return scope.join(reference_population, how="cross")
+
+    def _weighted_quantity(
+        self,
+        *,
+        quantity_column: str,
+        output_column: str,
+        group_columns: list[str],
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return an absolute weighted quantity averaged over replications."""
+        plan_steps = self._plan_steps_with_quantity(
+            quantity_column,
+            iterations=iterations,
+        )
+        needed_demand_columns = [
+            column
+            for column in group_columns
+            if column in DEMAND_GROUP_COLUMNS
+        ]
+        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if needed_demand_columns:
+            plan_steps = add_demand_group_columns(
+                plan_steps,
+                self._table("demand_groups", iterations=iterations).get(),
+                needed_demand_columns,
+            )
+        if inner_zone_residents_only:
+            plan_steps = filter_plan_steps_to_inner_zone_residents(
+                plan_steps,
+                self.results.transport_zones,
+            )
+        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
+        required_columns = set(SCOPE_COLUMNS + group_columns + ["activity_seq_id", quantity_column, "n_persons"])
+        missing_columns = required_columns.difference(plan_steps.collect_schema().names())
+        if missing_columns:
+            raise ValueError(
+                "Metric plan steps are missing columns: "
+                f"{sorted(missing_columns)}."
+            )
+
+        output_columns = RESULT_COLUMNS + group_columns
+        return (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(SCOPE_COLUMNS + group_columns)
+            .agg(
+                value=(
+                    pl.col(quantity_column).cast(pl.Float64)
+                    * pl.col("n_persons").cast(pl.Float64)
+                ).sum()
+            )
+            .group_by(output_columns)
+            .agg(
+                pl.col("value").mean().alias(output_column),
+                pl.col("value").std().alias(f"{output_column}_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+    def _metric_by_replication(
+        self,
+        *,
+        quantity: str,
+        quantity_column: str | None,
+        metric_column: str,
+        group_columns: list[str],
+        zone_column: str | None,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return metric values before averaging replications."""
+        if quantity == "trip_count":
+            value_column = "trip_count"
+            per_replication = self._trip_count_by_replication(
+                group_columns=group_columns,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+                value_column=value_column,
+            )
+        else:
+            value_column = quantity
+            per_replication = self._weighted_quantity_by_replication(
+                quantity_column=quantity_column,
+                output_column=value_column,
+                group_columns=group_columns,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+
+        if normalize_by == "person_count":
+            per_replication = self._with_person_count_normalization_by_replication(
+                per_replication,
+                normalize_scope=normalize_scope,
+                zone_column=zone_column,
+                group_columns=group_columns,
+                value_column=value_column,
+                output_column=metric_column,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+        elif normalize_by == "metric_total":
+            per_replication = self._with_metric_total_share_by_replication(
+                per_replication,
+                denominator_columns=self._denominator_columns(
+                    normalize_scope=normalize_scope,
+                    zone_column=zone_column,
+                ),
+                group_columns=group_columns,
+                value_column=value_column,
+                output_column=metric_column,
+            )
+        elif value_column != metric_column:
+            per_replication = per_replication.rename({value_column: metric_column})
+
+        return per_replication.select(SCOPE_COLUMNS + list(group_columns) + [metric_column])
+
+    def _trip_count_by_replication(
+        self,
+        *,
+        group_columns: list[str],
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+        value_column: str,
+    ) -> pl.DataFrame:
+        """Return weighted trip counts by replication."""
+        needed_demand_columns = [
+            column
+            for column in group_columns
+            if column in DEMAND_GROUP_COLUMNS
+        ]
+        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        plan_steps = add_demand_group_columns(
+            self._table("plan_steps", iterations=iterations).get(),
+            self._table("demand_groups", iterations=iterations).get(),
+            needed_demand_columns,
+        )
+        if inner_zone_residents_only:
+            plan_steps = filter_plan_steps_to_inner_zone_residents(
+                plan_steps,
+                self.results.transport_zones,
+            )
+        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
+        return (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(SCOPE_COLUMNS + list(group_columns))
+            .agg(pl.col("n_persons").cast(pl.Float64).sum().alias(value_column))
+            .pipe(
+                complete_missing_replication_groups,
+                group_columns=group_columns,
+                value_column=value_column,
+            )
+            .collect(engine="streaming")
+        )
+
+    def _weighted_quantity_by_replication(
+        self,
+        *,
+        quantity_column: str,
+        output_column: str,
+        group_columns: list[str],
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return one weighted quantity by replication."""
+        plan_steps = self._plan_steps_with_quantity(
+            quantity_column,
+            iterations=iterations,
+        )
+        needed_demand_columns = [
+            column
+            for column in group_columns
+            if column in DEMAND_GROUP_COLUMNS
+        ]
+        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if needed_demand_columns:
+            plan_steps = add_demand_group_columns(
+                plan_steps,
+                self._table("demand_groups", iterations=iterations).get(),
+                needed_demand_columns,
+            )
+        if inner_zone_residents_only:
+            plan_steps = filter_plan_steps_to_inner_zone_residents(
+                plan_steps,
+                self.results.transport_zones,
+            )
+        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
+        return (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(SCOPE_COLUMNS + list(group_columns))
+            .agg(
+                (
+                    pl.col(quantity_column).cast(pl.Float64)
+                    * pl.col("n_persons").cast(pl.Float64)
+                ).sum().alias(output_column)
+            )
+            .collect(engine="streaming")
+        )
+
+    def _with_person_count_normalization_by_replication(
+        self,
+        values: pl.DataFrame,
+        *,
+        normalize_scope: NormalizeScope | None,
+        zone_column: str | None,
+        group_columns: list[str],
+        value_column: str,
+        output_column: str,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Normalize one per-replication metric by population."""
+        if normalize_scope == "zone":
+            if zone_column is None:
+                raise ValueError('normalize_scope="zone" needs `by_zone`.')
+            values = values.with_columns(pl.col(zone_column).cast(pl.String))
+            population = self._zone_population_by_replication(
+                zone_column=zone_column,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+            join_columns = SCOPE_COLUMNS + [zone_column]
+        else:
+            population = self._total_population_by_replication(
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+            join_columns = SCOPE_COLUMNS
+
+        return (
+            values
+            .join(population, on=join_columns, how="left")
+            .with_columns(
+                pl.col(value_column).truediv(pl.col("n_persons").clip(1e-12)).alias(output_column)
+            )
+            .select(SCOPE_COLUMNS + list(group_columns) + [output_column])
+        )
+
+    @staticmethod
+    def _with_metric_total_share_by_replication(
+        values: pl.DataFrame,
+        *,
+        denominator_columns: list[str],
+        group_columns: list[str],
+        value_column: str,
+        output_column: str,
+    ) -> pl.DataFrame:
+        """Normalize one per-replication metric by its total."""
+        total_scope_columns = SCOPE_COLUMNS + list(denominator_columns)
+        return (
+            values
+            .with_columns(total=pl.col(value_column).sum().over(total_scope_columns))
+            .with_columns(
+                pl.col(value_column).truediv(pl.col("total").clip(1e-12)).alias(output_column)
+            )
+            .select(SCOPE_COLUMNS + list(group_columns) + [output_column])
+        )
+
+    def _with_person_count_normalization(
+        self,
+        values: pl.DataFrame,
+        *,
+        normalize_scope: NormalizeScope | None,
+        zone_column: str | None,
+        group_columns: list[str],
+        value_column: str,
+        output_column: str,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Normalize a metric by population at the requested scope."""
+        if normalize_scope == "zone":
+            if zone_column is None:
+                raise ValueError('normalize_scope="zone" needs `by_zone`.')
+            values = values.with_columns(pl.col(zone_column).cast(pl.String))
+            population = self._zone_population(
+                zone_column=zone_column,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+            join_columns = RESULT_COLUMNS + [zone_column]
+        else:
+            population = self._total_population(
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+            )
+            join_columns = RESULT_COLUMNS
+
+        output_columns = RESULT_COLUMNS + list(group_columns)
+        return (
+            values
+            .join(population, on=join_columns, how="left")
+            .with_columns(
+                pl.col(value_column).truediv(pl.col("n_persons").clip(1e-12)).alias(output_column),
+                pl.col(f"{value_column}_std").truediv(pl.col("n_persons").clip(1e-12)).alias(f"{output_column}_std"),
+            )
+            .select(output_columns + [output_column, f"{output_column}_std", "n_replications"])
+            .sort(output_columns)
+        )
+
+    def _with_metric_total_share(
+        self,
+        values: pl.DataFrame,
+        *,
+        denominator_columns: list[str],
+        group_columns: list[str],
+        value_column: str,
+        output_column: str,
+    ) -> pl.DataFrame:
+        """Normalize a metric by its total at the requested scope."""
+        total_scope_columns = RESULT_COLUMNS + list(denominator_columns)
+        output_columns = RESULT_COLUMNS + list(group_columns)
+        return (
+            values
+            .with_columns(
+                total=pl.col(value_column).sum().over(total_scope_columns),
+            )
+            .with_columns(
+                pl.col(value_column).truediv(pl.col("total").clip(1e-12)).alias(output_column),
+                pl.col(f"{value_column}_std").truediv(pl.col("total").clip(1e-12)).alias(f"{output_column}_std"),
+            )
+            .select(output_columns + [output_column, f"{output_column}_std", "n_replications"])
+            .sort(output_columns)
+        )
+
+    def _plan_steps_with_quantity(
+        self,
+        quantity_column: str,
+        *,
+        iterations: IterationSelector,
+    ) -> pl.LazyFrame:
+        """Return plan steps, joining costs when the requested quantity is absent."""
+        plan_steps = self._table("plan_steps", iterations=iterations).get()
+        if quantity_column in plan_steps.collect_schema().names():
+            return plan_steps
+
+        costs = self._table("costs", iterations=iterations).get()
+        join_columns = SCOPE_COLUMNS + ["from", "to", "mode"]
+        return plan_steps.join(
+            costs.select(join_columns + [quantity_column]),
+            on=join_columns,
+            how="left",
+        )
+
+    def _filter_scenarios(
+        self,
+        values: pl.DataFrame,
+        *,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+    ) -> pl.DataFrame:
+        """Filter a result table to selected scenarios."""
+        if scenarios is None:
+            return values
+        selected_scenarios = select_scenarios(self.results, scenarios)
+        return values.filter(pl.col("scenario").is_in(selected_scenarios))
+
+    def _survey_reference_marginal(self, marginal_columns: list[str]) -> SurveyReferenceMarginal:
+        """Build one cached survey-reference marginal."""
+        return SurveyReferenceMarginal(
+            comparison=SurveyReferenceComparison(
+                plan_steps=self._table("plan_steps"),
+                reference_plan_steps=self.results.survey_reference_plan_steps,
+                transport_zones=self.results.transport_zones,
+            ),
+            marginal_columns=marginal_columns,
+        )
+
+    def _country_population(self, *, iterations: IterationSelector) -> pl.DataFrame:
+        """Return population by scenario, day type, and country."""
+        zones = self.results.transport_zones.get()
+        if "geometry" in zones.columns:
+            zones = zones.drop(columns="geometry")
+        study_area = self.results.transport_zones.study_area.get()
+        if "geometry" in study_area.columns:
+            study_area = study_area.drop(columns="geometry")
+
+        zone_country = (
+            pl.from_pandas(zones)
+            .filter(pl.col("is_inner_zone"))
+            .join(
+                pl.from_pandas(study_area)
+                .select([
+                    "local_admin_unit_id",
+                    pl.col("country").cast(pl.String),
+                ]),
+                on="local_admin_unit_id",
+                how="left",
+            )
+            .select([
+                pl.col("transport_zone_id").cast(pl.String).alias("home_zone_id"),
+                pl.col("country").cast(pl.String),
+            ])
+        )
+        demand_groups = self._table("demand_groups", iterations=iterations).get().with_columns(
+            pl.col("home_zone_id").cast(pl.String)
+        )
+        return (
+            demand_groups
+            .join(zone_country.lazy(), on="home_zone_id", how="inner")
+            .group_by(SCOPE_COLUMNS + ["country"])
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+            .group_by(RESULT_COLUMNS + ["country"])
+            .agg(n_persons=pl.col("n_persons").mean())
+            .with_columns(pl.col("country").cast(pl.String))
+            .collect(engine="streaming")
+        )
+
+    def _total_population(
+        self,
+        *,
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return total population by scenario and day type."""
+        demand_groups = self._table("demand_groups", iterations=iterations).get()
+        if inner_zone_residents_only:
+            demand_groups = filter_demand_groups_to_inner_zone_residents(
+                demand_groups,
+                self.results.transport_zones,
+            )
+        return (
+            demand_groups
+            .group_by(SCOPE_COLUMNS)
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+            .group_by(RESULT_COLUMNS)
+            .agg(n_persons=pl.col("n_persons").mean())
+            .collect(engine="streaming")
+        )
+
+    def _total_population_by_replication(
+        self,
+        *,
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return total population by scenario, day type, iteration, and replication."""
+        demand_groups = self._table("demand_groups", iterations=iterations).get()
+        if inner_zone_residents_only:
+            demand_groups = filter_demand_groups_to_inner_zone_residents(
+                demand_groups,
+                self.results.transport_zones,
+            )
+        return (
+            demand_groups
+            .group_by(SCOPE_COLUMNS)
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+            .collect(engine="streaming")
+        )
+
+    def _zone_population(
+        self,
+        *,
+        zone_column: str,
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return resident population by transport zone."""
+        demand_groups = self._table("demand_groups", iterations=iterations).get()
+        if inner_zone_residents_only:
+            demand_groups = filter_demand_groups_to_inner_zone_residents(
+                demand_groups,
+                self.results.transport_zones,
+            )
+        return (
+            demand_groups
+            .with_columns(pl.col("home_zone_id").cast(pl.String).alias(zone_column))
+            .group_by(SCOPE_COLUMNS + [zone_column])
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+            .group_by(RESULT_COLUMNS + [zone_column])
+            .agg(n_persons=pl.col("n_persons").mean())
+            .collect(engine="streaming")
+        )
+
+    def _zone_population_by_replication(
+        self,
+        *,
+        zone_column: str,
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return resident population by transport zone and replication."""
+        demand_groups = self._table("demand_groups", iterations=iterations).get()
+        if inner_zone_residents_only:
+            demand_groups = filter_demand_groups_to_inner_zone_residents(
+                demand_groups,
+                self.results.transport_zones,
+            )
+        return (
+            demand_groups
+            .with_columns(pl.col("home_zone_id").cast(pl.String).alias(zone_column))
+            .group_by(SCOPE_COLUMNS + [zone_column])
+            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
+            .collect(engine="streaming")
+        )
+
+    def _survey_immobility(self) -> pl.DataFrame:
+        """Return survey immobility probabilities by country and CSP."""
+        column_name = "immobility_weekday" if self.results.is_weekday else "immobility_weekend"
+        survey_tables = [
+            pl.DataFrame(survey.get()["p_immobility"].reset_index()).with_columns(
+                country=pl.lit(survey.inputs["parameters"].country, dtype=pl.String)
+            )
+            for survey in self.results.surveys
+        ]
+        if not survey_tables:
+            raise ValueError("Immobility needs at least one survey with immobility probabilities.")
+        return (
+            pl.concat(survey_tables, how="vertical_relaxed")
+            .with_columns(
+                country=pl.col("country").cast(pl.String),
+                csp=pl.col("csp").cast(pl.String),
+                p_immobility_ref=pl.col(column_name).cast(pl.Float64),
+            )
+            .select(["country", "csp", "p_immobility_ref"])
+        )
+
+    def _trip_count(
+        self,
+        *,
+        output_column: str,
+        group_columns: list[str],
+        per_person: bool,
+        inner_zone_residents_only: bool = False,
+        iterations: IterationSelector = "last",
+    ) -> TripCountMetric:
+        """Build one cached trip-count asset."""
+        return TripCountMetric(
+            plan_steps=self._table("plan_steps", iterations=iterations),
+            demand_groups=self._table("demand_groups", iterations=iterations),
+            transport_zones=self.results.transport_zones,
+            output_column=output_column,
+            group_columns=group_columns,
+            per_person=per_person,
+            inner_zone_residents_only=inner_zone_residents_only,
+        )
+
+    @staticmethod
+    def _zone_column(by_zone: ZoneDimension) -> str:
+        """Return the plan-step/demand-group column for one zone dimension."""
+        if by_zone == "home_zone":
+            return "home_zone_id"
+        if by_zone == "origin_zone":
+            return "origin_zone_id"
+        if by_zone == "destination_zone":
+            return "destination_zone_id"
+        raise ValueError(
+            "by_zone should be one of: 'home_zone', 'origin_zone', "
+            f"'destination_zone'. Received {by_zone!r}."
+        )
+
+    @staticmethod
+    def _zone_columns(by_zone: ZoneDimensions | None) -> list[str]:
+        """Return public zone-id columns for requested zone dimensions."""
+        if by_zone is None:
+            return []
+        if isinstance(by_zone, str):
+            zone_dimensions = [by_zone]
+        elif isinstance(by_zone, (list, tuple)):
+            zone_dimensions = list(by_zone)
+        else:
+            raise TypeError("by_zone should be None, one zone dimension, or a list of zone dimensions.")
+        if not zone_dimensions:
+            raise ValueError("by_zone should not be an empty list.")
+        duplicate_zones = sorted(
+            zone
+            for zone in set(zone_dimensions)
+            if zone_dimensions.count(zone) > 1
+        )
+        if duplicate_zones:
+            raise ValueError(
+                "by_zone should not contain duplicate dimensions. "
+                f"Received duplicates: {duplicate_zones}."
+            )
+        return [
+            GroupDayTripsResultMetrics._zone_column(zone)
+            for zone in zone_dimensions
+        ]
+
+    @staticmethod
+    def _variable_column(by_variable: VariableDimension) -> str:
+        """Return the plan-step column for one non-spatial dimension."""
+        if by_variable in {"mode", "activity", "distance_bin", "time_bin", "csp"}:
+            return by_variable
+        raise ValueError(
+            "by_variable should be one of: 'activity', 'csp', 'distance_bin', "
+            f"'mode', 'time_bin'. Received {by_variable!r}."
+        )
+
+    @staticmethod
+    def _denominator_columns(
+        *,
+        normalize_scope: NormalizeScope | None,
+        zone_column: str | None,
+    ) -> list[str]:
+        """Return extra denominator grouping columns for metric-total shares."""
+        if normalize_scope == "zone":
+            if zone_column is None:
+                raise ValueError('normalize_scope="zone" needs `by_zone`.')
+            return [zone_column]
+        return []
+
+    @staticmethod
+    def _reference_kind(reference: MetricReference) -> Literal["none", "external", "scenario"]:
+        """Return the kind of reference requested by a metric call."""
+        if reference is None:
+            return "none"
+        if reference == "external":
+            return "external"
+        if (
+            isinstance(reference, tuple)
+            and len(reference) == 2
+            and reference[0] == "scenario"
+            and isinstance(reference[1], str)
+        ):
+            return "scenario"
+        raise ValueError('reference should be None, "external", or ("scenario", scenario_name).')
+
+    @staticmethod
+    def _reference_scenario(reference: MetricReference) -> str:
+        """Return the scenario name from a scenario reference selector."""
+        if (
+            isinstance(reference, tuple)
+            and len(reference) == 2
+            and reference[0] == "scenario"
+            and isinstance(reference[1], str)
+        ):
+            return reference[1]
+        raise ValueError('reference should be None, "external", or ("scenario", scenario_name).')
+
+    @staticmethod
+    def _metric_column(quantity: str, normalize_by: NormalizeBy | None) -> str:
+        """Return the public value column name."""
+        if normalize_by is None:
+            return quantity
+        if normalize_by == "person_count":
+            return f"{quantity}_per_person"
+        return f"{quantity}_share"
+
+    @staticmethod
+    def _activity_duration_expr(schema: set[str]) -> pl.Expr:
+        """Return total person-hours for one activity step."""
+        if "duration" in schema:
+            return pl.col("duration").cast(pl.Float64)
+        if {"duration_per_pers", "n_persons"} <= schema:
+            return (
+                pl.col("duration_per_pers").cast(pl.Float64)
+                * pl.col("n_persons").cast(pl.Float64)
+            )
+        raise ValueError(
+            "Opportunity occupation needs plan steps with `duration` or "
+            "`duration_per_pers` and `n_persons`."
+        )
+
+    @staticmethod
+    def _title(
+        quantity: str,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+        normalize_by: NormalizeBy | None,
+    ) -> str:
+        """Return a simple plot title."""
+        label = GroupDayTripsResultMetrics._metric_column(quantity, normalize_by).replace("_", " ")
+        zone_dimensions = []
+        if isinstance(by_zone, str):
+            zone_dimensions = [by_zone]
+        elif isinstance(by_zone, (list, tuple)):
+            zone_dimensions = list(by_zone)
+        dimensions = [
+            value.replace("_", " ")
+            for value in zone_dimensions + ([by_variable] if by_variable is not None else [])
+            if value is not None
+        ]
+        if not dimensions:
+            return label.capitalize()
+        return f"{label.capitalize()} by {' and '.join(dimensions)}"
+
+    @staticmethod
+    def _plot_title(
+        quantity: str,
+        *,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+        normalize_by: NormalizeBy | None,
+        reference_kind: Literal["none", "external", "scenario"],
+        reference_view: ReferenceView,
+    ) -> str:
+        """Return the plot title for direct metrics or reference gaps."""
+        title = GroupDayTripsResultMetrics._title(
+            quantity,
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+        )
+        if reference_kind == "none":
+            return title
+        if reference_view == "values":
+            return f"Metric and reference: {title}"
+        return f"Gap to reference: {title}"
+
+    @staticmethod
+    def _validate_reference_view(
+        reference_view: ReferenceView,
+        *,
+        reference_kind: Literal["none", "external", "scenario"],
+    ) -> None:
+        """Check how reference values should be returned."""
+        if reference_view not in {"gap", "values"}:
+            raise ValueError('reference_view should be either "gap" or "values".')
+        if reference_kind == "none" and reference_view != "gap":
+            raise ValueError('reference_view="values" needs a reference.')
+
+    @staticmethod
+    def _validate_grouping(
+        *,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+    ) -> None:
+        """Check that requested grouping dimensions are supported."""
+        GroupDayTripsResultMetrics._zone_columns(by_zone)
+        if by_variable is not None:
+            GroupDayTripsResultMetrics._variable_column(by_variable)
+
+    @staticmethod
+    def _validate_normalization(
+        *,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+    ) -> None:
+        """Check that the requested normalization is supported."""
+        zone_columns = GroupDayTripsResultMetrics._zone_columns(by_zone)
+        if normalize_by is None:
+            if normalize_scope is not None:
+                raise ValueError("normalize_scope should be None when normalize_by is None.")
+            return
+        if len(zone_columns) > 1:
+            raise ValueError("Normalization is not supported when grouping by multiple zone dimensions.")
+        if normalize_by not in {"person_count", "metric_total"}:
+            raise ValueError('normalize_by should be None, "person_count", or "metric_total".')
+        if normalize_scope not in {"zone", "study_area"}:
+            raise ValueError('normalize_scope should be "zone" or "study_area" when normalize_by is set.')
+        if normalize_scope == "zone" and by_zone is None:
+            raise ValueError('normalize_scope="zone" needs `by_zone`.')
+        if normalize_by == "metric_total" and by_zone is None and by_variable is None:
+            raise ValueError('normalize_by="metric_total" needs `by_zone` or `by_variable`.')

--- a/mobility/trips/group_day_trips/results/metrics.py
+++ b/mobility/trips/group_day_trips/results/metrics.py
@@ -1469,14 +1469,16 @@ class GroupDayTripsResultMetrics:
             if zone_column is None:
                 raise ValueError('normalize_scope="zone" needs `by_zone`.')
             values = values.with_columns(pl.col(zone_column).cast(pl.String))
-            population = self._zone_population_by_replication(
+            population = self._population(
                 zone_column=zone_column,
+                by_replication=True,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
             )
             join_columns = SCOPE_COLUMNS + [zone_column]
         else:
-            population = self._total_population_by_replication(
+            population = self._population(
+                by_replication=True,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
             )
@@ -1528,14 +1530,14 @@ class GroupDayTripsResultMetrics:
             if zone_column is None:
                 raise ValueError('normalize_scope="zone" needs `by_zone`.')
             values = values.with_columns(pl.col(zone_column).cast(pl.String))
-            population = self._zone_population(
+            population = self._population(
                 zone_column=zone_column,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
             )
             join_columns = RESULT_COLUMNS + [zone_column]
         else:
-            population = self._total_population(
+            population = self._population(
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
             )
@@ -1660,91 +1662,40 @@ class GroupDayTripsResultMetrics:
             .collect(engine="streaming")
         )
 
-    def _total_population(
+    def _population(
         self,
         *,
+        zone_column: str | None = None,
+        by_replication: bool = False,
         inner_zone_residents_only: bool = False,
         iterations: IterationSelector,
     ) -> pl.DataFrame:
-        """Return total population by scenario and day type."""
+        """Return resident population for the requested result scope."""
         demand_groups = self._table("demand_groups", iterations=iterations).get()
         if inner_zone_residents_only:
             demand_groups = filter_demand_groups_to_inner_zone_residents(
                 demand_groups,
                 self.results.transport_zones,
             )
-        return (
+        extra_columns = []
+        if zone_column is not None:
+            extra_columns.append(zone_column)
+            demand_groups = demand_groups.with_columns(
+                pl.col("home_zone_id").cast(pl.String).alias(zone_column)
+            )
+
+        per_replication = (
             demand_groups
-            .group_by(SCOPE_COLUMNS)
+            .group_by(SCOPE_COLUMNS + extra_columns)
             .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
-            .group_by(RESULT_COLUMNS)
+        )
+        if by_replication:
+            return per_replication.collect(engine="streaming")
+
+        return (
+            per_replication
+            .group_by(RESULT_COLUMNS + extra_columns)
             .agg(n_persons=pl.col("n_persons").mean())
-            .collect(engine="streaming")
-        )
-
-    def _total_population_by_replication(
-        self,
-        *,
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector,
-    ) -> pl.DataFrame:
-        """Return total population by scenario, day type, iteration, and replication."""
-        demand_groups = self._table("demand_groups", iterations=iterations).get()
-        if inner_zone_residents_only:
-            demand_groups = filter_demand_groups_to_inner_zone_residents(
-                demand_groups,
-                self.results.transport_zones,
-            )
-        return (
-            demand_groups
-            .group_by(SCOPE_COLUMNS)
-            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
-            .collect(engine="streaming")
-        )
-
-    def _zone_population(
-        self,
-        *,
-        zone_column: str,
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector,
-    ) -> pl.DataFrame:
-        """Return resident population by transport zone."""
-        demand_groups = self._table("demand_groups", iterations=iterations).get()
-        if inner_zone_residents_only:
-            demand_groups = filter_demand_groups_to_inner_zone_residents(
-                demand_groups,
-                self.results.transport_zones,
-            )
-        return (
-            demand_groups
-            .with_columns(pl.col("home_zone_id").cast(pl.String).alias(zone_column))
-            .group_by(SCOPE_COLUMNS + [zone_column])
-            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
-            .group_by(RESULT_COLUMNS + [zone_column])
-            .agg(n_persons=pl.col("n_persons").mean())
-            .collect(engine="streaming")
-        )
-
-    def _zone_population_by_replication(
-        self,
-        *,
-        zone_column: str,
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector,
-    ) -> pl.DataFrame:
-        """Return resident population by transport zone and replication."""
-        demand_groups = self._table("demand_groups", iterations=iterations).get()
-        if inner_zone_residents_only:
-            demand_groups = filter_demand_groups_to_inner_zone_residents(
-                demand_groups,
-                self.results.transport_zones,
-            )
-        return (
-            demand_groups
-            .with_columns(pl.col("home_zone_id").cast(pl.String).alias(zone_column))
-            .group_by(SCOPE_COLUMNS + [zone_column])
-            .agg(n_persons=pl.col("n_persons").cast(pl.Float64).sum())
             .collect(engine="streaming")
         )
 

--- a/mobility/trips/group_day_trips/results/metrics.py
+++ b/mobility/trips/group_day_trips/results/metrics.py
@@ -1255,29 +1255,12 @@ class GroupDayTripsResultMetrics:
         iterations: IterationSelector,
     ) -> pl.DataFrame:
         """Return an absolute weighted quantity averaged over replications."""
-        plan_steps = self._plan_steps_with_quantity(
-            quantity_column,
+        plan_steps = self._metric_plan_steps(
+            quantity_column=quantity_column,
+            group_columns=group_columns,
+            inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
         )
-        needed_demand_columns = [
-            column
-            for column in group_columns
-            if column in DEMAND_GROUP_COLUMNS
-        ]
-        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
-            needed_demand_columns.append("home_zone_id")
-        if needed_demand_columns:
-            plan_steps = add_demand_group_columns(
-                plan_steps,
-                self._table("demand_groups", iterations=iterations).get(),
-                needed_demand_columns,
-            )
-        if inner_zone_residents_only:
-            plan_steps = filter_plan_steps_to_inner_zone_residents(
-                plan_steps,
-                self.results.transport_zones,
-            )
-        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
         required_columns = set(SCOPE_COLUMNS + group_columns + ["activity_seq_id", quantity_column, "n_persons"])
         missing_columns = required_columns.difference(plan_steps.collect_schema().names())
         if missing_columns:
@@ -1375,24 +1358,11 @@ class GroupDayTripsResultMetrics:
         value_column: str,
     ) -> pl.DataFrame:
         """Return weighted trip counts by replication."""
-        needed_demand_columns = [
-            column
-            for column in group_columns
-            if column in DEMAND_GROUP_COLUMNS
-        ]
-        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
-            needed_demand_columns.append("home_zone_id")
-        plan_steps = add_demand_group_columns(
-            self._table("plan_steps", iterations=iterations).get(),
-            self._table("demand_groups", iterations=iterations).get(),
-            needed_demand_columns,
+        plan_steps = self._metric_plan_steps(
+            group_columns=group_columns,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
         )
-        if inner_zone_residents_only:
-            plan_steps = filter_plan_steps_to_inner_zone_residents(
-                plan_steps,
-                self.results.transport_zones,
-            )
-        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
         return (
             plan_steps
             .filter(pl.col("activity_seq_id") != 0)
@@ -1416,10 +1386,41 @@ class GroupDayTripsResultMetrics:
         iterations: IterationSelector,
     ) -> pl.DataFrame:
         """Return one weighted quantity by replication."""
-        plan_steps = self._plan_steps_with_quantity(
-            quantity_column,
+        plan_steps = self._metric_plan_steps(
+            quantity_column=quantity_column,
+            group_columns=group_columns,
+            inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
         )
+        return (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .group_by(SCOPE_COLUMNS + list(group_columns))
+            .agg(
+                (
+                    pl.col(quantity_column).cast(pl.Float64)
+                    * pl.col("n_persons").cast(pl.Float64)
+                ).sum().alias(output_column)
+            )
+            .collect(engine="streaming")
+        )
+
+    def _metric_plan_steps(
+        self,
+        *,
+        quantity_column: str | None = None,
+        group_columns: list[str],
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+    ) -> pl.LazyFrame:
+        """Return plan steps with the columns needed by metric queries."""
+        if quantity_column is None:
+            plan_steps = self._table("plan_steps", iterations=iterations).get()
+        else:
+            plan_steps = self._plan_steps_with_quantity(
+                quantity_column,
+                iterations=iterations,
+            )
         needed_demand_columns = [
             column
             for column in group_columns
@@ -1438,19 +1439,7 @@ class GroupDayTripsResultMetrics:
                 plan_steps,
                 self.results.transport_zones,
             )
-        plan_steps = with_analysis_dimensions(plan_steps, group_columns)
-        return (
-            plan_steps
-            .filter(pl.col("activity_seq_id") != 0)
-            .group_by(SCOPE_COLUMNS + list(group_columns))
-            .agg(
-                (
-                    pl.col(quantity_column).cast(pl.Float64)
-                    * pl.col("n_persons").cast(pl.Float64)
-                ).sum().alias(output_column)
-            )
-            .collect(engine="streaming")
-        )
+        return with_analysis_dimensions(plan_steps, group_columns)
 
     def _with_person_count_normalization_by_replication(
         self,

--- a/mobility/trips/group_day_trips/results/metrics.py
+++ b/mobility/trips/group_day_trips/results/metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 import polars as pl
@@ -36,6 +37,7 @@ from .plots import (
 ZoneDimension = Literal["home_zone", "origin_zone", "destination_zone"]
 ZoneDimensions = ZoneDimension | list[ZoneDimension] | tuple[ZoneDimension, ...]
 VariableDimension = Literal["mode", "activity", "distance_bin", "time_bin", "csp"]
+MetricName = Literal["trip_count", "travel_distance", "travel_time", "cost", "ghg_emissions"]
 MetricOutput = Literal["table", "plot"]
 NormalizeBy = Literal["person_count", "metric_total"]
 NormalizeScope = Literal["zone", "study_area"]
@@ -44,6 +46,44 @@ MetricReference = Literal["external"] | tuple[Literal["scenario"], str] | None
 ReferenceView = Literal["gap", "values"]
 
 REFERENCE_DIMENSIONS = {"mode", "activity", "distance_bin", "time_bin"}
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """Definition of one simple trip metric exposed by the public API."""
+
+    quantity: str
+    quantity_column: str | None
+    indicator: str | None
+
+
+METRIC_SPECS: dict[MetricName, MetricSpec] = {
+    "trip_count": MetricSpec(
+        quantity="trip_count",
+        quantity_column=None,
+        indicator="trip_count",
+    ),
+    "travel_distance": MetricSpec(
+        quantity="travel_distance",
+        quantity_column="distance",
+        indicator="travel_distance",
+    ),
+    "travel_time": MetricSpec(
+        quantity="travel_time",
+        quantity_column="time",
+        indicator="travel_time",
+    ),
+    "cost": MetricSpec(
+        quantity="cost",
+        quantity_column="cost",
+        indicator=None,
+    ),
+    "ghg_emissions": MetricSpec(
+        quantity="ghg_emissions",
+        quantity_column="ghg_emissions_per_trip",
+        indicator=None,
+    ),
+}
 
 
 class GroupDayTripsResultMetrics:
@@ -61,8 +101,9 @@ class GroupDayTripsResultMetrics:
             iterations=iterations,
         )
 
-    def trip_count(
+    def metric(
         self,
+        name: MetricName,
         *,
         by_zone: ZoneDimensions | None = None,
         by_variable: VariableDimension | None = None,
@@ -83,218 +124,57 @@ class GroupDayTripsResultMetrics:
         max_line_width: float = 8.0,
         min_line_width: float = 0.1,
     ) -> pl.DataFrame:
+        """Return one simple trip metric, optionally split and normalized."""
+        if name not in METRIC_SPECS:
+            raise ValueError(
+                "Unknown metric name. Expected one of: "
+                + ", ".join(sorted(METRIC_SPECS))
+                + "."
+            )
+        spec = METRIC_SPECS[name]
+        return self._metric(
+            quantity=spec.quantity,
+            quantity_column=spec.quantity_column,
+            indicator=spec.indicator,
+            by_zone=by_zone,
+            by_variable=by_variable,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            reference=reference,
+            reference_view=reference_view,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+            output=output,
+            scenarios=scenarios,
+            width=width,
+            height=height,
+            labels=labels,
+            n_largest=n_largest,
+            min_value=min_value,
+            min_share=min_share,
+            max_line_width=max_line_width,
+            min_line_width=min_line_width,
+        )
+
+    def trip_count(self, **kwargs) -> pl.DataFrame:
         """Return trip counts, optionally split and normalized."""
-        return self._metric(
-            quantity="trip_count",
-            quantity_column=None,
-            indicator="trip_count",
-            by_zone=by_zone,
-            by_variable=by_variable,
-            normalize_by=normalize_by,
-            normalize_scope=normalize_scope,
-            reference=reference,
-            reference_view=reference_view,
-            inner_zone_residents_only=inner_zone_residents_only,
-            iterations=iterations,
-            output=output,
-            scenarios=scenarios,
-            width=width,
-            height=height,
-            labels=labels,
-            n_largest=n_largest,
-            min_value=min_value,
-            min_share=min_share,
-            max_line_width=max_line_width,
-            min_line_width=min_line_width,
-        )
+        return self.metric("trip_count", **kwargs)
 
-    def travel_distance(
-        self,
-        *,
-        by_zone: ZoneDimensions | None = None,
-        by_variable: VariableDimension | None = None,
-        normalize_by: NormalizeBy | None = None,
-        normalize_scope: NormalizeScope | None = None,
-        reference: MetricReference = None,
-        reference_view: ReferenceView = "gap",
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector = "last",
-        output: MetricOutput = "table",
-        scenarios: str | list[str] | tuple[str, ...] | None = None,
-        width: int = 760,
-        height: int = 460,
-        labels: bool = True,
-        n_largest: int | None = None,
-        min_value: float | None = None,
-        min_share: float | None = None,
-        max_line_width: float = 8.0,
-        min_line_width: float = 0.1,
-    ) -> pl.DataFrame:
+    def travel_distance(self, **kwargs) -> pl.DataFrame:
         """Return travelled distance, optionally split and normalized."""
-        return self._metric(
-            quantity="travel_distance",
-            quantity_column="distance",
-            indicator="travel_distance",
-            by_zone=by_zone,
-            by_variable=by_variable,
-            normalize_by=normalize_by,
-            normalize_scope=normalize_scope,
-            reference=reference,
-            reference_view=reference_view,
-            inner_zone_residents_only=inner_zone_residents_only,
-            iterations=iterations,
-            output=output,
-            scenarios=scenarios,
-            width=width,
-            height=height,
-            labels=labels,
-            n_largest=n_largest,
-            min_value=min_value,
-            min_share=min_share,
-            max_line_width=max_line_width,
-            min_line_width=min_line_width,
-        )
+        return self.metric("travel_distance", **kwargs)
 
-    def travel_time(
-        self,
-        *,
-        by_zone: ZoneDimensions | None = None,
-        by_variable: VariableDimension | None = None,
-        normalize_by: NormalizeBy | None = None,
-        normalize_scope: NormalizeScope | None = None,
-        reference: MetricReference = None,
-        reference_view: ReferenceView = "gap",
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector = "last",
-        output: MetricOutput = "table",
-        scenarios: str | list[str] | tuple[str, ...] | None = None,
-        width: int = 760,
-        height: int = 460,
-        labels: bool = True,
-        n_largest: int | None = None,
-        min_value: float | None = None,
-        min_share: float | None = None,
-        max_line_width: float = 8.0,
-        min_line_width: float = 0.1,
-    ) -> pl.DataFrame:
+    def travel_time(self, **kwargs) -> pl.DataFrame:
         """Return travelled time, optionally split and normalized."""
-        return self._metric(
-            quantity="travel_time",
-            quantity_column="time",
-            indicator="travel_time",
-            by_zone=by_zone,
-            by_variable=by_variable,
-            normalize_by=normalize_by,
-            normalize_scope=normalize_scope,
-            reference=reference,
-            reference_view=reference_view,
-            inner_zone_residents_only=inner_zone_residents_only,
-            iterations=iterations,
-            output=output,
-            scenarios=scenarios,
-            width=width,
-            height=height,
-            labels=labels,
-            n_largest=n_largest,
-            min_value=min_value,
-            min_share=min_share,
-            max_line_width=max_line_width,
-            min_line_width=min_line_width,
-        )
+        return self.metric("travel_time", **kwargs)
 
-    def cost(
-        self,
-        *,
-        by_zone: ZoneDimensions | None = None,
-        by_variable: VariableDimension | None = None,
-        normalize_by: NormalizeBy | None = None,
-        normalize_scope: NormalizeScope | None = None,
-        reference: MetricReference = None,
-        reference_view: ReferenceView = "gap",
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector = "last",
-        output: MetricOutput = "table",
-        scenarios: str | list[str] | tuple[str, ...] | None = None,
-        width: int = 760,
-        height: int = 460,
-        labels: bool = True,
-        n_largest: int | None = None,
-        min_value: float | None = None,
-        min_share: float | None = None,
-        max_line_width: float = 8.0,
-        min_line_width: float = 0.1,
-    ) -> pl.DataFrame:
+    def cost(self, **kwargs) -> pl.DataFrame:
         """Return travelled cost, optionally split and normalized."""
-        return self._metric(
-            quantity="cost",
-            quantity_column="cost",
-            indicator=None,
-            by_zone=by_zone,
-            by_variable=by_variable,
-            normalize_by=normalize_by,
-            normalize_scope=normalize_scope,
-            reference=reference,
-            reference_view=reference_view,
-            inner_zone_residents_only=inner_zone_residents_only,
-            iterations=iterations,
-            output=output,
-            scenarios=scenarios,
-            width=width,
-            height=height,
-            labels=labels,
-            n_largest=n_largest,
-            min_value=min_value,
-            min_share=min_share,
-            max_line_width=max_line_width,
-            min_line_width=min_line_width,
-        )
+        return self.metric("cost", **kwargs)
 
-    def ghg_emissions(
-        self,
-        *,
-        by_zone: ZoneDimensions | None = None,
-        by_variable: VariableDimension | None = None,
-        normalize_by: NormalizeBy | None = None,
-        normalize_scope: NormalizeScope | None = None,
-        reference: MetricReference = None,
-        reference_view: ReferenceView = "gap",
-        inner_zone_residents_only: bool = False,
-        iterations: IterationSelector = "last",
-        output: MetricOutput = "table",
-        scenarios: str | list[str] | tuple[str, ...] | None = None,
-        width: int = 760,
-        height: int = 460,
-        labels: bool = True,
-        n_largest: int | None = None,
-        min_value: float | None = None,
-        min_share: float | None = None,
-        max_line_width: float = 8.0,
-        min_line_width: float = 0.1,
-    ) -> pl.DataFrame:
+    def ghg_emissions(self, **kwargs) -> pl.DataFrame:
         """Return greenhouse gas emissions, optionally split and normalized."""
-        return self._metric(
-            quantity="ghg_emissions",
-            quantity_column="ghg_emissions_per_trip",
-            indicator=None,
-            by_zone=by_zone,
-            by_variable=by_variable,
-            normalize_by=normalize_by,
-            normalize_scope=normalize_scope,
-            reference=reference,
-            reference_view=reference_view,
-            inner_zone_residents_only=inner_zone_residents_only,
-            iterations=iterations,
-            output=output,
-            scenarios=scenarios,
-            width=width,
-            height=height,
-            labels=labels,
-            n_largest=n_largest,
-            min_value=min_value,
-            min_share=min_share,
-            max_line_width=max_line_width,
-            min_line_width=min_line_width,
-        )
+        return self.metric("ghg_emissions", **kwargs)
 
     def immobility(
         self,

--- a/mobility/trips/group_day_trips/results/plots.py
+++ b/mobility/trips/group_day_trips/results/plots.py
@@ -1,0 +1,858 @@
+from __future__ import annotations
+
+import plotly.graph_objects as go
+import polars as pl
+import plotly.express as px
+from plotly.subplots import make_subplots
+
+from mobility.reports.theme import MOBILITY_COLORS, apply_report_layout
+
+SCENARIO_COLORS = [
+    MOBILITY_COLORS["model"],
+    "#2B6CB0",
+    "#2F855A",
+    "#805AD5",
+    "#B7791F",
+    "#319795",
+]
+REFERENCE_COLOR = "#8A8F98"
+
+
+def validate_output(output: str) -> None:
+    """Check that a result method output is supported."""
+    if output not in {"table", "plot"}:
+        raise ValueError('output should be either "table" or "plot".')
+
+
+def plot_metric_by_dimension(
+    values: pl.DataFrame,
+    *,
+    dimension: str,
+    metric: str,
+    yaxis_title: str,
+    title: str,
+    scenarios: str | list[str] | tuple[str, ...] | None = None,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 760,
+    height: int = 460,
+) -> go.Figure:
+    """Plot one metric by an analysis dimension and scenario."""
+    if f"{metric}_reference" in values.columns:
+        return plot_reference_metric_by_dimension(
+            values,
+            dimension=dimension,
+            metric=metric,
+            title=title,
+            scenarios=scenarios,
+            scenario_titles=scenario_titles,
+            width=width,
+            height=height,
+        )
+
+    if "series" in values.columns:
+        return plot_metric_series_by_dimension(
+            values,
+            dimension=dimension,
+            metric=metric,
+            yaxis_title=yaxis_title,
+            title=title,
+            scenarios=scenarios,
+            scenario_titles=scenario_titles,
+            width=width,
+            height=height,
+        )
+
+    if scenarios is not None:
+        selected_scenarios = _selected_scenarios_from_values(values, scenarios)
+        values = values.filter(pl.col("scenario").is_in(selected_scenarios))
+    else:
+        selected_scenarios = values["scenario"].unique(maintain_order=True).to_list()
+
+    scenario_labels = _scenario_label_map(selected_scenarios, scenario_titles)
+    dimensions = values[dimension].unique(maintain_order=True).to_list()
+    labels = [_dimension_label(value) for value in dimensions]
+    fig = go.Figure()
+    for scenario_index, scenario in enumerate(selected_scenarios):
+        scenario_values = values.filter(pl.col("scenario") == scenario)
+        metric_values = dict(
+            zip(
+                scenario_values[dimension].to_list(),
+                scenario_values[metric].to_list(),
+            )
+        )
+        metric_errors = dict(
+            zip(
+                scenario_values[dimension].to_list(),
+                scenario_values[f"{metric}_std"].to_list(),
+            )
+        )
+        fig.add_bar(
+            x=labels,
+            y=[metric_values.get(value, 0.0) for value in dimensions],
+            error_y={
+                "type": "data",
+                "array": [metric_errors.get(value) for value in dimensions],
+                "visible": True,
+            },
+            marker_color=_scenario_color(scenario_index),
+            name=scenario_labels[scenario],
+        )
+    _apply_vertical_bar_layout(
+        fig,
+        labels=labels,
+        title=title,
+        width=width,
+        height=height,
+        yaxis_title=yaxis_title,
+        showlegend=True,
+    )
+    if metric.endswith("_share"):
+        fig.update_yaxes(tickformat=".0%")
+    return fig
+
+
+def plot_metric_series_by_dimension(
+    values: pl.DataFrame,
+    *,
+    dimension: str,
+    metric: str,
+    yaxis_title: str,
+    title: str,
+    scenarios: str | list[str] | tuple[str, ...] | None = None,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 760,
+    height: int = 460,
+) -> go.Figure:
+    """Plot model and reference value rows by dimension."""
+    if scenarios is not None:
+        selected_scenarios = _selected_scenarios_from_values(values, scenarios)
+        values = values.filter(pl.col("scenario").is_in(selected_scenarios))
+    else:
+        selected_scenarios = values["scenario"].unique(maintain_order=True).to_list()
+
+    scenario_labels = _scenario_label_map(selected_scenarios, scenario_titles)
+    dimensions = values[dimension].unique(maintain_order=True).to_list()
+    labels = [_dimension_label(value) for value in dimensions]
+    std_column = f"{metric}_std"
+    fig = go.Figure()
+    reference_rows = values.filter(pl.col("series") == "reference")
+    if not reference_rows.is_empty():
+        aggregate_expressions = [pl.col(metric).mean().alias(metric)]
+        if std_column in reference_rows.columns:
+            aggregate_expressions.append(pl.col(std_column).mean().alias(std_column))
+        reference_values = reference_rows.group_by(dimension).agg(aggregate_expressions)
+        metric_values = dict(zip(reference_values[dimension].to_list(), reference_values[metric].to_list()))
+        if std_column in reference_values.columns:
+            metric_errors = dict(zip(reference_values[dimension].to_list(), reference_values[std_column].to_list()))
+            error_values = [metric_errors.get(value) for value in dimensions]
+            error_y = {
+                "type": "data",
+                "array": error_values,
+                "visible": any(value is not None for value in error_values),
+            }
+        else:
+            error_y = None
+        fig.add_bar(
+            x=labels,
+            y=[metric_values.get(value, 0.0) for value in dimensions],
+            error_y=error_y,
+            marker_color=REFERENCE_COLOR,
+            name="Reference",
+        )
+
+    for scenario_index, scenario in enumerate(selected_scenarios):
+        trace_values = values.filter(
+            (pl.col("scenario") == scenario)
+            & (pl.col("series") == "model")
+        )
+        if trace_values.is_empty():
+            continue
+        metric_values = dict(zip(trace_values[dimension].to_list(), trace_values[metric].to_list()))
+        if std_column in trace_values.columns:
+            metric_errors = dict(zip(trace_values[dimension].to_list(), trace_values[std_column].to_list()))
+            error_y = {
+                "type": "data",
+                "array": [metric_errors.get(value) for value in dimensions],
+                "visible": True,
+            }
+        else:
+            error_y = None
+        fig.add_bar(
+            x=labels,
+            y=[metric_values.get(value, 0.0) for value in dimensions],
+            error_y=error_y,
+            marker_color=_scenario_color(scenario_index),
+            name=scenario_labels[scenario],
+        )
+
+    _apply_vertical_bar_layout(
+        fig,
+        labels=labels,
+        title=title,
+        width=width,
+        height=height,
+        yaxis_title=yaxis_title,
+        showlegend=True,
+    )
+    if metric.endswith("_share"):
+        fig.update_yaxes(tickformat=".0%")
+    return fig
+
+
+def plot_metric_over_iterations(
+    values: pl.DataFrame,
+    *,
+    metric: str,
+    title: str,
+    dimension_columns: list[str],
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 760,
+    height: int = 460,
+) -> go.Figure:
+    """Plot one metric over model iterations."""
+    if values.is_empty():
+        raise ValueError("No rows are available to plot.")
+
+    selected_scenarios = values["scenario"].unique(maintain_order=True).to_list()
+    scenario_labels = _scenario_label_map(selected_scenarios, scenario_titles)
+    plot_values = values
+    dimension_column = "_dimension_label"
+    if dimension_columns:
+        plot_values = plot_values.with_columns(
+            pl.concat_str(
+                [pl.col(column).cast(pl.String) for column in dimension_columns],
+                separator=" / ",
+            ).alias(dimension_column)
+        )
+    else:
+        plot_values = plot_values.with_columns(pl.lit("Total").alias(dimension_column))
+
+    has_dimensions = bool(dimension_columns)
+    line_dashes = ["solid", "dash", "dot", "dashdot", "longdash", "longdashdot"]
+    std_column = f"{metric}_std"
+    fig = go.Figure()
+    for scenario_index, scenario in enumerate(selected_scenarios):
+        scenario_values = plot_values.filter(pl.col("scenario") == scenario)
+        dimensions = scenario_values[dimension_column].unique(maintain_order=True).to_list()
+        for dimension_index, dimension in enumerate(dimensions):
+            trace_values = (
+                scenario_values
+                .filter(pl.col(dimension_column) == dimension)
+                .sort("iteration")
+            )
+            if has_dimensions and len(selected_scenarios) == 1:
+                trace_name = _dimension_label(dimension)
+                color = _scenario_color(dimension_index)
+                dash = "solid"
+            elif has_dimensions:
+                trace_name = f"{scenario_labels[scenario]} - {_dimension_label(dimension)}"
+                color = _scenario_color(scenario_index)
+                dash = line_dashes[dimension_index % len(line_dashes)]
+            else:
+                trace_name = scenario_labels[scenario]
+                color = _scenario_color(scenario_index)
+                dash = "solid"
+
+            iterations = trace_values["iteration"].to_list()
+            metric_values = trace_values[metric].to_list()
+            if std_column in trace_values.columns:
+                metric_std = trace_values[std_column].to_list()
+                if any(value is not None for value in metric_std):
+                    std_values = [0.0 if value is None else value for value in metric_std]
+                    lower_values = [
+                        value - std
+                        for value, std in zip(metric_values, std_values)
+                    ]
+                    upper_values = [
+                        value + std
+                        for value, std in zip(metric_values, std_values)
+                    ]
+                    fig.add_scatter(
+                        x=iterations + list(reversed(iterations)),
+                        y=upper_values + list(reversed(lower_values)),
+                        fill="toself",
+                        fillcolor=_transparent_color(color, 0.18),
+                        line={"color": "rgba(0,0,0,0)"},
+                        hoverinfo="skip",
+                        mode="lines",
+                        name=f"{trace_name} uncertainty",
+                        showlegend=False,
+                    )
+            fig.add_scatter(
+                x=iterations,
+                y=metric_values,
+                mode="lines+markers",
+                line={"color": color, "dash": dash},
+                marker={"color": color},
+                name=trace_name,
+            )
+
+    apply_report_layout(fig, title=title)
+    fig.update_layout(
+        width=width,
+        height=height,
+        xaxis_title="Iteration",
+        yaxis_title=metric.replace("_", " "),
+        showlegend=True,
+        margin={"l": 70, "r": 45, "t": 95, "b": 80},
+        legend={
+            "orientation": "h",
+            "yanchor": "bottom",
+            "y": 1.03,
+            "xanchor": "left",
+            "x": 0.0,
+        },
+    )
+    fig.update_xaxes(dtick=1, automargin=True)
+    fig.update_yaxes(automargin=True)
+    if metric.endswith("_share"):
+        fig.update_yaxes(tickformat=".0%")
+    return fig
+
+
+def plot_metric_by_zone(
+    maps,
+    values: pl.DataFrame,
+    *,
+    metric: str,
+    zone_column: str,
+    title: str,
+    scenario_titles: dict[str, str] | None = None,
+    diverging_center: float | None = None,
+    width: int = 760,
+    height: int = 460,
+    labels: bool = True,
+) -> go.Figure:
+    """Plot a zone metric as one map per scenario."""
+    scenarios = values["scenario"].unique(maintain_order=True).to_list()
+    if not scenarios:
+        raise ValueError("No rows are available to plot.")
+
+    map_values = (
+        values
+        .rename({zone_column: "transport_zone_id"})
+        .with_columns(pl.col("transport_zone_id").cast(pl.String))
+    )
+    facet_column = "scenario"
+    if scenario_titles:
+        facet_column = "scenario_label"
+        map_values = _with_scenario_label_column(map_values, scenario_titles)
+    hover_columns = []
+    std_column = f"{metric}_std"
+    if std_column in map_values.columns:
+        hover_columns.append(std_column)
+    range_color = _symmetric_range(map_values, metric, diverging_center)
+    return maps.metric_facets(
+        map_values,
+        value_column=metric,
+        facet_column=facet_column,
+        save_name=f"{metric}-by-zone-map",
+        id_column="transport_zone_id",
+        labels=labels,
+        width=width,
+        height=height,
+        hover_columns=hover_columns,
+        legend_label=metric.replace("_", " "),
+        frame_title=title,
+        classify=False,
+        color_continuous_scale=(
+            _blue_white_red_color_scale()
+            if diverging_center is not None
+            else _ylorrd_color_scale()
+        ),
+        color_continuous_midpoint=diverging_center,
+        range_color=range_color,
+        colorbar_tickformat=".0%" if metric.endswith("_share") else None,
+    )
+
+
+def plot_metric_grid_by_zone(
+    maps,
+    values: pl.DataFrame,
+    *,
+    metric: str,
+    zone_column: str,
+    variable_column: str,
+    title: str,
+    scenario_titles: dict[str, str] | None = None,
+    diverging_center: float | None = None,
+    width: int = 760,
+    height: int = 460,
+    labels: bool = True,
+) -> go.Figure:
+    """Plot a zone metric as variable rows by scenario columns."""
+    if values.is_empty():
+        raise ValueError("No rows are available to plot.")
+
+    map_values = (
+        values
+        .rename({zone_column: "transport_zone_id"})
+        .with_columns(pl.col("transport_zone_id").cast(pl.String))
+    )
+    scenario_column = "scenario"
+    if scenario_titles:
+        scenario_column = "scenario_label"
+        map_values = _with_scenario_label_column(map_values, scenario_titles)
+    hover_columns = []
+    std_column = f"{metric}_std"
+    if std_column in map_values.columns:
+        hover_columns.append(std_column)
+    range_color = _symmetric_range(map_values, metric, diverging_center)
+    return maps.metric_grid(
+        map_values,
+        value_column=metric,
+        row_column=variable_column,
+        column_column=scenario_column,
+        save_name=f"{metric}-by-zone-and-{variable_column}-map",
+        id_column="transport_zone_id",
+        labels=labels,
+        width=width,
+        height=height,
+        hover_columns=hover_columns,
+        legend_label=metric.replace("_", " "),
+        frame_title=title,
+        classify=False,
+        color_continuous_scale=(
+            _blue_white_red_color_scale()
+            if diverging_center is not None
+            else _ylorrd_color_scale()
+        ),
+        color_continuous_midpoint=diverging_center,
+        range_color=range_color if diverging_center is not None else (
+            (0.0, 1.0) if metric.endswith("_share") else None
+        ),
+        colorbar_tickformat=".0%" if metric.endswith("_share") else None,
+    )
+
+
+def plot_metric_flows_by_zone(
+    maps,
+    values: pl.DataFrame,
+    *,
+    metric: str,
+    origin_column: str,
+    destination_column: str,
+    title: str,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 760,
+    height: int = 460,
+    labels: bool = True,
+    n_largest: int | None = 100,
+    min_value: float | None = None,
+    min_share: float | None = None,
+    max_line_width: float = 8.0,
+    min_line_width: float = 0.1,
+) -> go.Figure:
+    """Plot an OD metric as proportional-width flow lines."""
+    if values.is_empty():
+        raise ValueError("No rows are available to plot.")
+
+    map_values = values.with_columns(
+        pl.col(origin_column).cast(pl.String),
+        pl.col(destination_column).cast(pl.String),
+    )
+    facet_column = "scenario"
+    if scenario_titles:
+        facet_column = "scenario_label"
+        map_values = _with_scenario_label_column(map_values, scenario_titles)
+    hover_columns = []
+    std_column = f"{metric}_std"
+    if std_column in map_values.columns:
+        hover_columns.append(std_column)
+    return maps.metric_flows(
+        map_values,
+        value_column=metric,
+        origin_column=origin_column,
+        destination_column=destination_column,
+        facet_column=facet_column,
+        save_name=f"{metric}-by-origin-and-destination-map",
+        labels=labels,
+        width=width,
+        height=height,
+        hover_columns=hover_columns,
+        legend_label=metric.replace("_", " "),
+        frame_title=title,
+        n_largest=n_largest,
+        min_value=min_value,
+        min_share=min_share,
+        max_line_width=max_line_width,
+        min_line_width=min_line_width,
+    )
+
+
+def plot_activity_duration_distribution(
+    values: pl.DataFrame,
+    *,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 900,
+    height: int = 520,
+) -> go.Figure:
+    """Plot activity-duration probabilities by activity and source."""
+    if values.is_empty():
+        raise ValueError("No rows are available to plot.")
+    plot_values = _with_scenario_label_column(values, scenario_titles)
+    fig = px.line(
+        plot_values.to_pandas(),
+        x="duration_bin_mid",
+        y="probability",
+        color="source",
+        line_dash="scenario_label",
+        facet_col="activity",
+        facet_col_wrap=3,
+        error_y="probability_std" if "probability_std" in plot_values.columns else None,
+        labels={
+            "duration_bin_mid": "Duration (h)",
+            "probability": "Probability",
+            "source": "Source",
+            "scenario_label": "Scenario",
+        },
+    )
+    fig.for_each_annotation(
+        lambda annotation: annotation.update(text=annotation.text.replace("activity=", ""))
+    )
+    apply_report_layout(fig, title="Activity duration distribution")
+    fig.update_layout(width=width, height=height, legend_title_text=None)
+    fig.update_yaxes(tickformat=".0%")
+    return fig
+
+
+def plot_activity_time_series(
+    values: pl.DataFrame,
+    *,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 980,
+    height: int = 560,
+) -> go.Figure:
+    """Plot activity occupancy over the day."""
+    if values.is_empty():
+        raise ValueError("No rows are available to plot.")
+    plot_values = _with_scenario_label_column(values, scenario_titles)
+    fig = px.area(
+        plot_values.to_pandas(),
+        x="time_label",
+        y="n_persons",
+        color="label",
+        facet_row="source",
+        facet_col="scenario_label",
+        labels={
+            "time_label": "Time",
+            "n_persons": "Persons",
+            "label": "Activity",
+            "scenario_label": "Scenario",
+        },
+    )
+    fig.for_each_annotation(
+        lambda annotation: annotation.update(
+            text=annotation.text.replace("source=", "").replace("scenario_label=", "")
+        )
+    )
+    apply_report_layout(fig, title="Activity time series")
+    fig.update_layout(width=width, height=height, legend_title_text=None)
+    fig.update_xaxes(tickangle=0, nticks=8)
+    return fig
+
+
+def plot_reference_metric_by_dimension(
+    values: pl.DataFrame,
+    *,
+    dimension: str,
+    metric: str,
+    title: str,
+    scenarios: str | list[str] | tuple[str, ...] | None = None,
+    scenario_titles: dict[str, str] | None = None,
+    width: int = 820,
+    height: int = 480,
+) -> go.Figure:
+    """Plot one metric against its reference by country, dimension, and scenario."""
+    if scenarios is not None:
+        selected_scenarios = _selected_scenarios_from_values(values, scenarios)
+        values = values.filter(pl.col("scenario").is_in(selected_scenarios))
+    else:
+        selected_scenarios = values["scenario"].unique(maintain_order=True).to_list()
+
+    scenario_labels = _scenario_label_map(selected_scenarios, scenario_titles)
+    countries = values["country"].unique(maintain_order=True).to_list()
+    if not countries:
+        raise ValueError("No reference rows are available to plot.")
+
+    max_dimensions = max(values.filter(pl.col("country") == country)[dimension].n_unique() for country in countries)
+    fig = make_subplots(
+        rows=1,
+        cols=len(countries),
+        subplot_titles=countries,
+        shared_yaxes=True,
+        horizontal_spacing=0.08 if len(countries) > 1 else 0.0,
+    )
+    reference_column = f"{metric}_reference"
+    error_column = f"{metric}_std"
+    for column_index, country in enumerate(countries, start=1):
+        country_values = values.filter(pl.col("country") == country).sort(dimension)
+        dimensions = country_values[dimension].unique(maintain_order=True).to_list()
+        labels = [_dimension_label(value) for value in dimensions]
+        reference_rows = country_values.select([dimension, reference_column]).unique(
+            subset=[dimension],
+            maintain_order=True,
+        )
+        reference_values = dict(zip(reference_rows[dimension].to_list(), reference_rows[reference_column].to_list()))
+        fig.add_bar(
+            x=labels,
+            y=[reference_values.get(value, 0.0) for value in dimensions],
+            marker_color=MOBILITY_COLORS["survey"],
+            name="Reference",
+            showlegend=column_index == 1,
+            row=1,
+            col=column_index,
+        )
+        for scenario_index, scenario in enumerate(selected_scenarios):
+            scenario_values = country_values.filter(pl.col("scenario") == scenario)
+            metric_values = dict(zip(scenario_values[dimension].to_list(), scenario_values[metric].to_list()))
+            metric_errors = dict(zip(scenario_values[dimension].to_list(), scenario_values[error_column].to_list()))
+            fig.add_bar(
+                x=labels,
+                y=[metric_values.get(value, 0.0) for value in dimensions],
+                error_y={
+                    "type": "data",
+                    "array": [metric_errors.get(value) for value in dimensions],
+                    "visible": True,
+                },
+                marker_color=_scenario_color(scenario_index),
+                name=scenario_labels[scenario],
+                showlegend=column_index == 1,
+                row=1,
+                col=column_index,
+            )
+        fig.update_xaxes(automargin=True, row=1, col=column_index)
+        fig.update_yaxes(automargin=True, row=1, col=column_index)
+
+    apply_report_layout(fig, title=title)
+    fig.update_layout(
+        width=max(width, 390 * len(countries)),
+        height=max(height, 480 + 18 * max_dimensions),
+        barmode="group",
+        bargap=0.22,
+        bargroupgap=0.16,
+        yaxis_title=metric.replace("_", " "),
+        showlegend=True,
+        margin={"l": 70, "r": 45, "t": 105, "b": 125},
+        legend={
+            "orientation": "h",
+            "yanchor": "bottom",
+            "y": 1.04,
+            "xanchor": "left",
+            "x": 0.0,
+        },
+    )
+    if metric.endswith("_share"):
+        fig.update_yaxes(tickformat=".0%")
+    return fig
+
+
+def select_scenarios(
+    results,
+    scenarios: str | list[str] | tuple[str, ...] | None,
+) -> list[str]:
+    """Return scenario names after checking they are in this result set."""
+    if scenarios is None:
+        selected_scenarios = list(results.scenarios)
+    elif isinstance(scenarios, str):
+        selected_scenarios = [scenarios]
+    elif isinstance(scenarios, (list, tuple)):
+        selected_scenarios = list(scenarios)
+    else:
+        raise TypeError("scenarios should be None, one scenario name, or a list of scenario names.")
+
+    if not selected_scenarios:
+        raise ValueError("At least one scenario is needed.")
+    if not all(isinstance(scenario, str) for scenario in selected_scenarios):
+        raise TypeError("scenarios should only contain scenario names.")
+
+    missing_scenarios = [
+        scenario
+        for scenario in selected_scenarios
+        if scenario not in results.scenarios
+    ]
+    if missing_scenarios:
+        raise ValueError(
+            "Selected scenarios should be included in the result set. "
+            f"Missing scenarios: {missing_scenarios}."
+        )
+
+    duplicate_scenarios = sorted(
+        scenario
+        for scenario in set(selected_scenarios)
+        if selected_scenarios.count(scenario) > 1
+    )
+    if duplicate_scenarios:
+        raise ValueError(
+            "scenarios should not contain duplicate names. "
+            f"Received duplicates: {duplicate_scenarios}."
+        )
+
+    return selected_scenarios
+
+
+def _selected_scenarios_from_values(
+    values: pl.DataFrame,
+    scenarios: str | list[str] | tuple[str, ...],
+) -> list[str]:
+    """Return scenario names after checking they are in a value table."""
+    if isinstance(scenarios, str):
+        selected_scenarios = [scenarios]
+    elif isinstance(scenarios, (list, tuple)):
+        selected_scenarios = list(scenarios)
+    else:
+        raise TypeError("scenarios should be one scenario name or a list of scenario names.")
+
+    if not selected_scenarios:
+        raise ValueError("At least one scenario is needed.")
+    available_scenarios = set(values["scenario"].unique().to_list())
+    missing_scenarios = [
+        scenario
+        for scenario in selected_scenarios
+        if scenario not in available_scenarios
+    ]
+    if missing_scenarios:
+        raise ValueError(
+            "Selected scenarios should be included in the result table. "
+            f"Missing scenarios: {missing_scenarios}."
+        )
+    return selected_scenarios
+
+
+def _with_scenario_label_column(
+    values: pl.DataFrame,
+    scenario_titles: dict[str, str] | None,
+) -> pl.DataFrame:
+    """Return values with a display-only scenario label column."""
+    scenarios = values["scenario"].unique(maintain_order=True).to_list()
+    labels = _scenario_label_map(scenarios, scenario_titles)
+    label_frame = pl.DataFrame(
+        {
+            "scenario": list(labels),
+            "scenario_label": list(labels.values()),
+        }
+    )
+    return values.join(label_frame, on="scenario", how="left")
+
+
+def _scenario_label_map(
+    scenarios: list[str],
+    scenario_titles: dict[str, str] | None,
+) -> dict[str, str]:
+    """Return unique display labels for scenario names."""
+    raw_labels = {
+        scenario: (scenario_titles or {}).get(scenario, scenario)
+        for scenario in scenarios
+    }
+    duplicated_labels = {
+        label
+        for label in raw_labels.values()
+        if list(raw_labels.values()).count(label) > 1
+    }
+    return {
+        scenario: (
+            f"{label} ({scenario})"
+            if label in duplicated_labels
+            else label
+        )
+        for scenario, label in raw_labels.items()
+    }
+
+
+def _dimension_label(value: object) -> str:
+    """Return a readable dimension value label for plots."""
+    return str(value).replace("_", " ").replace("/", "<br>")
+
+
+def _scenario_color(index: int) -> str:
+    """Return a stable color for one scenario trace."""
+    return SCENARIO_COLORS[index % len(SCENARIO_COLORS)]
+
+
+def _transparent_color(color: str, alpha: float) -> str:
+    """Return a transparent CSS color from a hex color."""
+    if not color.startswith("#") or len(color) != 7:
+        return color
+    red = int(color[1:3], 16)
+    green = int(color[3:5], 16)
+    blue = int(color[5:7], 16)
+    return f"rgba({red},{green},{blue},{alpha})"
+
+
+def _ylorrd_color_scale() -> list[list[float | str]]:
+    """Return the positive-value map color scale used in report maps."""
+    return [
+        [0.0, "#ffffcc"],
+        [0.125, "#ffeda0"],
+        [0.25, "#fed976"],
+        [0.375, "#feb24c"],
+        [0.5, "#fd8d3c"],
+        [0.625, "#fc4e2a"],
+        [0.75, "#e31a1c"],
+        [0.875, "#bd0026"],
+        [1.0, "#800026"],
+    ]
+
+
+def _blue_white_red_color_scale() -> list[list[float | str]]:
+    """Return a diverging color scale for positive and negative gaps."""
+    return [
+        [0.0, "#2166AC"],
+        [0.5, "#FFFFFF"],
+        [1.0, "#B2182B"],
+    ]
+
+
+def _symmetric_range(
+    values: pl.DataFrame,
+    metric: str,
+    center: float | None,
+) -> tuple[float, float] | None:
+    """Return a color range symmetric around the requested center."""
+    if center is None or metric not in values.columns or values.is_empty():
+        return None
+    metric_values = values[metric].drop_nulls()
+    if metric_values.is_empty():
+        return (center - 1.0, center + 1.0)
+    lower = float(metric_values.min())
+    upper = float(metric_values.max())
+    span = max(abs(lower - center), abs(upper - center), 1e-12)
+    return (center - span, center + span)
+
+
+def _apply_vertical_bar_layout(
+    fig: go.Figure,
+    *,
+    labels: list[str],
+    title: str,
+    width: int,
+    height: int,
+    yaxis_title: str,
+    showlegend: bool,
+    left_margin: int | None = None,
+) -> None:
+    """Apply a consistent layout for vertical result bar charts."""
+    figure_width = max(width, 220 + 130 * len(labels))
+    if left_margin is None:
+        left_margin = 70
+    apply_report_layout(fig, title=title)
+    fig.update_layout(
+        width=figure_width,
+        height=height,
+        barmode="group",
+        bargap=0.22,
+        bargroupgap=0.16,
+        xaxis_title=None,
+        yaxis_title=yaxis_title,
+        showlegend=showlegend,
+        margin={"l": left_margin, "r": 45, "t": 95, "b": 125},
+        legend={
+            "orientation": "h",
+            "yanchor": "bottom",
+            "y": 1.03,
+            "xanchor": "left",
+            "x": 0.0,
+        },
+    )
+    fig.update_xaxes(automargin=True)
+    fig.update_yaxes(automargin=True)

--- a/mobility/trips/group_day_trips/results/plots.py
+++ b/mobility/trips/group_day_trips/results/plots.py
@@ -328,19 +328,12 @@ def plot_metric_by_zone(
     if not scenarios:
         raise ValueError("No rows are available to plot.")
 
-    map_values = (
-        values
-        .rename({zone_column: "transport_zone_id"})
-        .with_columns(pl.col("transport_zone_id").cast(pl.String))
+    map_values, facet_column = _zone_metric_values(
+        values,
+        zone_column=zone_column,
+        scenario_titles=scenario_titles,
     )
-    facet_column = "scenario"
-    if scenario_titles:
-        facet_column = "scenario_label"
-        map_values = _with_scenario_label_column(map_values, scenario_titles)
-    hover_columns = []
-    std_column = f"{metric}_std"
-    if std_column in map_values.columns:
-        hover_columns.append(std_column)
+    hover_columns = _metric_hover_columns(map_values, metric)
     range_color = _symmetric_range(map_values, metric, diverging_center)
     return maps.metric_facets(
         map_values,
@@ -384,19 +377,12 @@ def plot_metric_grid_by_zone(
     if values.is_empty():
         raise ValueError("No rows are available to plot.")
 
-    map_values = (
-        values
-        .rename({zone_column: "transport_zone_id"})
-        .with_columns(pl.col("transport_zone_id").cast(pl.String))
+    map_values, scenario_column = _zone_metric_values(
+        values,
+        zone_column=zone_column,
+        scenario_titles=scenario_titles,
     )
-    scenario_column = "scenario"
-    if scenario_titles:
-        scenario_column = "scenario_label"
-        map_values = _with_scenario_label_column(map_values, scenario_titles)
-    hover_columns = []
-    std_column = f"{metric}_std"
-    if std_column in map_values.columns:
-        hover_columns.append(std_column)
+    hover_columns = _metric_hover_columns(map_values, metric)
     range_color = _symmetric_range(map_values, metric, diverging_center)
     return maps.metric_grid(
         map_values,
@@ -451,14 +437,8 @@ def plot_metric_flows_by_zone(
         pl.col(origin_column).cast(pl.String),
         pl.col(destination_column).cast(pl.String),
     )
-    facet_column = "scenario"
-    if scenario_titles:
-        facet_column = "scenario_label"
-        map_values = _with_scenario_label_column(map_values, scenario_titles)
-    hover_columns = []
-    std_column = f"{metric}_std"
-    if std_column in map_values.columns:
-        hover_columns.append(std_column)
+    map_values, facet_column = _with_scenario_column(map_values, scenario_titles)
+    hover_columns = _metric_hover_columns(map_values, metric)
     return maps.metric_flows(
         map_values,
         value_column=metric,
@@ -689,6 +669,37 @@ def select_scenarios(
         )
 
     return selected_scenarios
+
+
+def _zone_metric_values(
+    values: pl.DataFrame,
+    *,
+    zone_column: str,
+    scenario_titles: dict[str, str] | None,
+) -> tuple[pl.DataFrame, str]:
+    """Return map-ready zone values and the scenario facet column."""
+    map_values = (
+        values
+        .rename({zone_column: "transport_zone_id"})
+        .with_columns(pl.col("transport_zone_id").cast(pl.String))
+    )
+    return _with_scenario_column(map_values, scenario_titles)
+
+
+def _with_scenario_column(
+    values: pl.DataFrame,
+    scenario_titles: dict[str, str] | None,
+) -> tuple[pl.DataFrame, str]:
+    """Return values and the scenario column to use for plots."""
+    if not scenario_titles:
+        return values, "scenario"
+    return _with_scenario_label_column(values, scenario_titles), "scenario_label"
+
+
+def _metric_hover_columns(values: pl.DataFrame, metric: str) -> list[str]:
+    """Return optional metric detail columns for map hover labels."""
+    std_column = f"{metric}_std"
+    return [std_column] if std_column in values.columns else []
 
 
 def _selected_scenarios_from_values(

--- a/mobility/trips/group_day_trips/results/results.py
+++ b/mobility/trips/group_day_trips/results/results.py
@@ -7,6 +7,7 @@ from mobility.runtime.parameter_values import DEFAULT_SCENARIO
 from mobility.runtime.scenarios import Scenarios
 
 from .diagnostics import GroupDayTripsResultDiagnostics
+from .metrics import GroupDayTripsResultMetrics
 from .tables import GroupDayTripsResultTables
 
 IterationSelector = str | int | list[int] | range
@@ -54,6 +55,7 @@ class GroupDayTripsResults:
         self._run_contexts: list[ResultRun] | None = None
 
         self.tables = GroupDayTripsResultTables(self)
+        self.metrics = GroupDayTripsResultMetrics(self)
         self.diagnostics = GroupDayTripsResultDiagnostics(self)
 
     @property
@@ -105,6 +107,42 @@ class GroupDayTripsResults:
     def has_multiple_iterations(self, iterations: IterationSelector = "last") -> bool:
         """Return whether one result query contains several iterations."""
         return len(self.selected_iterations(iterations)) > 1
+
+    @property
+    def scenario_titles(self) -> dict[str, str]:
+        """Return display titles for selected scenarios."""
+        if self.scenario_manifest is None:
+            return {}
+        return {
+            scenario: self.scenario_manifest.get(scenario).display_title
+            for scenario in self.scenarios
+        }
+
+    @property
+    def survey_reference_plan_steps(self):
+        """Return the survey-weighted plan-step asset for this result scope."""
+        try:
+            return self.first_run._get_expected_diagnostics_inputs().population_weighted_plan_steps
+        except AttributeError as exc:
+            raise TypeError(
+                "Survey diagnostics need runs that expose population-weighted survey plan steps."
+            ) from exc
+
+    @property
+    def transport_zones(self):
+        """Return the transport-zone asset used by this result scope."""
+        try:
+            return self.first_run.population.transport_zones
+        except AttributeError as exc:
+            raise TypeError("Survey diagnostics need runs with a population transport-zone asset.") from exc
+
+    @property
+    def surveys(self):
+        """Return the surveys used by this result scope."""
+        try:
+            return self.first_run.surveys
+        except AttributeError as exc:
+            raise TypeError("Survey-based metrics need runs that expose their surveys.") from exc
 
     @property
     def is_weekday(self) -> bool:

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -280,9 +280,26 @@ def _titled_results(tmp_path: Path):
     )
 
 
+@pytest.fixture(autouse=True)
+def _project_data_folder(tmp_path, monkeypatch):
+    """Point result assets at each test's temporary folder."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+
+def _record_metric_plot(monkeypatch, name: str) -> list[dict]:
+    """Patch one metric plot helper and record all calls."""
+    calls = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return go.Figure()
+
+    monkeypatch.setattr(f"mobility.trips.group_day_trips.results.metrics.{name}", fake_plot)
+    return calls
+
+
 def test_population_group_day_trips_results_selects_all_replications(tmp_path, monkeypatch):
     """Check that the top-level results method selects every configured seed."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     wrapper = PopulationGroupDayTrips.__new__(PopulationGroupDayTrips)
     wrapper.parameters = SimpleNamespace(run=SimpleNamespace(n_replications=2))
     wrapper.scenarios = Scenarios()
@@ -298,7 +315,6 @@ def test_population_group_day_trips_results_selects_all_replications(tmp_path, m
 
 def test_results_rejects_empty_and_duplicate_scenarios(tmp_path, monkeypatch):
     """Check that scenario selection fails before any run is built."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     with pytest.raises(ValueError, match="at least one scenario"):
         GroupDayTripsResults(
@@ -319,7 +335,6 @@ def test_results_rejects_empty_and_duplicate_scenarios(tmp_path, monkeypatch):
 
 def test_results_rejects_scenarios_missing_from_manifest(tmp_path, monkeypatch):
     """Check that direct result objects still use the scenario manifest."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     with pytest.raises(ValueError, match="Missing scenarios"):
         GroupDayTripsResults(
@@ -333,7 +348,6 @@ def test_results_rejects_scenarios_missing_from_manifest(tmp_path, monkeypatch):
 
 def test_results_object_no_longer_accepts_iterations(tmp_path, monkeypatch):
     """Check iteration selection belongs to tables and metrics."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     with pytest.raises(TypeError, match="unexpected keyword"):
         GroupDayTripsResults(
@@ -347,7 +361,6 @@ def test_results_object_no_longer_accepts_iterations(tmp_path, monkeypatch):
 
 def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
     """Check that raw tables keep run identity columns after concatenation."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     plan_steps = results.tables.plan_steps().sort("replication").collect()
@@ -363,7 +376,6 @@ def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
 
 def test_result_tables_can_include_multiple_scenarios(tmp_path, monkeypatch):
     """Check that one result set can concatenate several scenarios."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
 
     plan_steps = results.tables.plan_steps().collect()
@@ -383,7 +395,6 @@ def test_result_tables_can_include_multiple_scenarios(tmp_path, monkeypatch):
 
 def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
     """Check that raw plan steps can be read from saved iteration artifacts."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     plan_steps = (
@@ -398,7 +409,6 @@ def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
 
 def test_trip_count_metrics_keep_selected_iterations(tmp_path, monkeypatch):
     """Check that metric tables keep iteration when several iterations are selected."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     trip_count = results.metrics.trip_count(
@@ -412,7 +422,6 @@ def test_trip_count_metrics_keep_selected_iterations(tmp_path, monkeypatch):
 
 def test_iteration_trip_count_can_group_by_home_zone_from_demand_groups(tmp_path, monkeypatch):
     """Check saved iteration plan steps can use resident zone columns from demand groups."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     trip_count = results.metrics.trip_count(
@@ -428,7 +437,6 @@ def test_iteration_trip_count_can_group_by_home_zone_from_demand_groups(tmp_path
 
 def test_iteration_travel_metrics_can_group_by_demand_group_columns(tmp_path, monkeypatch):
     """Check saved iteration travel metrics can use columns stored on demand groups."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     distance = results.metrics.travel_distance(
@@ -448,7 +456,6 @@ def test_iteration_travel_metrics_can_group_by_demand_group_columns(tmp_path, mo
 
 def test_iteration_final_state_metrics_use_demand_group_columns(tmp_path, monkeypatch):
     """Check saved iteration final-state metrics can join demand-group dimensions."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     immobility = results.metrics.immobility(
@@ -470,7 +477,6 @@ def test_iteration_final_state_metrics_use_demand_group_columns(tmp_path, monkey
 
 def test_compact_trip_count_api_handles_absolute_per_person_and_share(tmp_path, monkeypatch):
     """Check trip count normalization is controlled by normalize_by."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     absolute = results.metrics.trip_count(by_variable="mode").sort("mode")
@@ -484,7 +490,6 @@ def test_compact_trip_count_api_handles_absolute_per_person_and_share(tmp_path, 
 
 def test_metrics_can_group_by_origin_and_destination_zone(tmp_path, monkeypatch):
     """Check explicit zone dimensions select the matching plan-step zone id."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     by_origin = results.metrics.trip_count(by_zone="origin_zone").sort("origin_zone_id")
@@ -498,7 +503,6 @@ def test_metrics_can_group_by_origin_and_destination_zone(tmp_path, monkeypatch)
 
 def test_metrics_can_group_by_origin_destination_pairs(tmp_path, monkeypatch):
     """Check multiple zone dimensions return OD contribution tables."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     od_trips = results.metrics.trip_count(
@@ -516,7 +520,6 @@ def test_metrics_can_group_by_origin_destination_pairs(tmp_path, monkeypatch):
 
 def test_multi_zone_grouping_rejects_normalization(tmp_path, monkeypatch):
     """Check OD contributions stay absolute until normalization semantics are explicit."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     with pytest.raises(ValueError, match="Normalization is not supported"):
@@ -532,7 +535,6 @@ def test_multi_zone_grouping_rejects_normalization(tmp_path, monkeypatch):
 
 def test_zone_person_count_normalization_aligns_zone_id_types(tmp_path, monkeypatch):
     """Check zone normalization works when run tables store zone ids differently."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
         demand_groups = pl.DataFrame(
@@ -584,7 +586,6 @@ def test_zone_person_count_normalization_aligns_zone_id_types(tmp_path, monkeypa
 
 def test_metrics_can_filter_to_inner_zone_residents(tmp_path, monkeypatch):
     """Check metrics can ignore residents whose home zone is outside the inner area."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     class TransportZonesWithOuterZone(_FakeTransportZones):
         """Fake zones where one resident home zone is outside the inner area."""
@@ -661,7 +662,6 @@ def test_metrics_can_filter_to_inner_zone_residents(tmp_path, monkeypatch):
 
 def test_compact_travel_distance_api_uses_public_travel_distance_name(tmp_path, monkeypatch):
     """Check travel distance replaces the old distance public name."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     by_mode = results.metrics.travel_distance(by_variable="mode", normalize_by="person_count", normalize_scope="study_area").sort("mode")
@@ -687,7 +687,6 @@ def test_compact_travel_distance_api_uses_public_travel_distance_name(tmp_path, 
 
 def test_compact_time_cost_and_emissions_metrics(tmp_path, monkeypatch):
     """Check non-trip quantities use the same compact metric API."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     travel_time = results.metrics.travel_time(normalize_by="person_count", normalize_scope="study_area")
@@ -701,7 +700,6 @@ def test_compact_time_cost_and_emissions_metrics(tmp_path, monkeypatch):
 
 def test_metrics_can_include_survey_reference(tmp_path, monkeypatch):
     """Check supported quantities can opt into external references."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     distance = results.metrics.travel_distance(
@@ -772,7 +770,6 @@ def test_metrics_can_include_survey_reference(tmp_path, monkeypatch):
 
 def test_external_reference_person_count_uses_reference_population(tmp_path, monkeypatch):
     """Check external per-person metrics use the population represented by the reference."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     class TransportZonesWithOuterZone(_FakeTransportZones):
         """Fake zones where one model home zone is outside the reference area."""
@@ -853,7 +850,6 @@ def test_external_reference_person_count_uses_reference_population(tmp_path, mon
 
 def test_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
     """Check metric tables can compare scenarios without keeping reference rows."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
 
     distance = results.metrics.travel_distance(
@@ -889,7 +885,6 @@ def test_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
 
 def test_iteration_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
     """Check scenario references match rows by iteration."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"], replication=0)
 
     distance = results.metrics.travel_distance(
@@ -918,7 +913,6 @@ def test_iteration_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
 
 def test_activity_and_bin_dimensions_are_available(tmp_path, monkeypatch):
     """Check activity, distance bins, and time bins are analysis dimensions."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     by_activity = results.metrics.travel_distance(
@@ -941,7 +935,6 @@ def test_activity_and_bin_dimensions_are_available(tmp_path, monkeypatch):
 
 def test_immobility_and_demand_group_metrics_remain_special_methods(tmp_path, monkeypatch):
     """Check special result products keep their explicit names."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     immobility = results.metrics.immobility(reference="external").sort("csp")
@@ -953,7 +946,6 @@ def test_immobility_and_demand_group_metrics_remain_special_methods(tmp_path, mo
 
 def test_sparse_dimension_groups_count_missing_seed_as_zero(tmp_path, monkeypatch):
     """Check that a group missing in one seed still contributes a zero."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
         demand_groups = pl.DataFrame(
@@ -1001,7 +993,6 @@ def test_sparse_dimension_groups_count_missing_seed_as_zero(tmp_path, monkeypatc
 
 def test_activity_duration_distribution_and_time_series_are_model_only_by_default(tmp_path, monkeypatch):
     """Check time-distribution products can opt into survey rows."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     duration = results.metrics.activity_duration_distribution(bin_width_minutes=60)
@@ -1023,7 +1014,6 @@ def test_activity_duration_distribution_and_time_series_are_model_only_by_defaul
 
 def test_activity_duration_distribution_and_time_series_can_plot(tmp_path, monkeypatch):
     """Check time-distribution products can return figures."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     duration_fig = results.metrics.activity_duration_distribution(
@@ -1049,7 +1039,6 @@ def test_activity_duration_distribution_and_time_series_can_plot(tmp_path, monke
 
 def test_opportunity_occupation_returns_table(tmp_path, monkeypatch):
     """Check opportunity occupation keeps capacities with modeled duration."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     occupation = results.metrics.opportunity_occupation().sort("activity")
@@ -1063,53 +1052,22 @@ def test_opportunity_occupation_returns_table(tmp_path, monkeypatch):
 
 def test_opportunity_occupation_plot_uses_zone_helpers(tmp_path, monkeypatch):
     """Check opportunity occupation can be mapped by activity or as one activity."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
-    seen = {}
-
-    def fake_zone_map(maps, values, *, metric, zone_column, title, width, height, **plot_kwargs):
-        seen["zone"] = {
-            "metric": metric,
-            "zone_column": zone_column,
-            "title": title,
-            "values": values,
-            "plot_kwargs": plot_kwargs,
-        }
-        return go.Figure()
-
-    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
-        seen["grid"] = {
-            "metric": metric,
-            "zone_column": zone_column,
-            "variable_column": variable_column,
-            "title": title,
-            "values": values,
-            "plot_kwargs": plot_kwargs,
-        }
-        return go.Figure()
-
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_by_zone",
-        fake_zone_map,
-    )
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
-        fake_grid_map,
-    )
+    zone_calls = _record_metric_plot(monkeypatch, "plot_metric_by_zone")
+    grid_calls = _record_metric_plot(monkeypatch, "plot_metric_grid_by_zone")
 
     grid_fig = results.metrics.opportunity_occupation(output="plot")
     zone_fig = results.metrics.opportunity_occupation(activity="work", output="plot")
 
     assert isinstance(grid_fig, BaseFigure)
     assert isinstance(zone_fig, BaseFigure)
-    assert seen["grid"]["metric"] == "opportunity_occupation"
-    assert seen["grid"]["variable_column"] == "activity"
-    assert seen["zone"]["values"]["activity"].unique().to_list() == ["work"]
+    assert grid_calls[0]["kwargs"]["metric"] == "opportunity_occupation"
+    assert grid_calls[0]["kwargs"]["variable_column"] == "activity"
+    assert zone_calls[0]["args"][1]["activity"].unique().to_list() == ["work"]
 
 
 def test_metric_output_plot_returns_report_figure(tmp_path, monkeypatch):
     """Check compact metric methods can return Plotly figures."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     fig = results.metrics.travel_distance(
@@ -1133,7 +1091,6 @@ def test_metric_output_plot_returns_report_figure(tmp_path, monkeypatch):
 
 def test_metric_plots_include_all_scenarios_by_default(tmp_path, monkeypatch):
     """Check that plots use every scenario in the result set by default."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
 
     fig = results.metrics.travel_distance(by_variable="mode", normalize_by="person_count", normalize_scope="study_area", output="plot")
@@ -1146,7 +1103,6 @@ def test_metric_plots_include_all_scenarios_by_default(tmp_path, monkeypatch):
 
 def test_metric_plot_uses_line_chart_for_multiple_iterations(tmp_path, monkeypatch):
     """Check metric plots use iteration lines when several iterations are selected."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     fig = results.metrics.travel_distance(
@@ -1175,7 +1131,6 @@ def test_metric_plot_uses_line_chart_for_multiple_iterations(tmp_path, monkeypat
 
 def test_metric_plot_uses_gap_for_scenario_reference(tmp_path, monkeypatch):
     """Check scenario-reference plots show the gap to the reference scenario."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
 
     fig = results.metrics.travel_distance(
@@ -1194,7 +1149,6 @@ def test_metric_plot_uses_gap_for_scenario_reference(tmp_path, monkeypatch):
 
 def test_metric_plots_use_scenario_titles_when_available(tmp_path, monkeypatch):
     """Check plot legends show scenario titles while tables keep scenario names."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _titled_results(tmp_path)
 
     table = results.metrics.travel_distance(by_variable="mode")
@@ -1206,7 +1160,6 @@ def test_metric_plots_use_scenario_titles_when_available(tmp_path, monkeypatch):
 
 def test_metric_plots_can_filter_scenarios(tmp_path, monkeypatch):
     """Check that plot methods can select one scenario from the result set."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
 
     fig = results.metrics.trip_count(
@@ -1221,30 +1174,8 @@ def test_metric_plots_can_filter_scenarios(tmp_path, monkeypatch):
 
 def test_home_zone_metric_plot_uses_map_helper(tmp_path, monkeypatch):
     """Check home-zone metric plots are maps over loaded scenarios."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
-    seen = {}
-
-    def fake_home_zone_map(maps, values, *, metric, zone_column, title, width, height, **plot_kwargs):
-        """Record the map inputs without needing test geometries."""
-        seen.setdefault("calls", []).append(
-            {
-                "maps": maps,
-                "values": values,
-                "metric": metric,
-                "zone_column": zone_column,
-                "title": title,
-                "width": width,
-                "height": height,
-                "plot_kwargs": plot_kwargs,
-            }
-        )
-        return go.Figure()
-
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_by_zone",
-        fake_home_zone_map,
-    )
+    calls = _record_metric_plot(monkeypatch, "plot_metric_by_zone")
 
     fig = results.metrics.travel_distance(
         by_zone="home_zone",
@@ -1260,42 +1191,21 @@ def test_home_zone_metric_plot_uses_map_helper(tmp_path, monkeypatch):
     )
 
     assert isinstance(fig, BaseFigure)
-    assert len(seen["calls"]) == 2
-    assert seen["calls"][0]["maps"] is seen["calls"][1]["maps"]
-    assert seen["calls"][0]["metric"] == "travel_distance_per_person"
-    assert seen["calls"][0]["zone_column"] == "home_zone_id"
-    assert seen["calls"][0]["title"] == "Travel distance per person by home zone"
-    assert seen["calls"][0]["width"] == 640
-    assert seen["calls"][0]["height"] == 360
-    assert seen["calls"][0]["values"]["scenario"].unique(maintain_order=True).to_list() == ["default", "test"]
-    assert "home_zone_id" in seen["calls"][0]["values"].columns
+    assert len(calls) == 2
+    assert calls[0]["args"][0] is calls[1]["args"][0]
+    assert calls[0]["kwargs"]["metric"] == "travel_distance_per_person"
+    assert calls[0]["kwargs"]["zone_column"] == "home_zone_id"
+    assert calls[0]["kwargs"]["title"] == "Travel distance per person by home zone"
+    assert calls[0]["kwargs"]["width"] == 640
+    assert calls[0]["kwargs"]["height"] == 360
+    assert calls[0]["args"][1]["scenario"].unique(maintain_order=True).to_list() == ["default", "test"]
+    assert "home_zone_id" in calls[0]["args"][1].columns
 
 
 def test_zone_variable_metric_plot_uses_grid_map_helper(tmp_path, monkeypatch):
     """Check zone-variable metric plots are scenario x variable map grids."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
-    seen = {}
-
-    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
-        """Record grid map inputs without needing test geometries."""
-        seen["call"] = {
-            "maps": maps,
-            "values": values,
-            "metric": metric,
-            "zone_column": zone_column,
-            "variable_column": variable_column,
-            "title": title,
-            "width": width,
-            "height": height,
-            "plot_kwargs": plot_kwargs,
-        }
-        return go.Figure()
-
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
-        fake_grid_map,
-    )
+    calls = _record_metric_plot(monkeypatch, "plot_metric_grid_by_zone")
 
     fig = results.metrics.trip_count(
         by_zone="home_zone",
@@ -1308,36 +1218,18 @@ def test_zone_variable_metric_plot_uses_grid_map_helper(tmp_path, monkeypatch):
     )
 
     assert isinstance(fig, BaseFigure)
-    assert seen["call"]["metric"] == "trip_count_share"
-    assert seen["call"]["zone_column"] == "home_zone_id"
-    assert seen["call"]["variable_column"] == "mode"
-    assert seen["call"]["title"] == "Trip count share by home zone and mode"
-    assert seen["call"]["width"] == 640
-    assert seen["call"]["height"] == 360
+    assert calls[0]["kwargs"]["metric"] == "trip_count_share"
+    assert calls[0]["kwargs"]["zone_column"] == "home_zone_id"
+    assert calls[0]["kwargs"]["variable_column"] == "mode"
+    assert calls[0]["kwargs"]["title"] == "Trip count share by home zone and mode"
+    assert calls[0]["kwargs"]["width"] == 640
+    assert calls[0]["kwargs"]["height"] == 360
 
 
 def test_reference_gap_map_uses_diverging_colors(tmp_path, monkeypatch):
     """Check map plots of reference gaps use a zero-centered diverging scale."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
-    seen = {}
-
-    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
-        """Record grid map inputs without needing test geometries."""
-        seen["call"] = {
-            "values": values,
-            "metric": metric,
-            "zone_column": zone_column,
-            "variable_column": variable_column,
-            "title": title,
-            "plot_kwargs": plot_kwargs,
-        }
-        return go.Figure()
-
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
-        fake_grid_map,
-    )
+    calls = _record_metric_plot(monkeypatch, "plot_metric_grid_by_zone")
 
     fig = results.metrics.trip_count(
         by_variable="mode",
@@ -1351,60 +1243,16 @@ def test_reference_gap_map_uses_diverging_colors(tmp_path, monkeypatch):
     )
 
     assert isinstance(fig, BaseFigure)
-    assert seen["call"]["metric"] == "gap"
-    assert seen["call"]["title"] == "Gap to reference: Trip count share by home zone and mode"
-    assert seen["call"]["plot_kwargs"]["diverging_center"] == 0.0
-    assert seen["call"]["values"]["scenario"].unique(maintain_order=True).to_list() == ["test"]
+    assert calls[0]["kwargs"]["metric"] == "gap"
+    assert calls[0]["kwargs"]["title"] == "Gap to reference: Trip count share by home zone and mode"
+    assert calls[0]["kwargs"]["diverging_center"] == 0.0
+    assert calls[0]["args"][1]["scenario"].unique(maintain_order=True).to_list() == ["test"]
 
 
 def test_origin_destination_metric_plot_uses_flow_map_helper(tmp_path, monkeypatch):
     """Check OD metric plots use the flow-map helper with default top-N filtering."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, scenarios=["default", "test"])
-    seen = {}
-
-    def fake_flow_map(
-        maps,
-        values,
-        *,
-        metric,
-        origin_column,
-        destination_column,
-        title,
-        width,
-        height,
-        scenario_titles,
-        labels,
-        n_largest,
-        min_value,
-        min_share,
-        max_line_width,
-        min_line_width,
-    ):
-        """Record flow-map inputs without needing test geometries."""
-        seen["call"] = {
-            "maps": maps,
-            "values": values,
-            "metric": metric,
-            "origin_column": origin_column,
-            "destination_column": destination_column,
-            "title": title,
-            "width": width,
-            "height": height,
-            "scenario_titles": scenario_titles,
-            "labels": labels,
-            "n_largest": n_largest,
-            "min_value": min_value,
-            "min_share": min_share,
-            "max_line_width": max_line_width,
-            "min_line_width": min_line_width,
-        }
-        return go.Figure()
-
-    monkeypatch.setattr(
-        "mobility.trips.group_day_trips.results.metrics.plot_metric_flows_by_zone",
-        fake_flow_map,
-    )
+    calls = _record_metric_plot(monkeypatch, "plot_metric_flows_by_zone")
 
     fig = results.metrics.ghg_emissions(
         by_zone=["origin_zone", "destination_zone"],
@@ -1416,18 +1264,18 @@ def test_origin_destination_metric_plot_uses_flow_map_helper(tmp_path, monkeypat
     )
 
     assert isinstance(fig, BaseFigure)
-    assert seen["call"]["metric"] == "ghg_emissions"
-    assert seen["call"]["origin_column"] == "origin_zone_id"
-    assert seen["call"]["destination_column"] == "destination_zone_id"
-    assert seen["call"]["title"] == "Ghg emissions by origin zone and destination zone"
-    assert seen["call"]["width"] == 640
-    assert seen["call"]["height"] == 360
-    assert seen["call"]["scenario_titles"] == {}
-    assert seen["call"]["n_largest"] == 50
-    assert seen["call"]["min_value"] == 1.0
-    assert seen["call"]["min_share"] is None
-    assert seen["call"]["max_line_width"] == 8.0
-    assert seen["call"]["min_line_width"] == 0.1
+    assert calls[0]["kwargs"]["metric"] == "ghg_emissions"
+    assert calls[0]["kwargs"]["origin_column"] == "origin_zone_id"
+    assert calls[0]["kwargs"]["destination_column"] == "destination_zone_id"
+    assert calls[0]["kwargs"]["title"] == "Ghg emissions by origin zone and destination zone"
+    assert calls[0]["kwargs"]["width"] == 640
+    assert calls[0]["kwargs"]["height"] == 360
+    assert calls[0]["kwargs"]["scenario_titles"] == {}
+    assert calls[0]["kwargs"]["n_largest"] == 50
+    assert calls[0]["kwargs"]["min_value"] == 1.0
+    assert calls[0]["kwargs"]["min_share"] is None
+    assert calls[0]["kwargs"]["max_line_width"] == 8.0
+    assert calls[0]["kwargs"]["min_line_width"] == 0.1
 
 
 def test_home_zone_metric_map_facets_scenarios():
@@ -1560,7 +1408,6 @@ def test_reference_gap_metric_map_uses_zero_centered_diverging_scale():
 
 def test_results_do_not_expose_parallel_analysis_namespaces(tmp_path, monkeypatch):
     """Check figures and references are requested from metric methods."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     assert not hasattr(results, "plots")
@@ -1569,7 +1416,6 @@ def test_results_do_not_expose_parallel_analysis_namespaces(tmp_path, monkeypatc
 
 def test_metric_arguments_are_validated(tmp_path, monkeypatch):
     """Check bad query arguments fail with clear errors."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path)
 
     with pytest.raises(ValueError, match="table"):
@@ -1602,7 +1448,6 @@ def test_metric_arguments_are_validated(tmp_path, monkeypatch):
 
 def test_single_replication_keeps_multi_seed_schema(tmp_path, monkeypatch):
     """Check that one seed still returns the multi-seed schema."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     results = _results(tmp_path, replication=0)
 
     metric = results.metrics.travel_distance(normalize_by="person_count", normalize_scope="study_area")
@@ -1614,7 +1459,6 @@ def test_single_replication_keeps_multi_seed_schema(tmp_path, monkeypatch):
 
 def test_results_rejects_invalid_replication(tmp_path, monkeypatch):
     """Check that invalid seed indices fail before any run is built."""
-    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     with pytest.raises(ValueError, match="n_replications=2"):
         GroupDayTripsResults(

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -1,17 +1,27 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import geopandas as gpd
+import pandas as pd
+from plotly.basedatatypes import BaseFigure
+import plotly.graph_objects as go
 import polars as pl
 import pytest
+from shapely.geometry import Polygon
 
-from mobility.runtime import Scenarios
+from mobility.reports import TransportZoneMaps
+from mobility.runtime import Scenario, Scenarios
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.trips.group_day_trips.core.group_day_trips import PopulationGroupDayTrips
 from mobility.trips.group_day_trips.results import GroupDayTripsResults
+from mobility.trips.group_day_trips.results.plots import (
+    plot_metric_by_zone,
+    plot_metric_grid_by_zone,
+)
 
 
 class _FakeRun(FileAsset):
-    """Small run asset that writes the tables needed by result table tests."""
+    """Small run asset that writes the tables needed by result assets."""
 
     def __init__(
         self,
@@ -20,20 +30,30 @@ class _FakeRun(FileAsset):
         name: str,
         plan_steps: pl.DataFrame,
         demand_groups: pl.DataFrame,
+        costs: pl.DataFrame,
         iteration_metrics: pl.DataFrame,
+        opportunities: pl.DataFrame | None = None,
+        reference_plan_steps: FileAsset | None = None,
+        transport_zones: FileAsset | None = None,
+        surveys: list | None = None,
         iteration_plan_steps: dict[int, pl.DataFrame] | None = None,
     ) -> None:
         self.frames = {
             "plan_steps": plan_steps,
             "demand_groups": demand_groups,
-            "costs": pl.DataFrame({"from": ["z1"], "to": ["z2"], "cost": [1.0]}),
-            "opportunities": pl.DataFrame(),
+            "costs": costs,
+            "opportunities": opportunities if opportunities is not None else pl.DataFrame(),
             "transitions": pl.DataFrame(),
             "iteration_metrics": iteration_metrics,
         }
+        self._reference_plan_steps = reference_plan_steps
         self._iteration_plan_steps = iteration_plan_steps or {}
-        self.n_iterations = max(self._iteration_plan_steps, default=1)
-        self.population = SimpleNamespace(transport_zones=None)
+        self.parameters = SimpleNamespace(
+            run=SimpleNamespace(n_iterations=max(self._iteration_plan_steps, default=1))
+        )
+        self.n_iterations = self.parameters.run.n_iterations
+        self.population = SimpleNamespace(transport_zones=transport_zones)
+        self.surveys = surveys or []
         cache_path = {
             table_name: base_folder / name / f"{table_name}.parquet"
             for table_name in self.frames
@@ -55,6 +75,10 @@ class _FakeRun(FileAsset):
             frame.write_parquet(path)
         return self.get_cached_asset()
 
+    def _get_expected_diagnostics_inputs(self):
+        """Return the fake survey reference asset expected by new diagnostics."""
+        return SimpleNamespace(population_weighted_plan_steps=self._reference_plan_steps)
+
     def iteration_table(self, table_name: str, iteration: int):
         """Return one fake saved iteration table."""
         if table_name != "plan_steps":
@@ -62,56 +86,202 @@ class _FakeRun(FileAsset):
         return self._iteration_plan_steps[iteration].lazy()
 
 
-def _run_factory(base_folder: Path):
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
-        scenario = "default" if scenario is None else scenario
-        distance_shift = 3.0 if scenario == "test" else 0.0
-        plan_steps = pl.DataFrame(
+class _FakeLazyFrameAsset(FileAsset):
+    """Small parquet-backed asset returning one lazy frame."""
+
+    def __init__(self, *, base_folder: Path, name: str, frame: pl.DataFrame) -> None:
+        self.frame = frame
+        super().__init__({"version": 1, "name": name}, base_folder / f"{name}.parquet")
+
+    def get_cached_asset(self):
+        """Return a lazy parquet reader."""
+        return pl.scan_parquet(self.cache_path)
+
+    def create_and_get_asset(self):
+        """Write the fake frame."""
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.frame.write_parquet(self.cache_path)
+        return self.get_cached_asset()
+
+
+class _FakeTransportZones(FileAsset):
+    """Small transport-zone asset with a study-area table."""
+
+    def __init__(self, *, base_folder: Path) -> None:
+        self.frame = pd.DataFrame(
             {
-                "demand_group_id": [1, 2],
-                "activity_seq_id": [1, 1],
-                "from": ["z1", "z2"],
-                "to": ["z3", "z4"],
-                "mode": ["car", "walk"],
-                "distance": [
-                    10.0 + 10.0 * replication + distance_shift,
-                    5.0 + 2.0 * replication + distance_shift,
-                ],
-                "n_persons": [2.0, 1.0],
+                "transport_zone_id": ["z1", "z2"],
+                "local_admin_unit_id": ["fr001", "fr001"],
+                "is_inner_zone": [True, True],
+                "geometry": [None, None],
             }
         )
+        self.study_area = SimpleNamespace(
+            get=lambda: pd.DataFrame(
+                {
+                    "local_admin_unit_id": ["fr001"],
+                    "country": ["fr"],
+                    "geometry": [None],
+                }
+            )
+        )
+        super().__init__({"version": 1}, base_folder / "transport_zones.parquet")
+
+    def get_cached_asset(self):
+        """Return the transport-zone table."""
+        return self.frame
+
+    def create_and_get_asset(self):
+        """Write a marker parquet and return the in-memory table."""
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        pl.DataFrame(self.frame.drop(columns="geometry")).write_parquet(self.cache_path)
+        return self.frame
+
+
+def _run_factory(base_folder: Path):
+    transport_zones = _FakeTransportZones(base_folder=base_folder)
+    reference_plan_steps = _FakeLazyFrameAsset(
+        base_folder=base_folder,
+        name="survey_reference_plan_steps",
+        frame=pl.DataFrame(
+            {
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "country": ["fr", "fr"],
+                "activity": ["work", "shop"],
+                "mode": ["car", "walk"],
+                "travel_time": [1.0, 1.0],
+                "distance": [8.0, 4.0],
+                "duration_per_pers": [8.0, 1.0],
+                "departure_time": [8.0, 10.0],
+                "arrival_time": [8.5, 10.25],
+                "next_departure_time": [17.0, 11.0],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+    )
+    survey = SimpleNamespace(
+        inputs={"parameters": SimpleNamespace(country="fr")},
+        get=lambda: {
+            "p_immobility": pd.DataFrame(
+                {"immobility_weekday": [0.2, 0.1], "immobility_weekend": [0.3, 0.2]},
+                index=pd.Index(["worker", "retired"], name="csp"),
+            )
+        },
+    )
+
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        scenario_distance_shift = 3.0 if scenario == "test" else 0.0
         demand_groups = pl.DataFrame(
             {
                 "demand_group_id": [1, 2],
                 "home_zone_id": ["z1", "z2"],
                 "csp": ["worker", "retired"],
+                "n_cars": ["1", "0"],
                 "n_persons": [2.0, 1.0],
+            }
+        )
+        plan_steps = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "n_cars": ["1", "0"],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "activity": ["work", "shop"],
+                "distance": [
+                    10.0 + 10.0 * replication + scenario_distance_shift,
+                    5.0 + 2.0 * replication + scenario_distance_shift,
+                ],
+                "time": [1.0 + replication, 0.5 + 0.2 * replication],
+                "duration_per_pers": [8.5, 0.75],
+                "departure_time": [8.0, 10.0],
+                "arrival_time": [8.5, 10.25],
+                "next_departure_time": [17.0, 11.0],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        iteration_plan_steps = {
+            1: plan_steps.with_columns(distance=pl.col("distance") * 0.5).drop(
+                ["home_zone_id", "csp", "n_cars"]
+            ),
+            2: plan_steps.drop(["home_zone_id", "csp", "n_cars"]),
+        }
+        costs = pl.DataFrame(
+            {
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "cost": [2.0 + 2.0 * replication, 1.0 + 2.0 * replication],
+                "ghg_emissions_per_trip": [1.0 + replication, 0.5 + 0.5 * replication],
+            }
+        )
+        opportunities = pl.DataFrame(
+            {
+                "to": ["z3", "z4"],
+                "activity": ["work", "shop"],
+                "opportunity_capacity": [20.0, 10.0],
             }
         )
         iteration_metrics = pl.DataFrame(
             {
                 "iteration": [1, 2],
-                "model_loss": [0.5 + replication, 0.25 + replication],
+                "total_loss": [float(replication), float(replication) + 10.0],
             }
         )
-        iteration_plan_steps = {
-            1: plan_steps.with_columns(distance=pl.col("distance") * 0.5),
-            2: plan_steps,
-        }
         return _FakeRun(
             base_folder=base_folder,
-            name=f"{day_type}-{scenario}-{replication}",
+            name=f"{scenario}-{day_type}-{replication}",
             plan_steps=plan_steps,
             demand_groups=demand_groups,
+            costs=costs,
+            opportunities=opportunities,
             iteration_metrics=iteration_metrics,
+            reference_plan_steps=reference_plan_steps,
+            transport_zones=transport_zones,
+            surveys=[survey],
             iteration_plan_steps=iteration_plan_steps,
         )
 
     return run
 
 
+def _results(
+    tmp_path: Path,
+    *,
+    scenarios="default",
+    n_replications: int = 2,
+    replication=None,
+):
+    return GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios=scenarios,
+        n_replications=n_replications,
+        replication=replication,
+    )
+
+
+def _titled_results(tmp_path: Path):
+    return GroupDayTripsResults(
+        run=_run_factory(tmp_path),
+        day_type="weekday",
+        scenarios=["default", "test"],
+        n_replications=2,
+        scenario_manifest=Scenarios(
+            [
+                Scenario(name="default", title="Reference"),
+                Scenario(name="test", title="Project test"),
+            ]
+        ),
+    )
+
+
 def test_population_group_day_trips_results_selects_all_replications(tmp_path, monkeypatch):
-    """Check that wrapper.results() selects all configured replications by default."""
+    """Check that the top-level results method selects every configured seed."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
     wrapper = PopulationGroupDayTrips.__new__(PopulationGroupDayTrips)
     wrapper.parameters = SimpleNamespace(run=SimpleNamespace(n_replications=2))
@@ -120,14 +290,14 @@ def test_population_group_day_trips_results_selects_all_replications(tmp_path, m
 
     results = wrapper.results("weekday")
 
-    assert [(context.scenario, context.replication) for context in results.run_contexts] == [
-        ("default", 0),
-        ("default", 1),
-    ]
+    assert isinstance(results, GroupDayTripsResults)
+    assert results.scenarios == ["default"]
+    assert results.day_type == "weekday"
+    assert results.replications == [0, 1]
 
 
-def test_results_rejects_invalid_scope(tmp_path, monkeypatch):
-    """Check scenario and replication validation at the public entry point."""
+def test_results_rejects_empty_and_duplicate_scenarios(tmp_path, monkeypatch):
+    """Check that scenario selection fails before any run is built."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
 
     with pytest.raises(ValueError, match="at least one scenario"):
@@ -135,24 +305,15 @@ def test_results_rejects_invalid_scope(tmp_path, monkeypatch):
             run=_run_factory(tmp_path),
             day_type="weekday",
             scenarios=[],
-            n_replications=1,
+            n_replications=2,
         )
 
     with pytest.raises(ValueError, match="duplicate"):
         GroupDayTripsResults(
             run=_run_factory(tmp_path),
             day_type="weekday",
-            scenarios=["a", "a"],
-            n_replications=1,
-        )
-
-    with pytest.raises(ValueError, match="n_replications=1"):
-        GroupDayTripsResults(
-            run=_run_factory(tmp_path),
-            day_type="weekday",
-            scenarios=None,
-            n_replications=1,
-            replication=1,
+            scenarios=["default", "default"],
+            n_replications=2,
         )
 
 
@@ -165,80 +326,1294 @@ def test_results_rejects_scenarios_missing_from_manifest(tmp_path, monkeypatch):
             run=_run_factory(tmp_path),
             day_type="weekday",
             scenarios=["unknown"],
-            n_replications=1,
+            n_replications=2,
             scenario_manifest=Scenarios(),
         )
 
 
-def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
-    """Check raw tables include scenario, day type, iteration, and replication."""
+def test_results_object_no_longer_accepts_iterations(tmp_path, monkeypatch):
+    """Check iteration selection belongs to tables and metrics."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios="default",
+            iterations=[1, 2],
+            n_replications=2,
+        )
+
+
+def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
+    """Check that raw tables keep run identity columns after concatenation."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    plan_steps = results.tables.plan_steps().sort("replication").collect()
+    iteration_metrics = results.diagnostics.iteration_metrics().sort("replication").collect()
+
+    assert plan_steps["scenario"].to_list() == ["default", "default", "default", "default"]
+    assert plan_steps["day_type"].to_list() == ["weekday", "weekday", "weekday", "weekday"]
+    assert plan_steps["iteration"].to_list() == [2, 2, 2, 2]
+    assert plan_steps["replication"].to_list() == [0, 0, 1, 1]
+    assert iteration_metrics["iteration"].to_list() == [2, 2]
+    assert iteration_metrics["total_loss"].to_list() == [10.0, 11.0]
+
+
+def test_result_tables_can_include_multiple_scenarios(tmp_path, monkeypatch):
+    """Check that one result set can concatenate several scenarios."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+
+    plan_steps = results.tables.plan_steps().collect()
+
+    assert results.scenarios == ["default", "test"]
+    assert plan_steps["scenario"].sort().to_list() == [
+        "default",
+        "default",
+        "default",
+        "default",
+        "test",
+        "test",
+        "test",
+        "test",
+    ]
+
+
+def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
+    """Check that raw plan steps can be read from saved iteration artifacts."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    plan_steps = (
+        results.tables.plan_steps(iterations=[1, 2])
+        .sort(["iteration", "mode"])
+        .collect()
+    )
+
+    assert plan_steps["iteration"].to_list() == [1, 1, 2, 2]
+    assert plan_steps["distance"].to_list() == pytest.approx([5.0, 2.5, 10.0, 5.0])
+
+
+def test_trip_count_metrics_keep_selected_iterations(tmp_path, monkeypatch):
+    """Check that metric tables keep iteration when several iterations are selected."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    trip_count = results.metrics.trip_count(
+        by_variable="mode",
+        iterations=[1, 2],
+    ).sort(["iteration", "mode"])
+
+    assert trip_count["iteration"].to_list() == [1, 1, 2, 2]
+    assert trip_count["trip_count"].to_list() == pytest.approx([2.0, 1.0, 2.0, 1.0])
+
+
+def test_iteration_trip_count_can_group_by_home_zone_from_demand_groups(tmp_path, monkeypatch):
+    """Check saved iteration plan steps can use resident zone columns from demand groups."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    trip_count = results.metrics.trip_count(
+        by_zone="home_zone",
+        inner_zone_residents_only=True,
+        iterations=[1, 2],
+    ).sort(["iteration", "home_zone_id"])
+
+    assert trip_count["iteration"].to_list() == [1, 1, 2, 2]
+    assert trip_count["home_zone_id"].to_list() == ["z1", "z2", "z1", "z2"]
+    assert trip_count["trip_count"].to_list() == pytest.approx([2.0, 1.0, 2.0, 1.0])
+
+
+def test_iteration_travel_metrics_can_group_by_demand_group_columns(tmp_path, monkeypatch):
+    """Check saved iteration travel metrics can use columns stored on demand groups."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    distance = results.metrics.travel_distance(
+        by_zone="home_zone",
+        iterations=[1, 2],
+    ).sort(["iteration", "home_zone_id"])
+    time = results.metrics.travel_time(
+        by_variable="csp",
+        iterations=[1, 2],
+    ).sort(["iteration", "csp"])
+
+    assert distance["home_zone_id"].to_list() == ["z1", "z2", "z1", "z2"]
+    assert distance["travel_distance"].to_list() == pytest.approx([10.0, 2.5, 20.0, 5.0])
+    assert time["csp"].to_list() == ["retired", "worker", "retired", "worker"]
+    assert time["travel_time"].to_list() == pytest.approx([0.5, 2.0, 0.5, 2.0])
+
+
+def test_iteration_final_state_metrics_use_demand_group_columns(tmp_path, monkeypatch):
+    """Check saved iteration final-state metrics can join demand-group dimensions."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    immobility = results.metrics.immobility(
+        iterations=[1, 2],
+    ).sort(["iteration", "csp"])
+    demand_group = results.metrics.trip_count_by_demand_group(
+        iterations=[1, 2],
+    ).sort(
+        ["iteration", "home_zone_id"]
+    )
+
+    assert immobility["iteration"].to_list() == [1, 1, 2, 2]
+    assert immobility["csp"].to_list() == ["retired", "worker", "retired", "worker"]
+    assert immobility["p_immobility"].to_list() == pytest.approx([0.0, 0.0, 0.0, 0.0])
+    assert demand_group["home_zone_id"].to_list() == ["z1", "z2", "z1", "z2"]
+    assert demand_group["n_cars"].to_list() == ["1", "0", "1", "0"]
+    assert demand_group["n_trips_per_person"].to_list() == pytest.approx([1.0, 1.0, 1.0, 1.0])
+
+
+def test_compact_trip_count_api_handles_absolute_per_person_and_share(tmp_path, monkeypatch):
+    """Check trip count normalization is controlled by normalize_by."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    absolute = results.metrics.trip_count(by_variable="mode").sort("mode")
+    per_person = results.metrics.trip_count(by_variable="mode", normalize_by="person_count", normalize_scope="study_area").sort("mode")
+    share = results.metrics.trip_count(by_variable="mode", normalize_by="metric_total", normalize_scope="study_area").sort("mode")
+
+    assert absolute["trip_count"].to_list() == pytest.approx([2.0, 1.0])
+    assert per_person["trip_count_per_person"].to_list() == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+    assert share["trip_count_share"].to_list() == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+
+
+def test_metrics_can_group_by_origin_and_destination_zone(tmp_path, monkeypatch):
+    """Check explicit zone dimensions select the matching plan-step zone id."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    by_origin = results.metrics.trip_count(by_zone="origin_zone").sort("origin_zone_id")
+    by_destination = results.metrics.trip_count(by_zone="destination_zone").sort("destination_zone_id")
+
+    assert by_origin["origin_zone_id"].to_list() == ["z1", "z2"]
+    assert by_origin["trip_count"].to_list() == pytest.approx([2.0, 1.0])
+    assert by_destination["destination_zone_id"].to_list() == ["z3", "z4"]
+    assert by_destination["trip_count"].to_list() == pytest.approx([2.0, 1.0])
+
+
+def test_metrics_can_group_by_origin_destination_pairs(tmp_path, monkeypatch):
+    """Check multiple zone dimensions return OD contribution tables."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    od_trips = results.metrics.trip_count(
+        by_zone=["origin_zone", "destination_zone"],
+    ).sort("origin_zone_id")
+    od_distance = results.metrics.travel_distance(
+        by_zone=["origin_zone", "destination_zone"],
+    ).sort("origin_zone_id")
+
+    assert od_trips["origin_zone_id"].to_list() == ["z1", "z2"]
+    assert od_trips["destination_zone_id"].to_list() == ["z3", "z4"]
+    assert od_trips["trip_count"].to_list() == pytest.approx([2.0, 1.0])
+    assert od_distance["travel_distance"].to_list() == pytest.approx([30.0, 6.0])
+
+
+def test_multi_zone_grouping_rejects_normalization(tmp_path, monkeypatch):
+    """Check OD contributions stay absolute until normalization semantics are explicit."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    with pytest.raises(ValueError, match="Normalization is not supported"):
+        results.metrics.trip_count(
+            by_zone=["origin_zone", "destination_zone"],
+            normalize_by="metric_total",
+            normalize_scope="study_area",
+        )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        results.metrics.trip_count(by_zone=["origin_zone", "origin_zone"])
+
+
+def test_zone_person_count_normalization_aligns_zone_id_types(tmp_path, monkeypatch):
+    """Check zone normalization works when run tables store zone ids differently."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        demand_groups = pl.DataFrame(
+            {
+                "home_zone_id": ["1", "2"],
+                "csp": ["worker", "retired"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        plan_steps = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "activity_seq_id": [1, 1],
+                "home_zone_id": [1, 2],
+                "csp": ["worker", "retired"],
+                "from": [1, 2],
+                "to": [3, 4],
+                "mode": ["car", "walk"],
+                "distance": [10.0, 5.0],
+                "time": [1.0, 0.5],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        return _FakeRun(
+            base_folder=tmp_path,
+            name=f"{scenario}-{day_type}-{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            costs=pl.DataFrame({"from": [], "to": [], "mode": []}),
+            iteration_metrics=pl.DataFrame({"iteration": [1], "total_loss": [0.0]}),
+        )
+
     results = GroupDayTripsResults(
-        run=_run_factory(tmp_path),
+        run=run,
+        day_type="weekday",
+        scenarios="default",
+        n_replications=1,
+    )
+
+    metric = results.metrics.trip_count(
+        by_zone="home_zone",
+        normalize_by="person_count",
+        normalize_scope="zone",
+    ).sort("home_zone_id")
+
+    assert metric["home_zone_id"].to_list() == ["1", "2"]
+    assert metric["trip_count_per_person"].to_list() == pytest.approx([1.0, 1.0])
+
+
+def test_metrics_can_filter_to_inner_zone_residents(tmp_path, monkeypatch):
+    """Check metrics can ignore residents whose home zone is outside the inner area."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    class TransportZonesWithOuterZone(_FakeTransportZones):
+        """Fake zones where one resident home zone is outside the inner area."""
+
+        def __init__(self, *, base_folder: Path) -> None:
+            super().__init__(base_folder=base_folder)
+            self.frame["is_inner_zone"] = [True, False]
+
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        transport_zones = TransportZonesWithOuterZone(base_folder=tmp_path)
+        demand_groups = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        plan_steps = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "activity": ["work", "shop"],
+                "distance": [10.0, 5.0],
+                "time": [1.0, 0.5],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        return _FakeRun(
+            base_folder=tmp_path,
+            name=f"{scenario}-{day_type}-{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            costs=pl.DataFrame(
+                {
+                    "from": ["z1", "z2"],
+                    "to": ["z3", "z4"],
+                    "mode": ["car", "walk"],
+                    "cost": [2.0, 1.0],
+                    "ghg_emissions_per_trip": [1.0, 0.5],
+                }
+            ),
+            iteration_metrics=pl.DataFrame({"iteration": [1], "total_loss": [0.0]}),
+            transport_zones=transport_zones,
+        )
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios="default",
+        n_replications=1,
+    )
+
+    trips = results.metrics.trip_count(
+        by_zone=["origin_zone", "destination_zone"],
+        inner_zone_residents_only=True,
+    )
+    distance = results.metrics.travel_distance(
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        inner_zone_residents_only=True,
+    )
+
+    assert trips["origin_zone_id"].to_list() == ["z1"]
+    assert trips["destination_zone_id"].to_list() == ["z3"]
+    assert trips["trip_count"].to_list() == pytest.approx([2.0])
+    assert distance["travel_distance_per_person"].to_list() == pytest.approx([10.0])
+
+
+def test_compact_travel_distance_api_uses_public_travel_distance_name(tmp_path, monkeypatch):
+    """Check travel distance replaces the old distance public name."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    by_mode = results.metrics.travel_distance(by_variable="mode", normalize_by="person_count", normalize_scope="study_area").sort("mode")
+    by_csp = results.metrics.travel_distance(
+        by_variable="csp",
+        normalize_by="person_count",
+        normalize_scope="study_area",
+    ).sort("csp")
+    total = results.metrics.travel_distance()
+
+    assert "travel_distance_per_person" in by_mode.columns
+    assert by_mode["travel_distance_per_person"].to_list() == pytest.approx([10.0, 2.0])
+    assert by_csp["travel_distance_per_person"].to_list() == pytest.approx([2.0, 10.0])
+    assert total["travel_distance"].to_list() == pytest.approx([36.0])
+
+
+def test_compact_time_cost_and_emissions_metrics(tmp_path, monkeypatch):
+    """Check non-trip quantities use the same compact metric API."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    travel_time = results.metrics.travel_time(normalize_by="person_count", normalize_scope="study_area")
+    cost = results.metrics.cost(normalize_by="person_count", normalize_scope="study_area")
+    emissions = results.metrics.ghg_emissions(normalize_by="person_count", normalize_scope="study_area")
+
+    assert travel_time["travel_time_per_person"].to_list() == pytest.approx([3.6 / 3.0])
+    assert cost["cost_per_person"].to_list() == pytest.approx([(5.0 / 3.0 + 11.0 / 3.0) / 2.0])
+    assert emissions["ghg_emissions_per_person"].to_list() == pytest.approx([(2.5 / 3.0 + 5.0 / 3.0) / 2.0])
+
+
+def test_metrics_can_include_survey_reference(tmp_path, monkeypatch):
+    """Check supported quantities can opt into external references."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    distance = results.metrics.travel_distance(
+        by_variable="mode",
+        normalize_by="person_count", normalize_scope="study_area",
+        reference="external",
+    ).sort("mode")
+    share = results.metrics.trip_count(
+        by_variable="mode",
+        normalize_by="metric_total", normalize_scope="study_area",
+        reference="external",
+    ).sort("mode")
+    overall = results.metrics.travel_time(
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        reference="external",
+    )
+    trip_count = results.metrics.trip_count(
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        reference="external",
+    )
+    trip_count_values = results.metrics.trip_count(
+        by_variable="mode",
+        reference="external",
+        reference_view="values",
+    ).sort(["series", "mode"])
+    trip_count_without_reference = results.metrics.trip_count(
+        normalize_by="person_count",
+        normalize_scope="study_area",
+    )
+    inner_zone_reference_plot = results.metrics.trip_count(
+        by_variable="mode",
+        output="plot",
+        inner_zone_residents_only=True,
+        iterations="last",
+        reference="external",
+    )
+    reference_values_plot = results.metrics.trip_count(
+        by_variable="activity",
+        output="plot",
+        reference="external",
+        reference_view="values",
+    )
+
+    assert "country" not in distance.columns
+    assert distance["travel_distance_per_person"].to_list() == pytest.approx([10.0, 2.0])
+    assert distance["travel_distance_per_person_reference"].to_list() == pytest.approx([16.0 / 3.0, 4.0 / 3.0])
+    assert share["trip_count_share_reference"].to_list() == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+    assert overall["travel_time_per_person_reference"].to_list() == pytest.approx([1.0])
+    assert trip_count["trip_count_per_person"].to_list() == pytest.approx(
+        trip_count_without_reference["trip_count_per_person"].to_list()
+    )
+    assert trip_count["trip_count_per_person_reference"].to_list() == pytest.approx([1.0])
+    assert trip_count_values["series"].to_list() == ["model", "model", "reference", "reference"]
+    assert trip_count_values["reference_source"].to_list() == [None, None, "survey", "survey"]
+    assert trip_count_values["trip_count"].to_list() == pytest.approx([2.0, 1.0, 2.0, 1.0])
+    assert isinstance(inner_zone_reference_plot, BaseFigure)
+    reference_traces = [
+        trace
+        for trace in reference_values_plot.data
+        if trace.name == "Reference"
+    ]
+    assert len(reference_traces) == 1
+    assert reference_traces[0].marker.color == "#8A8F98"
+    assert "pattern" not in reference_traces[0].marker.to_plotly_json()
+
+
+def test_external_reference_person_count_uses_reference_population(tmp_path, monkeypatch):
+    """Check external per-person metrics use the population represented by the reference."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    class TransportZonesWithOuterZone(_FakeTransportZones):
+        """Fake zones where one model home zone is outside the reference area."""
+
+        def __init__(self, *, base_folder: Path) -> None:
+            super().__init__(base_folder=base_folder)
+            self.frame["is_inner_zone"] = [True, False]
+
+    transport_zones = TransportZonesWithOuterZone(base_folder=tmp_path)
+    reference_plan_steps = _FakeLazyFrameAsset(
+        base_folder=tmp_path,
+        name="outer_scope_reference_plan_steps",
+        frame=pl.DataFrame(
+            {
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "country": ["fr", "fr"],
+                "activity": ["work", "shop"],
+                "mode": ["car", "walk"],
+                "travel_time": [1.0, 1.0],
+                "distance": [8.0, 4.0],
+                "n_persons": [2.0, 8.0],
+            }
+        ),
+    )
+
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        demand_groups = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "n_persons": [2.0, 8.0],
+            }
+        )
+        plan_steps = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "activity": ["work", "shop"],
+                "distance": [10.0, 5.0],
+                "time": [1.0, 0.5],
+                "n_persons": [2.0, 8.0],
+            }
+        )
+        return _FakeRun(
+            base_folder=tmp_path,
+            name=f"{scenario}-{day_type}-{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            costs=pl.DataFrame({"from": [], "to": [], "mode": []}),
+            iteration_metrics=pl.DataFrame({"iteration": [1], "total_loss": [0.0]}),
+            reference_plan_steps=reference_plan_steps,
+            transport_zones=transport_zones,
+        )
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios="default",
+        n_replications=1,
+    )
+
+    trip_count = results.metrics.trip_count(
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        reference="external",
+    )
+
+    assert trip_count["trip_count_per_person"].to_list() == pytest.approx([1.0])
+    assert trip_count["trip_count_per_person_reference"].to_list() == pytest.approx([1.0])
+
+
+def test_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
+    """Check metric tables can compare scenarios without keeping reference rows."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+
+    distance = results.metrics.travel_distance(
+        by_variable="mode",
+        reference=("scenario", "default"),
+    ).sort("mode")
+
+    assert distance["scenario"].to_list() == ["test", "test"]
+    assert distance["mode"].to_list() == ["car", "walk"]
+    assert distance["reference_source"].to_list() == ["scenario:default", "scenario:default"]
+    assert distance["travel_distance"].to_list() == pytest.approx([36.0, 9.0])
+    assert distance["travel_distance_reference"].to_list() == pytest.approx([30.0, 6.0])
+    assert distance["gap"].to_list() == pytest.approx([6.0, 3.0])
+    assert distance["gap_std"].to_list() == pytest.approx([0.0, 0.0])
+    assert distance["relative_gap"].to_list() == pytest.approx([0.2, 0.5])
+
+    distance_values = results.metrics.travel_distance(
+        by_variable="mode",
+        reference=("scenario", "default"),
+        reference_view="values",
+    ).sort(["series", "scenario", "mode"])
+
+    assert distance_values["scenario"].to_list() == ["test", "test", "default", "default"]
+    assert distance_values["series"].to_list() == ["model", "model", "reference", "reference"]
+    assert distance_values["reference_source"].to_list() == [
+        None,
+        None,
+        "scenario:default",
+        "scenario:default",
+    ]
+    assert distance_values["travel_distance"].to_list() == pytest.approx([36.0, 9.0, 30.0, 6.0])
+
+
+def test_iteration_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
+    """Check scenario references match rows by iteration."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"], replication=0)
+
+    distance = results.metrics.travel_distance(
+        by_variable="mode",
+        iterations=[1, 2],
+        reference=("scenario", "default"),
+    ).sort(["iteration", "mode"])
+
+    assert distance["scenario"].to_list() == ["test", "test", "test", "test"]
+    assert distance["iteration"].to_list() == [1, 1, 2, 2]
+    assert distance["mode"].to_list() == ["car", "walk", "car", "walk"]
+    assert distance["travel_distance"].to_list() == pytest.approx([13.0, 4.0, 26.0, 8.0])
+    assert distance["travel_distance_reference"].to_list() == pytest.approx([10.0, 2.5, 20.0, 5.0])
+    assert distance["gap"].to_list() == pytest.approx([3.0, 1.5, 6.0, 3.0])
+
+    distance_values_plot = results.metrics.travel_distance(
+        by_variable="mode",
+        iterations=[1, 2],
+        reference=("scenario", "default"),
+        reference_view="values",
+        output="plot",
+    )
+
+    assert isinstance(distance_values_plot, BaseFigure)
+
+
+def test_activity_and_bin_dimensions_are_available(tmp_path, monkeypatch):
+    """Check activity, distance bins, and time bins are analysis dimensions."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    by_activity = results.metrics.travel_distance(
+        by_variable="activity",
+        normalize_by="person_count", normalize_scope="study_area",
+        reference="external",
+    ).sort("activity")
+    by_distance_bin = results.metrics.trip_count(by_variable="distance_bin").sort("distance_bin")
+    by_time_bin = results.metrics.travel_time(
+        by_variable="time_bin",
+        normalize_by="person_count", normalize_scope="study_area",
+        reference="external",
+    )
+
+    assert by_activity["activity"].to_list() == ["shop", "work"]
+    assert by_activity["travel_distance_per_person"].to_list() == pytest.approx([2.0, 10.0])
+    assert by_distance_bin["trip_count"].sum() == pytest.approx(3.0)
+    assert "travel_time_per_person_reference" in by_time_bin.columns
+
+
+def test_immobility_and_demand_group_metrics_remain_special_methods(tmp_path, monkeypatch):
+    """Check special result products keep their explicit names."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    immobility = results.metrics.immobility(reference="external").sort("csp")
+    demand_group = results.metrics.trip_count_by_demand_group().sort("home_zone_id")
+
+    assert immobility["p_immobility_reference"].to_list() == pytest.approx([0.1, 0.2])
+    assert demand_group["n_trips_per_person"].to_list() == pytest.approx([1.0, 1.0])
+
+
+def test_sparse_dimension_groups_count_missing_seed_as_zero(tmp_path, monkeypatch):
+    """Check that a group missing in one seed still contributes a zero."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+        demand_groups = pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        mode = ["car", "walk"] if replication == 0 else ["car", "car"]
+        plan_steps = pl.DataFrame(
+            {
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "csp": ["worker", "retired"],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": mode,
+                "distance": [10.0, 5.0],
+                "time": [1.0, 0.5],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        return _FakeRun(
+            base_folder=tmp_path,
+            name=f"{scenario}-{day_type}-{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            costs=pl.DataFrame({"from": [], "to": [], "mode": []}),
+            iteration_metrics=pl.DataFrame({"iteration": [1], "total_loss": [0.0]}),
+        )
+
+    results = GroupDayTripsResults(
+        run=run,
         day_type="weekday",
         scenarios="default",
         n_replications=2,
     )
 
-    table = results.tables.plan_steps().collect()
+    share = results.metrics.trip_count(by_variable="mode", normalize_by="metric_total", normalize_scope="study_area").sort("mode")
 
-    assert {
-        "scenario",
-        "day_type",
-        "iteration",
-        "replication",
-    }.issubset(set(table.columns))
-    assert table["scenario"].unique().to_list() == ["default"]
-    assert set(table["replication"].unique().to_list()) == {0, 1}
-    assert table["iteration"].unique().to_list() == [2]
+    assert share["mode"].to_list() == ["car", "walk"]
+    assert share["trip_count_share"].to_list() == pytest.approx([5.0 / 6.0, 1.0 / 6.0])
 
 
-def test_result_tables_can_include_multiple_scenarios(tmp_path, monkeypatch):
-    """Check scenario selection fans out to all requested concrete runs."""
+def test_activity_duration_distribution_and_time_series_are_model_only_by_default(tmp_path, monkeypatch):
+    """Check time-distribution products can opt into survey rows."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
-    results = GroupDayTripsResults(
-        run=_run_factory(tmp_path),
-        day_type="weekday",
-        scenarios=["default", "test"],
-        n_replications=1,
+    results = _results(tmp_path)
+
+    duration = results.metrics.activity_duration_distribution(bin_width_minutes=60)
+    duration_with_external = results.metrics.activity_duration_distribution(
+        reference="external",
+        bin_width_minutes=60,
+    )
+    time_series = results.metrics.activity_time_series(interval_minutes=60)
+    time_series_with_external = results.metrics.activity_time_series(
+        reference="external",
+        interval_minutes=60,
     )
 
-    table = results.tables.plan_steps().collect()
-
-    assert set(table["scenario"].unique().to_list()) == {"default", "test"}
-    assert table.filter(pl.col("scenario") == "test")["distance"].sum() > table.filter(
-        pl.col("scenario") == "default"
-    )["distance"].sum()
+    assert {"model"} == set(duration["source"].to_list())
+    assert {"model", "survey"} == set(duration_with_external["source"].to_list())
+    assert {"model"} == set(time_series["source"].to_list())
+    assert {"model", "survey"} == set(time_series_with_external["source"].to_list())
 
 
-def test_result_tables_can_select_saved_iterations(tmp_path, monkeypatch):
-    """Check saved iteration selection for plan steps, demand groups, and diagnostics."""
+def test_activity_duration_distribution_and_time_series_can_plot(tmp_path, monkeypatch):
+    """Check time-distribution products can return figures."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
-    results = GroupDayTripsResults(
-        run=_run_factory(tmp_path),
-        day_type="weekday",
-        scenarios=None,
-        n_replications=1,
+    results = _results(tmp_path)
+
+    duration_fig = results.metrics.activity_duration_distribution(
+        bin_width_minutes=60,
+        output="plot",
+        width=640,
+        height=360,
+    )
+    time_series_fig = results.metrics.activity_time_series(
+        interval_minutes=60,
+        output="plot",
+        width=640,
+        height=360,
     )
 
-    plan_steps = results.tables.plan_steps(iterations=[1, 2]).collect()
-    demand_groups = results.tables.demand_groups(iterations=[1, 2]).collect()
-    diagnostics = results.diagnostics.iteration_metrics(iterations=[1, 2]).collect()
+    assert isinstance(duration_fig, BaseFigure)
+    assert duration_fig.layout.title.text == "Activity duration distribution"
+    assert duration_fig.layout.width == 640
+    assert isinstance(time_series_fig, BaseFigure)
+    assert time_series_fig.layout.title.text == "Activity time series"
+    assert time_series_fig.layout.width == 640
 
-    assert set(plan_steps["iteration"].unique().to_list()) == {1, 2}
-    assert set(demand_groups["iteration"].unique().to_list()) == {1, 2}
-    assert diagnostics.select("iteration").to_series().to_list() == [1, 2]
 
-
-def test_result_tables_reject_unavailable_saved_iteration_table(tmp_path, monkeypatch):
-    """Check non-persisted tables fail clearly for saved iteration queries."""
+def test_opportunity_occupation_returns_table(tmp_path, monkeypatch):
+    """Check opportunity occupation keeps capacities with modeled duration."""
     monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
-    results = GroupDayTripsResults(
-        run=_run_factory(tmp_path),
-        day_type="weekday",
-        scenarios=None,
-        n_replications=1,
+    results = _results(tmp_path)
+
+    occupation = results.metrics.opportunity_occupation().sort("activity")
+
+    assert occupation["transport_zone_id"].to_list() == ["z4", "z3"]
+    assert occupation["activity"].to_list() == ["shop", "work"]
+    assert occupation["duration"].to_list() == pytest.approx([0.75, 17.0])
+    assert occupation["opportunity_occupation"].to_list() == pytest.approx([0.075, 0.85])
+    assert occupation["n_replications"].to_list() == [2, 2]
+
+
+def test_opportunity_occupation_plot_uses_zone_helpers(tmp_path, monkeypatch):
+    """Check opportunity occupation can be mapped by activity or as one activity."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+    seen = {}
+
+    def fake_zone_map(maps, values, *, metric, zone_column, title, width, height, **plot_kwargs):
+        seen["zone"] = {
+            "metric": metric,
+            "zone_column": zone_column,
+            "title": title,
+            "values": values,
+            "plot_kwargs": plot_kwargs,
+        }
+        return go.Figure()
+
+    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
+        seen["grid"] = {
+            "metric": metric,
+            "zone_column": zone_column,
+            "variable_column": variable_column,
+            "title": title,
+            "values": values,
+            "plot_kwargs": plot_kwargs,
+        }
+        return go.Figure()
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_by_zone",
+        fake_zone_map,
+    )
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
+        fake_grid_map,
     )
 
-    with pytest.raises(ValueError, match="Saved iteration artifacts"):
-        results.tables.costs(iterations=[1]).collect()
+    grid_fig = results.metrics.opportunity_occupation(output="plot")
+    zone_fig = results.metrics.opportunity_occupation(activity="work", output="plot")
+
+    assert isinstance(grid_fig, BaseFigure)
+    assert isinstance(zone_fig, BaseFigure)
+    assert seen["grid"]["metric"] == "opportunity_occupation"
+    assert seen["grid"]["variable_column"] == "activity"
+    assert seen["zone"]["values"]["activity"].unique().to_list() == ["work"]
+
+
+def test_metric_output_plot_returns_report_figure(tmp_path, monkeypatch):
+    """Check compact metric methods can return Plotly figures."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    fig = results.metrics.travel_distance(
+        by_variable="mode",
+        normalize_by="person_count", normalize_scope="study_area",
+        reference="external",
+        output="plot",
+        width=640,
+        height=360,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert fig.layout.width == 640
+    assert fig.layout.height == 360
+    assert fig.layout.title.text == "Gap to reference: Travel distance per person by mode"
+    assert all(trace.type == "bar" for trace in fig.data)
+    assert [trace.name for trace in fig.data] == ["default"]
+    assert list(fig.data[0].x) == ["car", "walk"]
+    assert list(fig.data[0].y) == pytest.approx([10.0 - 16.0 / 3.0, 2.0 - 4.0 / 3.0])
+
+
+def test_metric_plots_include_all_scenarios_by_default(tmp_path, monkeypatch):
+    """Check that plots use every scenario in the result set by default."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+
+    fig = results.metrics.travel_distance(by_variable="mode", normalize_by="person_count", normalize_scope="study_area", output="plot")
+
+    assert [trace.name for trace in fig.data] == ["default", "test"]
+    assert all(trace.type == "bar" for trace in fig.data)
+    assert list(fig.data[0].y) == pytest.approx([10.0, 2.0])
+    assert list(fig.data[1].y) == pytest.approx([12.0, 3.0])
+
+
+def test_metric_plot_uses_line_chart_for_multiple_iterations(tmp_path, monkeypatch):
+    """Check metric plots use iteration lines when several iterations are selected."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    fig = results.metrics.travel_distance(
+        by_variable="mode",
+        iterations=[1, 2],
+        output="plot",
+        width=640,
+        height=360,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert fig.layout.title.text == "Travel distance by mode"
+    assert fig.layout.xaxis.title.text == "Iteration"
+    assert all(trace.type == "scatter" for trace in fig.data)
+    ribbon_traces = [trace for trace in fig.data if trace.fill == "toself"]
+    line_traces = [trace for trace in fig.data if trace.mode == "lines+markers"]
+    assert len(ribbon_traces) == 2
+    assert all(not trace.showlegend for trace in ribbon_traces)
+    assert [trace.name for trace in line_traces] == ["car", "walk"]
+    assert all(trace.error_y.to_plotly_json() == {} for trace in line_traces)
+    assert list(line_traces[0].x) == [1, 2]
+    assert list(line_traces[0].y) == pytest.approx([15.0, 30.0])
+    assert list(line_traces[1].x) == [1, 2]
+    assert list(line_traces[1].y) == pytest.approx([3.0, 6.0])
+
+
+def test_metric_plot_uses_gap_for_scenario_reference(tmp_path, monkeypatch):
+    """Check scenario-reference plots show the gap to the reference scenario."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+
+    fig = results.metrics.travel_distance(
+        by_variable="mode",
+        reference=("scenario", "default"),
+        output="plot",
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert fig.layout.title.text == "Gap to reference: Travel distance by mode"
+    assert all(trace.type == "bar" for trace in fig.data)
+    assert [trace.name for trace in fig.data] == ["test"]
+    assert list(fig.data[0].x) == ["car", "walk"]
+    assert list(fig.data[0].y) == pytest.approx([6.0, 3.0])
+
+
+def test_metric_plots_use_scenario_titles_when_available(tmp_path, monkeypatch):
+    """Check plot legends show scenario titles while tables keep scenario names."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _titled_results(tmp_path)
+
+    table = results.metrics.travel_distance(by_variable="mode")
+    fig = results.metrics.travel_distance(by_variable="mode", output="plot")
+
+    assert table["scenario"].unique(maintain_order=True).to_list() == ["default", "test"]
+    assert [trace.name for trace in fig.data] == ["Reference", "Project test"]
+
+
+def test_metric_plots_can_filter_scenarios(tmp_path, monkeypatch):
+    """Check that plot methods can select one scenario from the result set."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+
+    fig = results.metrics.trip_count(
+        by_variable="mode",
+        normalize_by="metric_total", normalize_scope="study_area",
+        output="plot",
+        scenarios="test",
+    )
+
+    assert [trace.name for trace in fig.data] == ["test"]
+
+
+def test_home_zone_metric_plot_uses_map_helper(tmp_path, monkeypatch):
+    """Check home-zone metric plots are maps over loaded scenarios."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+    seen = {}
+
+    def fake_home_zone_map(maps, values, *, metric, zone_column, title, width, height, **plot_kwargs):
+        """Record the map inputs without needing test geometries."""
+        seen.setdefault("calls", []).append(
+            {
+                "maps": maps,
+                "values": values,
+                "metric": metric,
+                "zone_column": zone_column,
+                "title": title,
+                "width": width,
+                "height": height,
+                "plot_kwargs": plot_kwargs,
+            }
+        )
+        return go.Figure()
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_by_zone",
+        fake_home_zone_map,
+    )
+
+    fig = results.metrics.travel_distance(
+        by_zone="home_zone",
+        normalize_by="person_count", normalize_scope="zone",
+        output="plot",
+        width=640,
+        height=360,
+    )
+    results.metrics.travel_distance(
+        by_zone="home_zone",
+        normalize_by="person_count", normalize_scope="zone",
+        output="plot",
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert len(seen["calls"]) == 2
+    assert seen["calls"][0]["maps"] is seen["calls"][1]["maps"]
+    assert seen["calls"][0]["metric"] == "travel_distance_per_person"
+    assert seen["calls"][0]["zone_column"] == "home_zone_id"
+    assert seen["calls"][0]["title"] == "Travel distance per person by home zone"
+    assert seen["calls"][0]["width"] == 640
+    assert seen["calls"][0]["height"] == 360
+    assert seen["calls"][0]["values"]["scenario"].unique(maintain_order=True).to_list() == ["default", "test"]
+    assert "home_zone_id" in seen["calls"][0]["values"].columns
+
+
+def test_zone_variable_metric_plot_uses_grid_map_helper(tmp_path, monkeypatch):
+    """Check zone-variable metric plots are scenario x variable map grids."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+    seen = {}
+
+    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
+        """Record grid map inputs without needing test geometries."""
+        seen["call"] = {
+            "maps": maps,
+            "values": values,
+            "metric": metric,
+            "zone_column": zone_column,
+            "variable_column": variable_column,
+            "title": title,
+            "width": width,
+            "height": height,
+            "plot_kwargs": plot_kwargs,
+        }
+        return go.Figure()
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
+        fake_grid_map,
+    )
+
+    fig = results.metrics.trip_count(
+        by_zone="home_zone",
+        by_variable="mode",
+        normalize_by="metric_total",
+        normalize_scope="zone",
+        output="plot",
+        width=640,
+        height=360,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert seen["call"]["metric"] == "trip_count_share"
+    assert seen["call"]["zone_column"] == "home_zone_id"
+    assert seen["call"]["variable_column"] == "mode"
+    assert seen["call"]["title"] == "Trip count share by home zone and mode"
+    assert seen["call"]["width"] == 640
+    assert seen["call"]["height"] == 360
+
+
+def test_reference_gap_map_uses_diverging_colors(tmp_path, monkeypatch):
+    """Check map plots of reference gaps use a zero-centered diverging scale."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+    seen = {}
+
+    def fake_grid_map(maps, values, *, metric, zone_column, variable_column, title, width, height, **plot_kwargs):
+        """Record grid map inputs without needing test geometries."""
+        seen["call"] = {
+            "values": values,
+            "metric": metric,
+            "zone_column": zone_column,
+            "variable_column": variable_column,
+            "title": title,
+            "plot_kwargs": plot_kwargs,
+        }
+        return go.Figure()
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_grid_by_zone",
+        fake_grid_map,
+    )
+
+    fig = results.metrics.trip_count(
+        by_variable="mode",
+        by_zone="home_zone",
+        normalize_by="metric_total",
+        normalize_scope="zone",
+        output="plot",
+        inner_zone_residents_only=True,
+        iterations="last",
+        reference=("scenario", "default"),
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert seen["call"]["metric"] == "gap"
+    assert seen["call"]["title"] == "Gap to reference: Trip count share by home zone and mode"
+    assert seen["call"]["plot_kwargs"]["diverging_center"] == 0.0
+    assert seen["call"]["values"]["scenario"].unique(maintain_order=True).to_list() == ["test"]
+
+
+def test_origin_destination_metric_plot_uses_flow_map_helper(tmp_path, monkeypatch):
+    """Check OD metric plots use the flow-map helper with default top-N filtering."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, scenarios=["default", "test"])
+    seen = {}
+
+    def fake_flow_map(
+        maps,
+        values,
+        *,
+        metric,
+        origin_column,
+        destination_column,
+        title,
+        width,
+        height,
+        scenario_titles,
+        labels,
+        n_largest,
+        min_value,
+        min_share,
+        max_line_width,
+        min_line_width,
+    ):
+        """Record flow-map inputs without needing test geometries."""
+        seen["call"] = {
+            "maps": maps,
+            "values": values,
+            "metric": metric,
+            "origin_column": origin_column,
+            "destination_column": destination_column,
+            "title": title,
+            "width": width,
+            "height": height,
+            "scenario_titles": scenario_titles,
+            "labels": labels,
+            "n_largest": n_largest,
+            "min_value": min_value,
+            "min_share": min_share,
+            "max_line_width": max_line_width,
+            "min_line_width": min_line_width,
+        }
+        return go.Figure()
+
+    monkeypatch.setattr(
+        "mobility.trips.group_day_trips.results.metrics.plot_metric_flows_by_zone",
+        fake_flow_map,
+    )
+
+    fig = results.metrics.ghg_emissions(
+        by_zone=["origin_zone", "destination_zone"],
+        output="plot",
+        width=640,
+        height=360,
+        n_largest=50,
+        min_value=1.0,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert seen["call"]["metric"] == "ghg_emissions"
+    assert seen["call"]["origin_column"] == "origin_zone_id"
+    assert seen["call"]["destination_column"] == "destination_zone_id"
+    assert seen["call"]["title"] == "Ghg emissions by origin zone and destination zone"
+    assert seen["call"]["width"] == 640
+    assert seen["call"]["height"] == 360
+    assert seen["call"]["scenario_titles"] == {}
+    assert seen["call"]["n_largest"] == 50
+    assert seen["call"]["min_value"] == 1.0
+    assert seen["call"]["min_share"] is None
+    assert seen["call"]["max_line_width"] == 8.0
+    assert seen["call"]["min_line_width"] == 0.1
+
+
+def test_home_zone_metric_map_facets_scenarios():
+    """Check the home-zone map helper creates one map facet per scenario."""
+    zones = gpd.GeoDataFrame(
+        {
+            "transport_zone_id": ["z1", "z2"],
+            "is_inner_zone": [True, True],
+            "geometry": [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+            ],
+        },
+        crs=4326,
+    )
+    maps = TransportZoneMaps(zones)
+    values = pl.DataFrame(
+        {
+            "scenario": ["default", "default", "test", "test"],
+            "day_type": ["weekday", "weekday", "weekday", "weekday"],
+            "home_zone_id": ["z1", "z2", "z1", "z2"],
+            "travel_distance_per_person": [1.0, 2.0, 3.0, 4.0],
+            "travel_distance_per_person_std": [0.1, 0.2, 0.3, 0.4],
+            "n_replications": [2, 2, 2, 2],
+        }
+    )
+
+    fig = plot_metric_by_zone(
+        maps,
+        values,
+        metric="travel_distance_per_person",
+        zone_column="home_zone_id",
+        title="Travel distance per person by home zone",
+        scenario_titles={"default": "Reference", "test": "Project test"},
+        width=500,
+        height=300,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert fig.layout.width == 1240
+    assert fig.layout.height == 620
+    assert len(fig.data) == 2
+    assert [annotation.text for annotation in fig.layout.annotations] == ["Reference", "Project test"]
+
+
+def test_zone_variable_metric_map_uses_variable_rows_and_scenario_columns():
+    """Check the zone-variable map helper puts variables in rows."""
+    seen = {}
+
+    class FakeMaps:
+        """Small map facade that records the requested grid layout."""
+
+        def metric_grid(self, values, **kwargs):
+            """Record the grid call and return a figure."""
+            seen["values"] = values
+            seen["kwargs"] = kwargs
+            return go.Figure()
+
+    values = pl.DataFrame(
+        {
+            "scenario": ["default", "test", "default", "test"],
+            "home_zone_id": ["z1", "z1", "z2", "z2"],
+            "mode": ["car", "car", "walk", "walk"],
+            "trip_count_share": [0.7, 0.6, 0.3, 0.4],
+            "trip_count_share_std": [0.01, 0.02, 0.03, 0.04],
+        }
+    )
+
+    fig = plot_metric_grid_by_zone(
+        FakeMaps(),
+        values,
+        metric="trip_count_share",
+        zone_column="home_zone_id",
+        variable_column="mode",
+        title="Trip count share by home zone and mode",
+        width=640,
+        height=360,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert seen["kwargs"]["row_column"] == "mode"
+    assert seen["kwargs"]["column_column"] == "scenario"
+    assert seen["kwargs"]["value_column"] == "trip_count_share"
+    assert seen["kwargs"]["hover_columns"] == ["trip_count_share_std"]
+    assert seen["kwargs"]["range_color"] == (0.0, 1.0)
+    assert seen["values"]["transport_zone_id"].to_list() == ["z1", "z1", "z2", "z2"]
+
+
+def test_reference_gap_metric_map_uses_zero_centered_diverging_scale():
+    """Check gap map helpers use blue-white-red colors centered on zero."""
+    seen = {}
+
+    class FakeMaps:
+        """Small map facade that records the requested color settings."""
+
+        def metric_grid(self, values, **kwargs):
+            """Record the grid call and return a figure."""
+            seen["kwargs"] = kwargs
+            return go.Figure()
+
+    values = pl.DataFrame(
+        {
+            "scenario": ["test", "test"],
+            "home_zone_id": ["z1", "z2"],
+            "mode": ["car", "walk"],
+            "gap": [-0.25, 0.5],
+            "gap_std": [0.01, 0.02],
+        }
+    )
+
+    fig = plot_metric_grid_by_zone(
+        FakeMaps(),
+        values,
+        metric="gap",
+        zone_column="home_zone_id",
+        variable_column="mode",
+        title="Gap to reference: trip count share",
+        diverging_center=0.0,
+    )
+
+    assert isinstance(fig, BaseFigure)
+    assert seen["kwargs"]["color_continuous_midpoint"] == 0.0
+    assert seen["kwargs"]["color_continuous_scale"] == [
+        [0.0, "#2166AC"],
+        [0.5, "#FFFFFF"],
+        [1.0, "#B2182B"],
+    ]
+    assert seen["kwargs"]["range_color"] == (-0.5, 0.5)
+
+
+def test_results_do_not_expose_parallel_analysis_namespaces(tmp_path, monkeypatch):
+    """Check figures and references are requested from metric methods."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    assert not hasattr(results, "plots")
+    assert not hasattr(results.diagnostics, "survey")
+
+
+def test_metric_arguments_are_validated(tmp_path, monkeypatch):
+    """Check bad query arguments fail with clear errors."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path)
+
+    with pytest.raises(ValueError, match="table"):
+        results.metrics.trip_count(by_variable="mode", output="figure")
+
+    with pytest.raises(ValueError, match="normalize_by"):
+        results.metrics.trip_count(normalize_by="share")
+
+    with pytest.raises(ValueError, match="by_variable"):
+        results.metrics.trip_count(by_variable="bad")
+
+    with pytest.raises(ValueError, match="metric_total"):
+        results.metrics.trip_count(normalize_by="metric_total", normalize_scope="study_area")
+
+    with pytest.raises(ValueError, match="normalize_scope"):
+        results.metrics.trip_count(by_variable="mode", normalize_by="person_count")
+
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        results.metrics.trip_count(by="mode")
+
+    with pytest.raises(ValueError, match="No reference"):
+        results.metrics.cost(by_variable="mode", reference="external")
+
+    with pytest.raises(ValueError, match="reference should"):
+        results.metrics.trip_count(by_variable="mode", reference="survey")
+
+    with pytest.raises(ValueError, match="Missing scenarios"):
+        results.metrics.trip_count(by_variable="mode", output="plot", scenarios="other")
+
+
+def test_single_replication_keeps_multi_seed_schema(tmp_path, monkeypatch):
+    """Check that one seed still returns the multi-seed schema."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    results = _results(tmp_path, replication=0)
+
+    metric = results.metrics.travel_distance(normalize_by="person_count", normalize_scope="study_area")
+
+    assert metric["travel_distance_per_person"].to_list() == pytest.approx([25.0 / 3.0])
+    assert metric["travel_distance_per_person_std"].to_list() == [None]
+    assert metric["n_replications"].to_list() == [1]
+
+
+def test_results_rejects_invalid_replication(tmp_path, monkeypatch):
+    """Check that invalid seed indices fail before any run is built."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+
+    with pytest.raises(ValueError, match="n_replications=2"):
+        GroupDayTripsResults(
+            run=_run_factory(tmp_path),
+            day_type="weekday",
+            scenarios="default",
+            n_replications=2,
+            replications=[2],
+        )

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -665,6 +665,12 @@ def test_compact_travel_distance_api_uses_public_travel_distance_name(tmp_path, 
     results = _results(tmp_path)
 
     by_mode = results.metrics.travel_distance(by_variable="mode", normalize_by="person_count", normalize_scope="study_area").sort("mode")
+    by_mode_from_generic_metric = results.metrics.metric(
+        "travel_distance",
+        by_variable="mode",
+        normalize_by="person_count",
+        normalize_scope="study_area",
+    ).sort("mode")
     by_csp = results.metrics.travel_distance(
         by_variable="csp",
         normalize_by="person_count",
@@ -674,6 +680,7 @@ def test_compact_travel_distance_api_uses_public_travel_distance_name(tmp_path, 
 
     assert "travel_distance_per_person" in by_mode.columns
     assert by_mode["travel_distance_per_person"].to_list() == pytest.approx([10.0, 2.0])
+    assert by_mode_from_generic_metric.equals(by_mode)
     assert by_csp["travel_distance_per_person"].to_list() == pytest.approx([2.0, 10.0])
     assert total["travel_distance"].to_list() == pytest.approx([36.0])
 


### PR DESCRIPTION
﻿### Motivation

This PR is the next small split after https://github.com/mobility-team/mobility/pull/347.

The previous result-table PR exposes raw grouped day-trip outputs across scenarios and replications. Users also need higher-level indicators, such as trip counts, distance, time, costs, emissions, immobility, activity durations, and activity time series.

This PR adds those result metrics on top of the scoped result tables. It keeps the result calculations separate from the table-scope API so each part can be reviewed independently.

### Changes

- Add `results.metrics` to `GroupDayTripsResults`.
- Add cached metric assets for trip counts, final-state metrics, survey diagnostics, and time diagnostics.
- Add compact metric methods for trip count, travel distance, travel time, cost, and greenhouse gas emissions.
- Support grouping by zones and variables such as mode, activity, distance bin, time bin, and socio-professional category.
- Support normalization by person count or metric total where applicable.
- Support external survey references and scenario references where available.
- Add plot output helpers for metric tables, iteration series, zone maps, grid maps, flow maps, activity durations, and activity time series.
- Expand result API tests to cover metric calculations, references, normalization, plots, maps, validation, and sparse replication groups.

### Example (if relevant)

```python
results = population_trips.results(
    "weekday",
    scenarios=["default", "project"],
    replications=[0, 1],
)

trip_count = results.metrics.trip_count(by_variable="mode")
distance_by_zone = results.metrics.travel_distance(by_zone="origin_zone")
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: helped split grouped day-trip metrics and plots out of the original large result-analysis PR.
- What you reviewed or changed: kept metric computation, metric plotting, cached metric assets, and metric-focused tests together on top of the smaller result-table and map-helper PRs.
- How you validated it (tests, checks, manual verification): ran the focused grouped day-trip result metrics tests, compiled the touched metric files, and reran the focused cross-stack test set after rebasing the stack.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
