### PR TITLE
Use prebuilt CI image for tests

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -11,70 +11,64 @@ on:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12
     strategy:
       max-parallel: 5
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Install conda dependencies
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        micromamba-version: '2.0.5-0'
-        environment-file: environment-test.yml
-        init-shell: bash
-        cache-environment: true
-        post-cleanup: 'environment'
-
-    - name: Install Python dependencies
+    - name: Select Python dependencies
       run: |
-        uv pip sync ${{ inputs.requirements_file }}
-        uv pip install -e . --no-deps
-      shell: bash -el {0}
+        if [[ "${{ inputs.use_min_dep_versions }}" == "true" ]]; then
+          python_env="/opt/venv-min"
+        else
+          python_env="/opt/venv-ci"
+        fi
 
-    - name: Set up R
-      uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: '4.4.1'
-        use-public-rspm: true
+        echo "VIRTUAL_ENV=${python_env}" >> "${GITHUB_ENV}"
+        echo "${python_env}/bin" >> "${GITHUB_PATH}"
+        echo "Using pre-installed Python dependencies from ${python_env}"
+      shell: bash
 
-    - name: Install R packages
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        cache: true
+    - name: Install current package
+      run: |
+        uv pip install --python "${VIRTUAL_ENV}/bin/python" -e . --no-deps
+      shell: bash
 
     - name: Lint with flake8
       if: ${{ !inputs.use_min_dep_versions }}
       run: |
         python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      shell: bash -el {0}
+      shell: bash
 
     - name: Test unit with pytest
       if: ${{ !inputs.use_min_dep_versions }}
       run: |
         python -m pytest tests/back/unit --cov=mobility --cov-config=.coveragerc --cov-append --log-cli-level=INFO --clear_inputs
-      shell: bash -el {0}
+      shell: bash
 
     - name: Test integration with pytest
       if: ${{ !inputs.use_min_dep_versions }}
       run: |
         python -m pytest tests/back/integration --cov=mobility --cov-config=.coveragerc --cov-append --log-cli-level=INFO --clear_inputs
-      shell: bash -el {0}
+      shell: bash
 
     - name: Build coverage report
       if: ${{ !inputs.use_min_dep_versions }}
       run: |
         python -m coverage xml -o coverage.xml
-      shell: bash -el {0}
+      shell: bash
 
     - name: Test with pytest without coverage
       if: ${{ inputs.use_min_dep_versions }}
       run: |
         python -m pytest --log-cli-level=INFO --clear_inputs
-      shell: bash -el {0}
+      shell: bash
 
     - name: Upload coverage reports to Codecov
       if: ${{ !inputs.use_min_dep_versions }}


### PR DESCRIPTION
### Motivation
CI test jobs currently spend time creating a micromamba environment, syncing Python dependencies, installing R, and resolving R package dependencies. The reusable CI image now contains those dependency layers, so test jobs can start from a prepared environment instead of rebuilding it every run.

### Changes
The reusable test workflow now runs on ubuntu-24.04 inside ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12. The workflow selects the pre-installed pinned or minimum Python environment from the image, installs the current checkout in editable mode without dependencies, then runs the existing lint, unit, integration, coverage, and minimum-dependency test commands.

This removes the per-job micromamba setup, Python dependency sync, R setup, and R dependency install steps from the test workflow. That should reduce CI setup time and make runs less dependent on transient package-cache and apt-cache behavior.

### Example (if relevant)
The existing test workflows keep using test-reusable.yml. They now get dependencies from the prebuilt CI image instead of installing them during each job.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: updated the reusable GitHub Actions test workflow to use the prebuilt GHCR image.
- What you reviewed or changed: checked the workflow diff and kept the existing test commands unchanged after dependency setup.
- How you validated it (tests, checks, manual verification): ran git diff --check locally. The pull request checks validate that the published image can run the test workflow.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior