### PR TITLE
Fix runtime asset DAG traversal

### DIFF
--- a/mobility/runtime/assets/__init__.py
+++ b/mobility/runtime/assets/__init__.py
@@ -1,9 +1,11 @@
 from .asset import Asset
 from .file_asset import FileAsset
+from .graph import build_asset_graph
 from .in_memory_asset import InMemoryAsset
 
 __all__ = [
     "Asset",
     "FileAsset",
+    "build_asset_graph",
     "InMemoryAsset",
 ]

--- a/mobility/runtime/assets/file_asset.py
+++ b/mobility/runtime/assets/file_asset.py
@@ -4,6 +4,7 @@ import logging
 import networkx as nx
 
 from mobility.runtime.assets.asset import Asset
+from mobility.runtime.assets.graph import build_upstream_file_asset_graph
 from typing import Any
 from abc import abstractmethod
 
@@ -148,57 +149,9 @@ class FileAsset(Asset):
             RuntimeError: If a dependency cycle is detected among FileAssets.
         """
         
-        # Build a graph of input assets
-        graph = nx.DiGraph()
-
-        def iter_file_assets(value):
-            if isinstance(value, FileAsset):
-                yield value
-            elif isinstance(value, dict):
-                for nested in value.values():
-                    yield from iter_file_assets(nested)
-            elif isinstance(value, (list, tuple, set)):
-                for nested in value:
-                    yield from iter_file_assets(nested)
-        
-        canonical_assets = {}
-
-        def asset_cache_key(asset):
-            if isinstance(asset.cache_path, dict):
-                cache_path = tuple(
-                    (str(key), str(path))
-                    for key, path in sorted(asset.cache_path.items())
-                )
-            else:
-                cache_path = str(asset.cache_path)
-            return (asset.__class__, asset.inputs_hash, cache_path)
-
-        def canonical_asset(asset):
-            key = asset_cache_key(asset)
-            if key not in canonical_assets:
-                canonical_assets[key] = asset
-            return canonical_assets[key]
-
-        visited_asset_keys = set()
-
-        def add_upstream_deps(asset):
-            asset = canonical_asset(asset)
-            asset_key = asset_cache_key(asset)
-            graph.add_node(asset)
-            if asset_key in visited_asset_keys:
-                return
-
-            visited_asset_keys.add(asset_key)
-            for inp in asset.inputs.values():
-                for dep in iter_file_assets(inp):
-                    dep = canonical_asset(dep)
-                    graph.add_node(dep)
-                    graph.add_edge(dep, asset)
-                    add_upstream_deps(dep)
-        
-        for inp in self.inputs.values():
-            for dep in iter_file_assets(inp):
-                add_upstream_deps(dep)
+        # Build the graph of upstream file assets. The same graph builder is
+        # also used by the debug UI, so both paths see the same dependencies.
+        graph = build_upstream_file_asset_graph(self)
 
         logging.debug(
             "Asset DAG for %s (%s) has %s upstream assets and %s dependency edges.",

--- a/mobility/runtime/assets/graph.py
+++ b/mobility/runtime/assets/graph.py
@@ -1,0 +1,315 @@
+import pathlib
+from typing import Any
+
+import networkx as nx
+
+from mobility.runtime.assets.asset import Asset
+
+
+def build_asset_graph(
+    root_asset: Asset,
+    *,
+    include_root: bool = True,
+    file_assets_only: bool = False,
+    include_node_data: bool = True,
+) -> nx.DiGraph:
+    """Build the dependency graph under one asset.
+
+    Args:
+        root_asset: Asset used as the graph root.
+        include_root: If ``True``, include ``root_asset`` as a graph node.
+            If ``False``, only include assets found in its inputs.
+        file_assets_only: If ``True``, only keep file-backed assets. This is
+            the execution graph used by ``FileAsset`` before it rebuilds stale
+            dependencies.
+        include_node_data: If ``True``, attach cache status and display
+            metadata to graph nodes. Runtime rebuild logic keeps this disabled
+            so it does not do viewer-only filesystem checks.
+
+    Returns:
+        A directed graph where edges point from an input asset to the asset that
+        depends on it.
+    """
+
+    graph = nx.DiGraph()
+    canonical_assets = {}
+    visited_asset_keys = set()
+
+    def canonical_asset(asset: Asset) -> Asset:
+        key = asset_graph_key(asset)
+        if key not in canonical_assets:
+            canonical_assets[key] = asset
+        return canonical_assets[key]
+
+    def add_asset(asset: Asset) -> Asset:
+        asset = canonical_asset(asset)
+        asset_key = asset_graph_key(asset)
+        if include_node_data:
+            graph.add_node(asset, **asset_graph_node_data(asset))
+        else:
+            graph.add_node(asset)
+
+        if asset_key in visited_asset_keys:
+            return asset
+
+        visited_asset_keys.add(asset_key)
+        for input_name, input_value in asset.inputs.items():
+            for dependency in iter_asset_dependencies(
+                input_value,
+                file_assets_only=file_assets_only,
+            ):
+                dependency = add_asset(dependency)
+                graph.add_edge(dependency, asset, input_name=input_name)
+
+        return asset
+
+    if include_root and (not file_assets_only or is_file_asset(root_asset)):
+        add_asset(root_asset)
+    else:
+        for input_value in root_asset.inputs.values():
+            for dependency in iter_asset_dependencies(
+                input_value,
+                file_assets_only=file_assets_only,
+            ):
+                add_asset(dependency)
+
+    return graph
+
+
+def build_asset_graph_from_roots(
+    root_assets: list[Asset] | tuple[Asset, ...],
+    *,
+    include_node_data: bool = True,
+) -> nx.DiGraph:
+    """Build one dependency graph from several root assets."""
+
+    graph = nx.DiGraph()
+    canonical_assets = {}
+
+    def canonical_asset(asset: Asset) -> Asset:
+        key = asset_graph_key(asset)
+        if key not in canonical_assets:
+            canonical_assets[key] = asset
+        return canonical_assets[key]
+
+    for root_asset in root_assets:
+        root_context = asset_run_context(root_asset)
+        root_graph = build_asset_graph(
+            root_asset,
+            include_root=True,
+            file_assets_only=False,
+            include_node_data=include_node_data,
+        )
+        if include_node_data:
+            for _, data in root_graph.nodes(data=True):
+                data["run_contexts"] = (root_context,)
+
+        for asset, data in root_graph.nodes(data=True):
+            asset = canonical_asset(asset)
+            if asset in graph:
+                if include_node_data:
+                    contexts = set(graph.nodes[asset].get("run_contexts", ()))
+                    contexts.update(data.get("run_contexts", ()))
+                    graph.nodes[asset]["run_contexts"] = tuple(sorted(contexts))
+            else:
+                graph.add_node(asset, **data)
+
+        for source, target, data in root_graph.edges(data=True):
+            graph.add_edge(
+                canonical_asset(source),
+                canonical_asset(target),
+                **data,
+            )
+    return graph
+
+
+def build_upstream_file_asset_graph(root_asset: Asset) -> nx.DiGraph:
+    """Build the file-backed upstream graph used before an asset is rebuilt."""
+
+    return build_asset_graph(
+        root_asset,
+        include_root=False,
+        file_assets_only=True,
+        include_node_data=False,
+    )
+
+
+def iter_asset_dependencies(
+    value: Any,
+    *,
+    file_assets_only: bool = False,
+    visited_assets: set[int] | None = None,
+):
+    """Yield assets nested in one input value."""
+
+    if visited_assets is None:
+        visited_assets = set()
+
+    if isinstance(value, Asset):
+        asset_id = id(value)
+        if asset_id in visited_assets:
+            return
+        visited_assets.add(asset_id)
+
+        if not file_assets_only or is_file_asset(value):
+            yield value
+            return
+
+        # Runtime cache checks keep the graph limited to FileAssets, but some
+        # FileAssets are stored below in-memory assets such as transport modes.
+        # Look through these in-memory assets so hidden file dependencies are
+        # still rebuilt before their descendants are read.
+        for nested in value.inputs.values():
+            yield from iter_asset_dependencies(
+                nested,
+                file_assets_only=file_assets_only,
+                visited_assets=visited_assets,
+            )
+        return
+
+    if isinstance(value, dict):
+        for nested in value.values():
+            yield from iter_asset_dependencies(
+                nested,
+                file_assets_only=file_assets_only,
+                visited_assets=visited_assets,
+            )
+        return
+
+    if isinstance(value, (list, tuple, set)):
+        for nested in value:
+            yield from iter_asset_dependencies(
+                nested,
+                file_assets_only=file_assets_only,
+                visited_assets=visited_assets,
+            )
+
+
+def is_file_asset(asset: Asset) -> bool:
+    """Return True for assets backed by cache files."""
+
+    return (
+        hasattr(asset, "cache_path")
+        and hasattr(asset, "hash_path")
+        and hasattr(asset, "is_update_needed")
+    )
+
+
+def asset_graph_key(asset: Asset) -> tuple:
+    """Return a stable key used to deduplicate equivalent graph assets."""
+
+    if is_file_asset(asset):
+        return (
+            asset.__class__,
+            asset.inputs_hash,
+            cache_path_value(asset),
+        )
+    return (asset.__class__, asset.inputs_hash)
+
+
+def asset_graph_node_data(asset: Asset) -> dict[str, Any]:
+    """Return plain node metadata for graph views and exports."""
+
+    existing_outputs, missing_outputs = asset_output_paths_by_existence(asset)
+    data = {
+        "asset_type": asset.__class__.__name__,
+        "inputs_hash": getattr(asset, "inputs_hash", None),
+        "status": asset_cache_status(asset),
+        "cache_path": cache_path_value(asset),
+        "existing_outputs": existing_outputs,
+        "missing_outputs": missing_outputs,
+        "cached_hash": asset_cached_hash(asset),
+    }
+
+    # These attributes are common on simulation assets and help filter long
+    # group-day-trips graphs without adding model-specific code here.
+    for attribute_name in ["iteration", "scenario", "replication", "is_weekday"]:
+        if hasattr(asset, attribute_name):
+            data[attribute_name] = getattr(asset, attribute_name)
+
+    return data
+
+
+def asset_run_context(asset: Asset) -> str:
+    """Return the scenario/day-type/replication context for a root asset."""
+
+    scenario = getattr(asset, "scenario", None) or "default"
+    replication = getattr(asset, "replication", None)
+    if replication is None:
+        replication = "unknown"
+
+    is_weekday = getattr(asset, "is_weekday", None)
+    if is_weekday is True:
+        day_type = "weekday"
+    elif is_weekday is False:
+        day_type = "weekend"
+    else:
+        day_type = "unknown"
+
+    return f"{scenario}|{day_type}|{replication}"
+
+
+def asset_cache_status(asset: Asset) -> str:
+    """Return a simple cache status for one asset."""
+
+    if not is_file_asset(asset):
+        return "not_file_asset"
+
+    if asset.inputs_changed():
+        return "stale"
+    if asset.assets_missing():
+        return "missing"
+    return "cached"
+
+
+def asset_output_paths_by_existence(asset: Asset) -> tuple[tuple[str, str], tuple[str, str]]:
+    """Split cache output paths into existing and missing groups."""
+
+    if not is_file_asset(asset):
+        return (), ()
+
+    existing_outputs = []
+    missing_outputs = []
+
+    cache_path = getattr(asset, "cache_path", None)
+    if cache_path is None:
+        return (), ()
+    if isinstance(cache_path, dict):
+        output_paths = [
+            (str(key), pathlib.Path(path))
+            for key, path in sorted(cache_path.items())
+        ]
+    else:
+        output_paths = [("output", pathlib.Path(cache_path))]
+
+    for key, path in output_paths:
+        row = (key, str(path))
+        if path.exists():
+            existing_outputs.append(row)
+        else:
+            missing_outputs.append(row)
+
+    return tuple(existing_outputs), tuple(missing_outputs)
+
+
+def asset_cached_hash(asset: Asset) -> str | None:
+    """Return the on-disk input hash when an asset exposes one."""
+
+    if not is_file_asset(asset):
+        return None
+    return asset.get_cached_hash()
+
+
+def cache_path_value(asset: Asset) -> str | tuple[tuple[str, str], ...] | None:
+    """Return cache paths as simple values that can be used in JSON-like data."""
+
+    cache_path = getattr(asset, "cache_path", None)
+    if cache_path is None:
+        return None
+
+    if isinstance(cache_path, dict):
+        return tuple(
+            (str(key), str(pathlib.Path(path)))
+            for key, path in sorted(cache_path.items())
+        )
+    return str(pathlib.Path(cache_path))

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -96,6 +96,14 @@ class Run(FileAsset):
             scenario=scenario,
             replication=replication,
         )
+        self.population = population
+        self.activities = activities
+        self.modes = modes
+        self.surveys = surveys
+        self.survey_plan_assets = survey_plan_assets
+        self.parameters = parameters
+        self.is_weekday = is_weekday
+        self.enabled = enabled
         self.scenario = scenario
         self.replication = int(replication)
 
@@ -147,8 +155,8 @@ class Run(FileAsset):
         )
 
         inputs = {
-            **run_context_inputs,
-            "version": 18,
+            "version": 19,
+            "run_context_hash": run_context_hash,
             "final_iteration_state": self.final_iteration_state,
         }
 

--- a/mobility/trips/group_day_trips/iterations/iteration_assets.py
+++ b/mobility/trips/group_day_trips/iterations/iteration_assets.py
@@ -23,6 +23,7 @@ from mobility.trips.group_day_trips.plans.plan_initializer import PlanInitialize
 from mobility.trips.group_day_trips.plans.plan_updater import PlanUpdater
 from mobility.trips.group_day_trips.transitions.transition_events import TransitionEventsAsset
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
+from mobility.transport.modes.core.mode_values import get_mode_values
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
 from ..plans.candidate_plan_steps import CandidatePlanStepsAsset
 
@@ -172,7 +173,10 @@ class InitialIterationStateAsset(FileAsset):
                 for activity in activities
             ],
             "initial_activity_parameters": initial_activity_parameters,
-            "modes": modes,
+            # The initial stay-home state only needs the canonical mode enum.
+            # Keep the full mode objects as runtime attributes so scenario
+            # routing parameters do not leak into this initial-state hash.
+            "mode_values": get_mode_values(modes, "stay_home"),
             "run_seed": parameters.run.seed,
             "min_activity_time_constant": parameters.plan_update.min_activity_time_constant,
             "initial_transport_costs": initial_transport_costs,
@@ -295,6 +299,7 @@ class PersonODFlowsByModeAsset(FileAsset):
         previous_state: FileAsset,
     ) -> None:
         self.source_iteration = int(source_iteration)
+        self.iteration = self.source_iteration
         self.previous_state = previous_state
         inputs = {
             "version": 1,

--- a/tests/back/unit/domain/group_day_trips/test_016_run_inputs.py
+++ b/tests/back/unit/domain/group_day_trips/test_016_run_inputs.py
@@ -1,0 +1,152 @@
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.graph import build_asset_graph
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+from mobility.trips.group_day_trips.iterations import iteration_assets
+from mobility.trips.group_day_trips.core import run as run_module
+from mobility.trips.group_day_trips.core.parameters import (
+    GroupDayTripsParameters,
+    GroupDayTripsRunParameters,
+)
+from mobility.trips.group_day_trips.core.run import Run
+
+
+class _MemoryAsset(InMemoryAsset):
+    def __init__(self, name):
+        super().__init__({"name": name})
+
+
+class _FinalStateAsset(FileAsset):
+    def __init__(self, cache_folder):
+        super().__init__({"name": "final-state"}, cache_folder / "final_state.json")
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _ModeParameters(BaseModel):
+    name: str
+    survey_ids: list[str]
+
+
+class _ModeAsset(InMemoryAsset):
+    def __init__(self, *, name, hidden_file_asset):
+        super().__init__(
+            {
+                "parameters": _ModeParameters(
+                    name=name,
+                    survey_ids=[],
+                ),
+                "travel_costs": hidden_file_asset,
+            }
+        )
+
+
+def test_run_inputs_keep_context_objects_out_of_direct_dependencies(tmp_path, monkeypatch):
+    """Run keeps setup objects as attributes, not as direct execution inputs."""
+    final_state = _FinalStateAsset(tmp_path)
+
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    monkeypatch.setattr(
+        run_module,
+        "Iterations",
+        lambda **kwargs: SimpleNamespace(folder_paths={}),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "InitialIterationStateAsset",
+        lambda **kwargs: _MemoryAsset("initial-state"),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "IterationTransportCostsAsset",
+        lambda **kwargs: _MemoryAsset("initial-costs"),
+    )
+    monkeypatch.setattr(
+        Run,
+        "_build_iteration_state_assets",
+        lambda self, **kwargs: [final_state],
+    )
+
+    population = _MemoryAsset("population")
+    activity = _MemoryAsset("activity")
+    mode = _MemoryAsset("mode")
+    survey = _MemoryAsset("survey")
+    survey_plan_assets = _MemoryAsset("survey-plan-assets")
+    transport_costs = _MemoryAsset("transport-costs")
+    parameters = GroupDayTripsParameters(
+        run=GroupDayTripsRunParameters(n_iterations=1),
+    )
+
+    run = Run(
+        population=population,
+        transport_costs=transport_costs,
+        activities=[activity],
+        modes=[mode],
+        surveys=[survey],
+        survey_plan_assets=survey_plan_assets,
+        parameters=parameters,
+        is_weekday=True,
+        scenario="default",
+    )
+
+    assert run.population is population
+    assert run.activities == [activity]
+    assert run.modes == [mode]
+    assert run.surveys == [survey]
+    assert run.survey_plan_assets is survey_plan_assets
+    assert set(run.inputs) == {"version", "run_context_hash", "final_iteration_state"}
+
+    graph = build_asset_graph(run)
+    direct_parents = set(graph.predecessors(run))
+
+    assert direct_parents == {final_state}
+
+
+def test_initial_state_inputs_keep_full_modes_out_of_dependencies(tmp_path, monkeypatch):
+    """Initial state hashes mode names, not full unresolved mode assets."""
+    hidden_file_asset = _FinalStateAsset(tmp_path / "hidden")
+    mode = _ModeAsset(name="walk/public_transport/walk", hidden_file_asset=hidden_file_asset)
+
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    monkeypatch.setattr(
+        iteration_assets,
+        "PopulationWeightedPlanSteps",
+        lambda **kwargs: _MemoryAsset("population-weighted-plan-steps"),
+    )
+    monkeypatch.setattr(
+        iteration_assets,
+        "resolve_activity_parameters",
+        lambda activities, iteration, scenario=None: {},
+    )
+
+    initial_state = iteration_assets.InitialIterationStateAsset(
+        is_weekday=True,
+        base_folder=tmp_path,
+        population=_MemoryAsset("population"),
+        survey_plan_assets=_MemoryAsset("survey-plan-assets"),
+        activities=[
+            SimpleNamespace(
+                name="home",
+                has_opportunities=False,
+                opportunities=None,
+                inputs={},
+            )
+        ],
+        modes=[mode],
+        parameters=GroupDayTripsParameters(),
+        scenario="default",
+        initial_transport_costs=_MemoryAsset("initial-transport-costs"),
+    )
+
+    graph = build_asset_graph(initial_state)
+
+    assert "modes" not in initial_state.inputs
+    assert initial_state.inputs["mode_values"] == ["walk/public_transport/walk", "stay_home"]
+    assert hidden_file_asset not in graph

--- a/tests/back/unit/runtime/test_001_file_asset_deduplicates_upstream_assets.py
+++ b/tests/back/unit/runtime/test_001_file_asset_deduplicates_upstream_assets.py
@@ -1,4 +1,5 @@
 from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
 
 
 class _CountingAsset(FileAsset):
@@ -27,6 +28,11 @@ class _ParentAsset(FileAsset):
         return None
 
 
+class _MemoryWrapperAsset(InMemoryAsset):
+    def __init__(self, *, child):
+        super().__init__({"child": child})
+
+
 def test_update_ancestors_deduplicates_logically_identical_file_assets(tmp_path):
     """Do not rebuild the same upstream asset twice when it appears as two objects."""
     _CountingAsset.create_calls = 0
@@ -41,3 +47,17 @@ def test_update_ancestors_deduplicates_logically_identical_file_assets(tmp_path)
 
     assert _CountingAsset.create_calls == 1
     assert first_child.cache_path.exists()
+
+
+def test_update_ancestors_rebuilds_file_assets_below_in_memory_file_inputs(tmp_path):
+    """Rebuild file assets even when an in-memory asset sits below another FileAsset."""
+    _CountingAsset.create_calls = 0
+    child = _CountingAsset(name="hidden", cache_folder=tmp_path / "child")
+    wrapper = _MemoryWrapperAsset(child=child)
+    bridge = _ParentAsset(children=[wrapper], cache_folder=tmp_path / "bridge")
+    parent = _ParentAsset(children=[bridge], cache_folder=tmp_path / "parent")
+
+    parent.update_ancestors_if_needed()
+
+    assert _CountingAsset.create_calls == 1
+    assert child.cache_path.exists()

--- a/tests/back/unit/runtime/test_002_asset_graph.py
+++ b/tests/back/unit/runtime/test_002_asset_graph.py
@@ -1,0 +1,183 @@
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.graph import (
+    build_asset_graph,
+    build_asset_graph_from_roots,
+    build_upstream_file_asset_graph,
+)
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+
+
+class _TextAsset(FileAsset):
+    status_checks = 0
+
+    def __init__(self, *, name, cache_folder):
+        super().__init__({"name": name}, cache_folder / "text_asset.txt")
+
+    def is_update_needed(self):
+        _TextAsset.status_checks += 1
+        return super().is_update_needed()
+
+    def get_cached_asset(self):
+        return self.cache_path.read_text(encoding="utf-8")
+
+    def create_and_get_asset(self):
+        self.cache_path.write_text("ready", encoding="utf-8")
+        return "ready"
+
+
+class _ParentAsset(FileAsset):
+    def __init__(self, *, children, cache_folder):
+        super().__init__({"children": children}, cache_folder / "parent_asset.txt")
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _MultiOutputAsset(FileAsset):
+    def __init__(self, *, cache_folder):
+        super().__init__(
+            {"name": "multi"},
+            {
+                "first": cache_folder / "first.txt",
+                "second": cache_folder / "second.txt",
+            },
+        )
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _MemoryAsset(InMemoryAsset):
+    def __init__(self, *, name, child=None):
+        super().__init__({"name": name, "child": child})
+
+
+def test_build_asset_graph_deduplicates_equivalent_file_assets(tmp_path):
+    """Show one node for two file assets that point to the same cached output."""
+    first_child = _TextAsset(name="same", cache_folder=tmp_path)
+    second_child = _TextAsset(name="same", cache_folder=tmp_path)
+    parent = _ParentAsset(
+        children=[first_child, second_child],
+        cache_folder=tmp_path,
+    )
+
+    graph = build_asset_graph(parent)
+
+    assert graph.number_of_nodes() == 2
+    assert graph.number_of_edges() == 1
+
+
+def test_build_upstream_file_asset_graph_leaves_out_the_root_asset(tmp_path):
+    """The rebuild graph contains only upstream assets, not the asset being read."""
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    graph = build_upstream_file_asset_graph(parent)
+
+    assert list(graph.nodes) == [child]
+
+
+def test_build_upstream_file_asset_graph_does_not_check_cache_status(tmp_path):
+    """Runtime graph building must not do viewer-only filesystem checks."""
+    _TextAsset.status_checks = 0
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    build_upstream_file_asset_graph(parent)
+
+    assert _TextAsset.status_checks == 0
+
+
+def test_build_upstream_file_asset_graph_looks_through_in_memory_assets(tmp_path):
+    """Runtime graph building finds file assets nested below in-memory assets."""
+    child = _TextAsset(name="hidden-file", cache_folder=tmp_path)
+    wrapper = _MemoryAsset(name="wrapper", child=child)
+    parent = _ParentAsset(children=[wrapper], cache_folder=tmp_path)
+
+    graph = build_upstream_file_asset_graph(parent)
+
+    assert list(graph.nodes) == [child]
+
+
+def test_build_asset_graph_reports_missing_cached_and_stale_assets(tmp_path):
+    """Expose simple cache states for graph views and exports."""
+    missing = _TextAsset(name="missing", cache_folder=tmp_path)
+    cached = _TextAsset(name="cached", cache_folder=tmp_path)
+    stale = _TextAsset(name="stale", cache_folder=tmp_path)
+    parent = _ParentAsset(
+        children=[missing, cached, stale],
+        cache_folder=tmp_path,
+    )
+
+    cached.create_and_get_asset()
+    stale.create_and_get_asset()
+    stale.hash_path.write_text("old-inputs", encoding="utf-8")
+
+    graph = build_asset_graph(parent)
+    statuses_by_name = {
+        asset.inputs["name"]: data["status"]
+        for asset, data in graph.nodes(data=True)
+        if isinstance(asset, _TextAsset)
+    }
+
+    assert statuses_by_name == {
+        "missing": "missing",
+        "cached": "cached",
+        "stale": "stale",
+    }
+
+
+def test_build_asset_graph_reports_which_outputs_are_missing(tmp_path):
+    """Show which file is missing when a multi-output asset is incomplete."""
+    asset = _MultiOutputAsset(cache_folder=tmp_path)
+    asset.cache_path["first"].write_text("ready", encoding="utf-8")
+
+    graph = build_asset_graph(asset)
+    node_data = graph.nodes[asset]
+
+    assert node_data["status"] == "missing"
+    assert node_data["existing_outputs"] == (("first", str(asset.cache_path["first"])),)
+    assert node_data["missing_outputs"] == (("second", str(asset.cache_path["second"])),)
+    assert node_data["cache_path"] == (
+        ("first", str(asset.cache_path["first"])),
+        ("second", str(asset.cache_path["second"])),
+    )
+
+
+def test_multi_root_asset_graph_marks_equivalent_children_as_shared(tmp_path):
+    """Equivalent assets reached from several roots get all run contexts."""
+    first_child = _TextAsset(name="same-child", cache_folder=tmp_path)
+    second_child = _TextAsset(name="same-child", cache_folder=tmp_path)
+    first_root = _ParentAsset(
+        children=[first_child],
+        cache_folder=tmp_path / "first-root",
+    )
+    second_root = _ParentAsset(
+        children=[second_child],
+        cache_folder=tmp_path / "second-root",
+    )
+    first_root.scenario = "baseline"
+    first_root.replication = 0
+    first_root.is_weekday = True
+    second_root.scenario = "project"
+    second_root.replication = 1
+    second_root.is_weekday = False
+
+    graph = build_asset_graph_from_roots([first_root, second_root])
+    shared_children = [
+        data
+        for asset, data in graph.nodes(data=True)
+        if isinstance(asset, _TextAsset)
+    ]
+
+    assert len(shared_children) == 1
+    assert shared_children[0]["run_contexts"] == (
+        "baseline|weekday|0",
+        "project|weekend|1",
+    )


### PR DESCRIPTION
### Motivation
Runtime cache checks could miss file assets hidden below in-memory assets, such as public transport costs below mode objects. After exposing the asset DAG, this also showed that unresolved setup modes could leak into the runtime dependency graph and make `GTFSRouter` receive a scenario `ParameterValue` instead of the resolved list of GTFS files.

### Changes
- Move the upstream file-asset graph builder into `mobility.runtime.assets.graph` and reuse it from `FileAsset.update_ancestors_if_needed()`.
- Keep the runtime graph limited to file-backed assets while still looking through in-memory assets to find hidden file dependencies.
- Keep broad setup objects out of direct `Run.inputs`; `Run` now hashes the setup through `run_context_hash` and depends directly on the final iteration state.
- Keep full mode objects out of `InitialIterationStateAsset.inputs`; the initial state now hashes the plain mode enum values it actually needs.
- Add regression tests for hidden file assets below in-memory assets and for unresolved mode branches staying out of run and initial-state dependencies.

### Example (if relevant)
A scenario-specific public transport setup with `additional_gtfs_files=ParameterValue.by_scenario_and_iteration(...)` now reaches `GTFSRouter` through the resolved iteration transport-cost branch, so the router receives `None` or a list of GTFS file paths instead of the raw `ParameterValue` object.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Implemented the runtime asset graph extraction and the group-day-trips input cleanup.
- What you reviewed or changed: Reviewed the runtime dependency path from `Run` to transport costs and adjusted the asset inputs to match the real execution dependencies.
- How you validated it (tests, checks, manual verification): Ran focused pytest tests for runtime asset traversal and run inputs, plus `py_compile` on the changed files.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior