### PR TITLE
Switch quickstart and tests to Limoges

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -26,7 +26,7 @@ If you prefer, you can also call ``mobility.set_params()`` with explicit paths.
 
 The example uses:
 
-* Foix, France, with a 10 km radius, for a small and relatively fast run,
+* Limoges, France, with a 10 km radius, to use the smaller Limousin OSM extract,
 * the French EMP mobility survey,
 * a synthetic population of 1000 people,
 * three transport modes: car, walk, and bicycle,
@@ -48,8 +48,8 @@ mobility.set_params(
     project_data_folder_path=os.environ["MOBILITY_PROJECT_DATA_FOLDER"]
 )
 
-# Using Foix (a small town) and a limited radius for quick results
-transport_zones = mobility.TransportZones("fr-09122", radius=10.0)
+# Using Limoges and a limited radius to reuse the smaller Limousin OSM extract
+transport_zones = mobility.TransportZones("fr-87085", radius=10.0)
 
 # Using EMP, the latest national mobility survey for France
 survey = mobility.EMPMobilitySurvey()
@@ -106,10 +106,10 @@ On a first run, this step can also trigger data preparation and R package setup 
 ### 2. Define the study area
 
 ```python
-transport_zones = mobility.TransportZones("fr-09122", radius=10.0)
+transport_zones = mobility.TransportZones("fr-87085", radius=10.0)
 ```
 
-This creates the study area around Foix and builds the transport-zone input used by the rest of the workflow.
+This creates the study area around Limoges and builds the transport-zone input used by the rest of the workflow.
 
 ### 3. Build the population and model inputs
 
@@ -179,7 +179,7 @@ A successful run should give you:
 * an origin-destination flow plot,
 * a parameter report for traceability.
 
-The first execution can take noticeably longer than later ones because Mobility may need to prepare local data and dependencies.
+The first execution can take noticeably longer than later ones because Mobility may need to prepare local data and dependencies. This example uses the same Limousin OSM extract as the tests, so later runs can reuse the cache.
 
 ## Common first-run issues
 

--- a/examples/quickstart-fr-ci.py
+++ b/examples/quickstart-fr-ci.py
@@ -5,8 +5,8 @@ import mobility
 def run_quickstart_ci():
     # In CI/integration tests, test setup configures Mobility paths in conftest.py.
 
-    # Using Foix (a small town) and a limited radius for quick results
-    transport_zones = mobility.TransportZones("fr-09122", radius=10.0)
+    # Using Limoges and a limited radius to reuse the smaller Limousin OSM extract
+    transport_zones = mobility.TransportZones("fr-87085", radius=10.0)
 
     # Using EMP, the latest national mobility survey for France
     survey = mobility.EMPMobilitySurvey()

--- a/examples/quickstart-fr.py
+++ b/examples/quickstart-fr.py
@@ -13,8 +13,8 @@ dotenv.load_dotenv()
 mobility.set_params(
 )
 
-# Using Foix (a small town) and a limited radius for quick results
-transport_zones = mobility.TransportZones("fr-09122", radius=10.0)
+# Using Limoges and a limited radius to reuse the smaller Limousin OSM extract
+transport_zones = mobility.TransportZones("fr-87085", radius=10.0)
 
 # Using EMP, the latest national mobility survey for France
 survey = mobility.EMPMobilitySurvey()

--- a/mobility/trips/group_day_trips/core/metrics.py
+++ b/mobility/trips/group_day_trips/core/metrics.py
@@ -4602,20 +4602,36 @@ class RunMetrics:
         flows_per_commune = population_df.merge(tzdf, left_on="from", right_on="transport_zone_id")
         flows_per_commune = flows_per_commune.groupby("local_admin_unit_id")["n_persons"].sum().reset_index()
         flows_per_commune = flows_per_commune.merge(study_area_df)
-        flows_per_commune = flows_per_commune.sort_values(by="n_persons", ascending=False).head(n_cities * 2).reset_index()
+        flows_per_commune = (
+            flows_per_commune.sort_values(by="n_persons", ascending=False)
+            .head(n_cities * 2)
+            .reset_index(drop=True)
+        )
+
+        if flows_per_commune.empty:
+            return gpd.GeoDataFrame(
+                columns=["local_admin_unit_id", "local_admin_unit_name", "prominence", "x", "y"]
+            )
+
+        # First rank cities by travel volume, then lower the rank of nearby cities
+        # so labels stay readable on dense maps.
         flows_per_commune.loc[0, "prominence"] = 1
         flows_per_commune.loc[1 : n_cities // 2, "prominence"] = 2
         flows_per_commune.loc[n_cities // 2 + 1 : n_cities, "prominence"] = 3
         flows_per_commune.loc[n_cities + 1 : n_cities * 2, "prominence"] = 3
 
         geoflows = gpd.GeoDataFrame(flows_per_commune)
+        n_reference_cities = min(n_cities // 2, len(geoflows))
 
-        for i in range(n_cities // 2):
-            coords = flows_per_commune.loc[i, "geometry"]
+        for i in range(n_reference_cities):
+            coords = geoflows.loc[i, "geometry"]
             geoflows["dists"] = geoflows["geometry"].distance(coords)
-            geoflows.loc[
-                ((geoflows["dists"] < distance_km * 1000) & (geoflows.index > i)), "prominence"
-            ] = geoflows["prominence"] + 2
+            nearby_lower_ranked_cities = (geoflows["dists"] < distance_km * 1000) & (
+                geoflows.index > i
+            )
+            geoflows.loc[nearby_lower_ranked_cities, "prominence"] = (
+                geoflows.loc[nearby_lower_ranked_cities, "prominence"] + 2
+            )
             geoflows = geoflows.sort_values(by="prominence").reset_index(drop=True)
 
         geoflows = geoflows[geoflows["prominence"] <= n_levels]

--- a/tests/back/integration/conftest.py
+++ b/tests/back/integration/conftest.py
@@ -29,7 +29,7 @@ json._default_encoder = _FallbackJSONEncoder()  # type: ignore[attr-defined]
 # -------------------- Fixtures de test --------------------
 def get_test_data():
     return {
-        "transport_zones_local_admin_unit_id": "fr-09261",  # Saint-Girons
+        "transport_zones_local_admin_unit_id": "fr-87085",  # Limoges keeps tests inside the smaller Limousin OSM extract.
         "transport_zones_radius": 10.0,
         "population_sample_size": 10,
     }

--- a/tests/back/integration/test_008d_group_day_trips_pt_gtfs_parameter_values_change_iteration_2.py
+++ b/tests/back/integration/test_008d_group_day_trips_pt_gtfs_parameter_values_change_iteration_2.py
@@ -114,9 +114,20 @@ def _build_modes(transport_zones: mobility.TransportZones, additional_gtfs_files
     walk_mode = mobility.WalkMode(transport_zones)
     bicycle_mode = mobility.BicycleMode(transport_zones)
     mode_registry = mobility.ModeRegistry([car_mode, walk_mode, bicycle_mode])
+
+    # The synthetic GTFS line is only used to check that iteration 2 picks up
+    # new GTFS inputs, so keep the access and exit walks generous enough for
+    # small test areas.
+    synthetic_gtfs_transfer = mobility.IntermodalTransfer(
+        max_travel_time=2.0,
+        average_speed=5.0,
+        transfer_time=1.0,
+    )
     public_transport_mode = mobility.PublicTransportMode(
         transport_zones,
         mode_registry=mode_registry,
+        first_intermodal_transfer=synthetic_gtfs_transfer,
+        last_intermodal_transfer=synthetic_gtfs_transfer,
         routing_parameters=mobility.PublicTransportRoutingParameters(
             additional_gtfs_files=additional_gtfs_files,
             max_traveltime=10.0,

--- a/tests/back/unit/domain/group_day_trips/test_013_run_metrics_prominent_cities.py
+++ b/tests/back/unit/domain/group_day_trips/test_013_run_metrics_prominent_cities.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+import geopandas as gpd
+import polars as pl
+from shapely.geometry import Point
+
+from mobility.trips.group_day_trips.core.metrics import RunMetrics
+
+
+def test_get_prominent_cities_accepts_small_study_area():
+    plan_steps = pl.DataFrame(
+        {
+            "from": [1, 2, 3, 4, 5, 6],
+            "n_persons": [60.0, 50.0, 40.0, 30.0, 20.0, 10.0],
+        }
+    )
+    transport_zones = gpd.GeoDataFrame(
+        {
+            "transport_zone_id": [1, 2, 3, 4, 5, 6],
+            "local_admin_unit_id": [f"city-{i}" for i in range(1, 7)],
+        },
+        geometry=[Point(i * 5000, 0) for i in range(6)],
+    )
+    study_area = gpd.GeoDataFrame(
+        {
+            "local_admin_unit_id": [f"city-{i}" for i in range(1, 7)],
+            "local_admin_unit_name": [f"City {i}" for i in range(1, 7)],
+        },
+        geometry=[Point(i * 5000, 0) for i in range(6)],
+    )
+    results = SimpleNamespace(
+        plan_steps=SimpleNamespace(collect=lambda: plan_steps),
+        transport_zones=SimpleNamespace(
+            get=lambda: transport_zones,
+            study_area=SimpleNamespace(get=lambda: study_area),
+        ),
+    )
+
+    labels = RunMetrics(results).get_prominent_cities(n_cities=20)
+
+    assert labels.shape[0] <= study_area.shape[0]
+    assert {
+        "local_admin_unit_id",
+        "local_admin_unit_name",
+        "prominence",
+        "x",
+        "y",
+    }.issubset(labels.columns)

--- a/tests/back/unit/test_901_quickstart_drift_guard.py
+++ b/tests/back/unit/test_901_quickstart_drift_guard.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 REQUIRED_SNIPPETS = [
-    'mobility.TransportZones("fr-09122", radius=10.0)',
+    'mobility.TransportZones("fr-87085", radius=10.0)',
     "mobility.EMPMobilitySurvey()",
     "mobility.Population(",
     "mobility.PopulationGroupDayTrips(",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def pytest_configure(config):
 
 def get_test_data():
     return {
-        "transport_zones_local_admin_unit_id": "fr-09261", #fails with Foix 09122 and Rodez 12202, let's test Saint-Girons
+        "transport_zones_local_admin_unit_id": "fr-87085",  # Limoges keeps tests inside the smaller Limousin OSM extract.
         "transport_zones_radius": 10.0,
         "population_sample_size": 10
     }


### PR DESCRIPTION
### Motivation
Closes #325.

The quickstart and tests used Foix or Saint-Girons, which made Mobility download the large Midi-Pyrenees OSM extract. This PR moves them to Limoges so they use the smaller Limousin extract.

### Changes
- Use Limoges (`fr-87085`) with the same 10 km radius in the quickstart, CI quickstart, and shared test fixtures.
- Update the quickstart documentation and drift guard.
- Fix `get_prominent_cities()` so it works when a small study area has fewer communes than the default number of labels.
- Keep the synthetic GTFS profile test connected in the new small test area.
- Add a unit test for the small-study-area label case.

### Example (if relevant)
```python
transport_zones = mobility.TransportZones(fr-87085, radius=10.0)
```

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: code, test, and documentation updates for this issue.
- What you reviewed or changed: reviewed the changed files and kept the fix limited to the quickstart/test path and the exposed label bug.
- How you validated it (tests, checks, manual verification): ran focused pytest checks with `mamba run -n mobility python -m pytest --local --use-truststore`, including quickstart, metrics, and GTFS profile checks.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior