### PR TITLE
Add gpg to CI image

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gdebi-core \
     git \
+    gnupg \
     osmium-tool \
     python3.12 \
     python3.12-venv \


### PR DESCRIPTION
### Motivation
The prebuilt CI image can run the test suite, but the Codecov action needs gpg inside the job container. Without it, coverage upload fails after the tests pass.

### Changes
Adds gnupg to the bootstrap tools installed in the CI image. This keeps the image compatible with Codecov when test jobs run inside the container.

### Example (if relevant)
The test workflow can upload coverage from inside ghcr.io/mobility-team/mobility-ci after this image is rebuilt.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: identified the missing container tool from the failed CI log and updated the CI Dockerfile.
- What you reviewed or changed: added only gnupg to the image bootstrap package list.
- How you validated it (tests, checks, manual verification): ran git diff --check locally. The image build workflow validates the Dockerfile on GitHub.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior