### PR TITLE
Add Dash asset DAG viewer

### DIFF
--- a/mobility/runtime/assets/dag_ui.py
+++ b/mobility/runtime/assets/dag_ui.py
@@ -1,0 +1,1218 @@
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+
+from mobility.runtime.assets.asset import Asset
+from mobility.runtime.assets.graph import build_asset_graph, build_asset_graph_from_roots
+
+try:
+    import dash
+    import dash_cytoscape as cyto
+    from dash import Input, Output, dcc, html
+except ImportError as exc:
+    dash = None
+    cyto = None
+    dcc = None
+    html = None
+    Input = None
+    Output = None
+    _DASH_IMPORT_ERROR = exc
+else:
+    _DASH_IMPORT_ERROR = None
+
+
+DASH_INSTALL_MESSAGE = (
+    "The asset DAG viewer needs Dash dependencies. "
+    "Install them with `pip install mobility[dag]`."
+)
+
+
+STATUS_COLORS = {
+    "cached": "#2E7D32",
+    "missing": "#C62828",
+    "stale": "#EF6C00",
+    "not_file_asset": "#546E7A",
+}
+
+DEFAULT_LAYOUT_NAME = "dagre_tb"
+RUN_GROUP_PREFIX = "run-group"
+
+LAYOUT_LABELS = {
+    "breadthfirst": "Dependency levels",
+    "dagre_lr": "Layered left to right",
+    "dagre_tb": "Layered top to bottom",
+    "cose_bilkent": "Clustered force",
+}
+
+
+def create_asset_dag_app(
+    root_asset: Asset,
+    *,
+    title: str | None = None,
+) -> "dash.Dash":
+    """Create a static Dash app that shows an asset dependency graph."""
+
+    _raise_if_dash_is_missing()
+
+    cyto.load_extra_layouts()
+    graph = build_asset_graph_from_roots([root_asset])
+    elements = asset_graph_cytoscape_elements(graph)
+    nodes = asset_graph_nodes(elements)
+    edge_count = len(elements) - len(nodes)
+    asset_types = sorted({node["data"]["asset_type"] for node in nodes})
+    statuses = sorted({node["data"]["status"] for node in nodes})
+    iterations = sorted(
+        {
+            node["data"]["iteration"]
+            for node in nodes
+            if node["data"].get("iteration") is not None
+        }
+    )
+
+    app = dash.Dash(__name__)
+    app.title = title or f"{root_asset.__class__.__name__} asset DAG"
+    app.layout = html.Div(
+        [
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.H1(app.title),
+                            html.Div(
+                                [
+                                    html.Span(f"{len(nodes)} assets"),
+                                    html.Span(f"{edge_count} links"),
+                                ],
+                                className="asset-dag-summary",
+                            ),
+                        ],
+                        className="asset-dag-heading",
+                    ),
+                    html.Div(
+                        [
+                            html.Div(
+                                [
+                                    html.Label("Asset type"),
+                                    dcc.Dropdown(
+                                        id="asset-type-filter",
+                                        options=[
+                                            {"label": asset_type, "value": asset_type}
+                                            for asset_type in asset_types
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All asset types",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Status"),
+                                    dcc.Dropdown(
+                                        id="asset-status-filter",
+                                        options=[
+                                            {"label": status, "value": status}
+                                            for status in statuses
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All statuses",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Iteration"),
+                                    dcc.Dropdown(
+                                        id="asset-iteration-filter",
+                                        options=[
+                                            {"label": str(iteration), "value": iteration}
+                                            for iteration in iterations
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All iterations",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Layout"),
+                                    dcc.Dropdown(
+                                        id="asset-layout-filter",
+                                        options=asset_dag_layout_options(),
+                                        value=DEFAULT_LAYOUT_NAME,
+                                        clearable=False,
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Group"),
+                                    dcc.Checklist(
+                                        id="asset-group-filter",
+                                        options=[
+                                            {
+                                                "label": "Run contexts",
+                                                "value": "run_context",
+                                            }
+                                        ],
+                                        value=[],
+                                        className="asset-dag-checklist",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                        ],
+                        className="asset-dag-filters",
+                    ),
+                    html.Div(
+                        [legend_item(status, color) for status, color in STATUS_COLORS.items()],
+                        className="asset-dag-legend",
+                    ),
+                ],
+                className="asset-dag-toolbar",
+            ),
+            html.Div(
+                [
+                    cyto.Cytoscape(
+                        id="asset-dag-graph",
+                        elements=elements,
+                        layout=asset_dag_layout(DEFAULT_LAYOUT_NAME),
+                        stylesheet=asset_graph_stylesheet(),
+                        style={"width": "100%", "height": "100%"},
+                        className="asset-dag-graph",
+                        wheelSensitivity=0.2,
+                        responsive=True,
+                    ),
+                    html.Div(
+                        id="asset-dag-details",
+                        className="asset-dag-details",
+                    ),
+                ],
+                className="asset-dag-main",
+            ),
+        ],
+        className="asset-dag-page",
+    )
+
+    register_asset_dag_callbacks(app, elements)
+    app.index_string = asset_dag_index_string()
+    return app
+
+
+def create_group_day_trips_dag_app(
+    group_day_trips,
+    *,
+    title: str | None = None,
+    scenarios: list[str] | tuple[str, ...] | None = None,
+    replications: list[int] | range | None = None,
+    day_types: list[str] | tuple[str, ...] | None = None,
+) -> "dash.Dash":
+    """Create a Dash app for all selected group-day-trips runs.
+
+    The setup object builds run assets lazily. This helper creates the selected
+    run objects so their asset DAGs can be inspected, but it does not call
+    ``get()`` and does not compute the model outputs.
+    """
+
+    _raise_if_dash_is_missing()
+
+    roots = group_day_trips_dag_roots(
+        group_day_trips,
+        scenarios=scenarios,
+        replications=replications,
+        day_types=day_types,
+    )
+    graph = build_asset_graph_from_roots(roots)
+    app_title = title or "PopulationGroupDayTrips asset DAG"
+    return create_asset_dag_app_from_graph(graph, title=app_title)
+
+
+def show_group_day_trips_dag(
+    group_day_trips,
+    *,
+    title: str | None = None,
+    scenarios: list[str] | tuple[str, ...] | None = None,
+    replications: list[int] | range | None = None,
+    day_types: list[str] | tuple[str, ...] | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8050,
+    debug: bool = False,
+) -> None:
+    """Open a local Dash server for a PopulationGroupDayTrips setup DAG."""
+
+    app = create_group_day_trips_dag_app(
+        group_day_trips,
+        title=title,
+        scenarios=scenarios,
+        replications=replications,
+        day_types=day_types,
+    )
+    app.run(host=host, port=port, debug=debug)
+
+
+def group_day_trips_dag_roots(
+    group_day_trips,
+    *,
+    scenarios: list[str] | tuple[str, ...] | None,
+    replications: list[int] | range | None,
+    day_types: list[str] | tuple[str, ...] | None,
+) -> list[Asset]:
+    """Build the selected Run assets for a PopulationGroupDayTrips setup."""
+
+    scenario_names = selected_group_day_trips_scenarios(group_day_trips, scenarios)
+    replication_ids = selected_group_day_trips_replications(group_day_trips, replications)
+    selected_day_types = selected_group_day_trips_day_types(group_day_trips, day_types)
+
+    roots = []
+    for scenario in scenario_names:
+        for replication in replication_ids:
+            for day_type in selected_day_types:
+                roots.append(
+                    group_day_trips.run(
+                        day_type,
+                        scenario=scenario,
+                        replication=replication,
+                    )
+                )
+    return roots
+
+
+def selected_group_day_trips_scenarios(
+    group_day_trips,
+    scenarios: list[str] | tuple[str, ...] | None,
+) -> list[str]:
+    """Return scenario names to include in the top-level DAG."""
+
+    if scenarios is not None:
+        return list(scenarios)
+
+    scenario_names = ["default"]
+    for scenario_name in getattr(group_day_trips.scenarios, "names", []):
+        if scenario_name not in scenario_names:
+            scenario_names.append(scenario_name)
+    return scenario_names
+
+
+def selected_group_day_trips_replications(
+    group_day_trips,
+    replications: list[int] | range | None,
+) -> list[int]:
+    """Return replication ids to include in the top-level DAG."""
+
+    if replications is not None:
+        return list(replications)
+    return list(range(group_day_trips.parameters.run.n_replications))
+
+
+def selected_group_day_trips_day_types(
+    group_day_trips,
+    day_types: list[str] | tuple[str, ...] | None,
+) -> list[str]:
+    """Return day types to include in the top-level DAG."""
+
+    if day_types is not None:
+        return list(day_types)
+
+    selected_day_types = ["weekday"]
+    if group_day_trips.parameters.periods.simulate_weekend:
+        selected_day_types.append("weekend")
+    return selected_day_types
+
+
+def show_asset_dag(
+    root_asset: Asset,
+    *,
+    title: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8050,
+    debug: bool = False,
+) -> None:
+    """Open a local Dash server for an asset dependency graph."""
+
+    app = create_asset_dag_app(root_asset, title=title)
+    app.run(host=host, port=port, debug=debug)
+
+
+def create_asset_dag_app_from_graph(
+    graph: nx.DiGraph,
+    *,
+    title: str,
+) -> "dash.Dash":
+    """Create a static Dash app from an already-built asset graph."""
+
+    _raise_if_dash_is_missing()
+
+    cyto.load_extra_layouts()
+    elements = asset_graph_cytoscape_elements(graph)
+    nodes = asset_graph_nodes(elements)
+    edge_count = len(elements) - len(nodes)
+    asset_types = sorted({node["data"]["asset_type"] for node in nodes})
+    statuses = sorted({node["data"]["status"] for node in nodes})
+    iterations = sorted(
+        {
+            node["data"]["iteration"]
+            for node in nodes
+            if node["data"].get("iteration") is not None
+        }
+    )
+
+    app = dash.Dash(__name__)
+    app.title = title
+    app.layout = html.Div(
+        [
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.H1(app.title),
+                            html.Div(
+                                [
+                                    html.Span(f"{len(nodes)} assets"),
+                                    html.Span(f"{edge_count} links"),
+                                ],
+                                className="asset-dag-summary",
+                            ),
+                        ],
+                        className="asset-dag-heading",
+                    ),
+                    html.Div(
+                        [
+                            html.Div(
+                                [
+                                    html.Label("Asset type"),
+                                    dcc.Dropdown(
+                                        id="asset-type-filter",
+                                        options=[
+                                            {"label": asset_type, "value": asset_type}
+                                            for asset_type in asset_types
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All asset types",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Status"),
+                                    dcc.Dropdown(
+                                        id="asset-status-filter",
+                                        options=[
+                                            {"label": status, "value": status}
+                                            for status in statuses
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All statuses",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Iteration"),
+                                    dcc.Dropdown(
+                                        id="asset-iteration-filter",
+                                        options=[
+                                            {"label": str(iteration), "value": iteration}
+                                            for iteration in iterations
+                                        ],
+                                        value=[],
+                                        multi=True,
+                                        clearable=True,
+                                        placeholder="All iterations",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Layout"),
+                                    dcc.Dropdown(
+                                        id="asset-layout-filter",
+                                        options=asset_dag_layout_options(),
+                                        value=DEFAULT_LAYOUT_NAME,
+                                        clearable=False,
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Group"),
+                                    dcc.Checklist(
+                                        id="asset-group-filter",
+                                        options=[
+                                            {
+                                                "label": "Run contexts",
+                                                "value": "run_context",
+                                            }
+                                        ],
+                                        value=[],
+                                        className="asset-dag-checklist",
+                                    ),
+                                ],
+                                className="asset-dag-filter",
+                            ),
+                        ],
+                        className="asset-dag-filters",
+                    ),
+                    html.Div(
+                        [legend_item(status, color) for status, color in STATUS_COLORS.items()],
+                        className="asset-dag-legend",
+                    ),
+                ],
+                className="asset-dag-toolbar",
+            ),
+            html.Div(
+                [
+                    cyto.Cytoscape(
+                        id="asset-dag-graph",
+                        elements=elements,
+                        layout=asset_dag_layout(DEFAULT_LAYOUT_NAME),
+                        stylesheet=asset_graph_stylesheet(),
+                        style={"width": "100%", "height": "100%"},
+                        className="asset-dag-graph",
+                        wheelSensitivity=0.2,
+                        responsive=True,
+                    ),
+                    html.Div(
+                        id="asset-dag-details",
+                        className="asset-dag-details",
+                    ),
+                ],
+                className="asset-dag-main",
+            ),
+        ],
+        className="asset-dag-page",
+    )
+
+    register_asset_dag_callbacks(app, elements)
+    app.index_string = asset_dag_index_string()
+    return app
+
+
+def asset_graph_cytoscape_elements(graph: nx.DiGraph) -> list[dict[str, Any]]:
+    """Convert an asset graph to Cytoscape elements."""
+
+    node_ids = {asset: f"asset-{index}" for index, asset in enumerate(graph.nodes)}
+    elements = []
+
+    for asset, node_id in node_ids.items():
+        data = graph.nodes[asset]
+        node_data = {
+            "id": node_id,
+            "label": data["asset_type"],
+            "asset_type": data["asset_type"],
+            "status": data["status"],
+            "inputs_hash": data["inputs_hash"],
+            "cache_path": format_cache_path(data["cache_path"]),
+            "existing_outputs": format_output_paths(data["existing_outputs"]),
+            "missing_outputs": format_output_paths(data["missing_outputs"]),
+            "cached_hash": data["cached_hash"],
+            "iteration": data.get("iteration"),
+            "replication": data.get("replication"),
+            "run_contexts": list(data.get("run_contexts", ())),
+            "scenario": data.get("scenario"),
+            "is_weekday": data.get("is_weekday"),
+        }
+        elements.append(
+            {
+                "data": node_data,
+                "classes": data["status"],
+            }
+        )
+
+    for source, target, edge_data in graph.edges(data=True):
+        source_id = node_ids[source]
+        target_id = node_ids[target]
+        elements.append(
+            {
+                "data": {
+                    "id": f"{source_id}-{target_id}",
+                    "source": source_id,
+                    "target": target_id,
+                    "input_name": edge_data.get("input_name"),
+                }
+            }
+        )
+
+    return elements
+
+
+def asset_graph_nodes(elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return only node elements from a Cytoscape element list."""
+
+    return [element for element in elements if "source" not in element["data"]]
+
+
+def register_asset_dag_callbacks(app: "dash.Dash", elements: list[dict[str, Any]]) -> None:
+    """Register filtering and detail callbacks for the static graph app."""
+
+    @app.callback(
+        Output("asset-dag-graph", "elements"),
+        Input("asset-type-filter", "value"),
+        Input("asset-status-filter", "value"),
+        Input("asset-iteration-filter", "value"),
+        Input("asset-group-filter", "value"),
+    )
+    def filter_elements(
+        selected_asset_types,
+        selected_statuses,
+        selected_iterations,
+        selected_groups,
+    ):
+        filtered_elements = filter_asset_graph_elements(
+            elements,
+            selected_asset_types=selected_asset_types,
+            selected_statuses=selected_statuses,
+            selected_iterations=selected_iterations,
+        )
+        if "run_context" in (selected_groups or []):
+            return group_asset_graph_elements_by_run_context(filtered_elements)
+        return filtered_elements
+
+    @app.callback(
+        Output("asset-dag-graph", "layout"),
+        Input("asset-layout-filter", "value"),
+        Input("asset-group-filter", "value"),
+    )
+    def update_layout(layout_name, selected_groups):
+        layout = asset_dag_layout(layout_name)
+        if "run_context" in (selected_groups or []):
+            return {
+                **layout,
+                "padding": max(layout.get("padding", 35), 55),
+                "spacingFactor": max(layout.get("spacingFactor", 1.0), 1.25),
+            }
+        return layout
+
+    @app.callback(
+        Output("asset-dag-details", "children"),
+        Input("asset-dag-graph", "tapNodeData"),
+    )
+    def show_node_details(node_data):
+        if not node_data:
+            return html.Div(
+                [
+                    html.H2("Asset"),
+                    html.P("Select an asset node."),
+                ]
+            )
+
+        rows = [
+            ("Type", node_data.get("asset_type")),
+            ("Status", node_data.get("status")),
+            ("Iteration", node_data.get("iteration")),
+            ("Scenario", node_data.get("scenario")),
+            ("Replication", node_data.get("replication")),
+            ("Weekday", node_data.get("is_weekday")),
+            ("Run contexts", ", ".join(node_data.get("run_contexts") or [])),
+            ("Inputs hash", node_data.get("inputs_hash")),
+            ("Cached hash", node_data.get("cached_hash")),
+        ]
+        missing_outputs = node_data.get("missing_outputs") or ""
+        existing_outputs = node_data.get("existing_outputs") or ""
+        return html.Div(
+            [
+                html.H2(node_data.get("label", "Asset")),
+                html.Table(
+                    [
+                        html.Tr([html.Th(label), html.Td("" if value is None else str(value))])
+                        for label, value in rows
+                    ]
+                ),
+                html.Details(
+                    [
+                        html.Summary("Missing outputs"),
+                        html.Pre(missing_outputs or "No missing output."),
+                    ],
+                    open=bool(missing_outputs),
+                ),
+                html.Details(
+                    [
+                        html.Summary("Existing outputs"),
+                        html.Pre(existing_outputs or "No existing output."),
+                    ],
+                    open=False,
+                ),
+                html.Details(
+                    [
+                        html.Summary("Cache path"),
+                        html.Pre(node_data.get("cache_path") or ""),
+                    ],
+                    open=False,
+                ),
+            ]
+        )
+
+
+def filter_asset_graph_elements(
+    elements: list[dict[str, Any]],
+    *,
+    selected_asset_types: list[str] | None,
+    selected_statuses: list[str] | None,
+    selected_iterations: list[int] | None,
+) -> list[dict[str, Any]]:
+    """Filter Cytoscape elements while keeping only edges between visible nodes."""
+
+    selected_asset_types = selected_asset_types or []
+    selected_statuses = selected_statuses or []
+    selected_iterations = selected_iterations or []
+    keep_all_asset_types = len(selected_asset_types) == 0
+    keep_all_statuses = len(selected_statuses) == 0
+    keep_all_iterations = len(selected_iterations) == 0
+    visible_node_ids = set()
+    filtered_elements = []
+
+    for element in asset_graph_nodes(elements):
+        data = element["data"]
+        if not keep_all_asset_types and data["asset_type"] not in selected_asset_types:
+            continue
+        if not keep_all_statuses and data["status"] not in selected_statuses:
+            continue
+        if not keep_all_iterations and data.get("iteration") not in selected_iterations:
+            continue
+        visible_node_ids.add(data["id"])
+        filtered_elements.append(element)
+
+    for element in elements:
+        data = element["data"]
+        if "source" not in data:
+            continue
+        if data["source"] in visible_node_ids and data["target"] in visible_node_ids:
+            filtered_elements.append(element)
+
+    return filtered_elements
+
+
+def group_asset_graph_elements_by_run_context(
+    elements: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Add Cytoscape compound parent nodes grouped by run context."""
+
+    group_nodes_by_id = {}
+    grouped_nodes = []
+
+    def add_group(group_id: str, label: str, parent: str | None = None) -> None:
+        if group_id in group_nodes_by_id:
+            return
+        data = {
+            "id": group_id,
+            "label": label,
+            "asset_type": "RunGroup",
+            "status": "run_group",
+        }
+        if parent is not None:
+            data["parent"] = parent
+        group_nodes_by_id[group_id] = {
+            "data": {
+                **data,
+            },
+            "classes": "run_group",
+            "grabbable": False,
+        }
+
+    for element in elements:
+        data = element["data"]
+        if "source" in data:
+            continue
+
+        parent_id, group_specs = run_context_parent_and_groups(data)
+        for group_id, label, parent in group_specs:
+            add_group(group_id, label, parent)
+
+        grouped_data = {
+            **data,
+            "parent": parent_id,
+        }
+        grouped_nodes.append(
+            {
+                **element,
+                "data": grouped_data,
+            }
+        )
+
+    return (
+        list(group_nodes_by_id.values())
+        + grouped_nodes
+        + [element for element in elements if "source" in element["data"]]
+    )
+
+
+def run_context_parent_and_groups(
+    node_data: dict[str, Any],
+) -> tuple[str, list[tuple[str, str, str | None]]]:
+    """Return the parent id and group nodes for one asset node."""
+
+    contexts = node_data.get("run_contexts") or []
+    if len(contexts) != 1:
+        shared_group_id = run_group_id("shared")
+        day_type, replication = shared_run_context_groups(contexts)
+        day_type_id = run_group_id("shared", "day", day_type)
+        replication_id = run_group_id("shared", "day", day_type, "replication", replication)
+        iteration = node_data.get("iteration")
+        if iteration is None:
+            shared_child_id = run_group_id("shared", "day", day_type, "replication", replication, "run-level")
+            shared_child_label = "Run-level assets"
+        else:
+            shared_child_id = run_group_id(
+                "shared",
+                "day",
+                day_type,
+                "replication",
+                replication,
+                "iteration",
+                iteration,
+            )
+            shared_child_label = f"Iteration: {iteration}"
+        return shared_child_id, [
+            (shared_group_id, "Shared by several runs", None),
+            (day_type_id, f"Day type: {day_type}", shared_group_id),
+            (replication_id, f"Replication: {replication}", day_type_id),
+            (shared_child_id, shared_child_label, replication_id),
+        ]
+
+    scenario, day_type, replication = parse_run_context(contexts[0])
+    iteration = node_data.get("iteration")
+    scenario_id = run_group_id("scenario", scenario)
+    day_type_id = run_group_id("scenario", scenario, "day", day_type)
+    replication_id = run_group_id(
+        "scenario",
+        scenario,
+        "day",
+        day_type,
+        "replication",
+        replication,
+    )
+    if iteration is None:
+        iteration_label = "Run-level assets"
+        iteration_id = run_group_id(
+            "scenario",
+            scenario,
+            "day",
+            day_type,
+            "replication",
+            replication,
+            "run-level",
+        )
+    else:
+        iteration_label = f"Iteration: {iteration}"
+        iteration_id = run_group_id(
+            "scenario",
+            scenario,
+            "day",
+            day_type,
+            "replication",
+            replication,
+            "iteration",
+            iteration,
+        )
+
+    return iteration_id, [
+        (scenario_id, f"Scenario: {scenario}", None),
+        (day_type_id, f"Day type: {day_type}", scenario_id),
+        (replication_id, f"Replication: {replication}", day_type_id),
+        (iteration_id, iteration_label, replication_id),
+    ]
+
+
+def parse_run_context(context: str) -> tuple[str, str, str]:
+    """Split a compact run context into scenario, day type, and replication."""
+
+    parts = str(context).split("|")
+    if len(parts) != 3:
+        return "unknown", "unknown", "unknown"
+    return parts[0], parts[1], parts[2]
+
+
+def shared_run_context_groups(contexts: list[str]) -> tuple[str, str]:
+    """Return shared day-type and replication labels for several contexts."""
+
+    parsed_contexts = [parse_run_context(context) for context in contexts]
+    day_types = sorted({day_type for _, day_type, _ in parsed_contexts})
+    replications = sorted({replication for _, _, replication in parsed_contexts})
+
+    day_type = day_types[0] if len(day_types) == 1 else "several-day-types"
+    replication = replications[0] if len(replications) == 1 else "several-replications"
+    return day_type, replication
+
+
+def run_group_id(*parts: Any) -> str:
+    """Return a stable Cytoscape group id."""
+
+    safe_parts = [
+        str(part).replace(" ", "-").replace("/", "-").replace("\\", "-")
+        for part in parts
+    ]
+    return f"{RUN_GROUP_PREFIX}-{'-'.join(safe_parts)}"
+
+
+def asset_dag_layout_options() -> list[dict[str, str]]:
+    """Return user-facing layout choices for the DAG viewer."""
+
+    return [
+        {"label": label, "value": value}
+        for value, label in LAYOUT_LABELS.items()
+    ]
+
+
+def asset_dag_layout(layout_name: str | None) -> dict[str, Any]:
+    """Return Cytoscape layout options for one named graph layout."""
+
+    layout_name = layout_name or DEFAULT_LAYOUT_NAME
+
+    if layout_name == "dagre_lr":
+        return {
+            "name": "dagre",
+            "rankDir": "LR",
+            "fit": True,
+            "padding": 35,
+            "nodeSep": 44,
+            "rankSep": 110,
+            "edgeSep": 14,
+        }
+
+    if layout_name == "dagre_tb":
+        return {
+            "name": "dagre",
+            "rankDir": "TB",
+            "fit": True,
+            "padding": 35,
+            "nodeSep": 34,
+            "rankSep": 100,
+            "edgeSep": 12,
+        }
+
+    if layout_name == "cose_bilkent":
+        return {
+            "name": "cose-bilkent",
+            "fit": True,
+            "padding": 35,
+            "nodeRepulsion": 7000,
+            "idealEdgeLength": 115,
+            "edgeElasticity": 0.25,
+            "gravity": 0.35,
+            "numIter": 2500,
+            "tile": True,
+        }
+
+    return {
+        "name": "breadthfirst",
+        "directed": True,
+        "circle": False,
+        "fit": True,
+        "padding": 35,
+        "spacingFactor": 1.35,
+        "avoidOverlap": True,
+        "maximalAdjustments": 4,
+        "animate": False,
+    }
+
+
+def asset_graph_stylesheet() -> list[dict[str, Any]]:
+    """Return Cytoscape styles for the asset graph."""
+
+    stylesheet = [
+        {
+            "selector": "node",
+            "style": {
+                "label": "data(label)",
+                "shape": "round-rectangle",
+                "width": "label",
+                "height": 40,
+                "padding": "8px",
+                "background-color": "#546E7A",
+                "border-width": 1,
+                "border-color": "#263238",
+                "color": "#FFFFFF",
+                "font-size": 10,
+                "text-wrap": "wrap",
+                "text-max-width": 120,
+                "text-valign": "center",
+                "text-halign": "center",
+            },
+        },
+        {
+            "selector": "edge",
+            "style": {
+                "width": 1.5,
+                "line-color": "#90A4AE",
+                "target-arrow-color": "#90A4AE",
+                "target-arrow-shape": "triangle",
+                "curve-style": "bezier",
+            },
+        },
+        {
+            "selector": ":selected",
+            "style": {
+                "border-width": 3,
+                "border-color": "#1565C0",
+            },
+        },
+        {
+            "selector": ".run_group",
+            "style": {
+                "label": "data(label)",
+                "shape": "round-rectangle",
+                "background-opacity": 0.16,
+                "background-color": "#D9F99D",
+                "border-width": 2,
+                "border-style": "solid",
+                "border-color": "#86A86A",
+                "color": "#3F6212",
+                "font-size": 12,
+                "font-weight": "bold",
+                "text-valign": "top",
+                "text-halign": "center",
+                "padding": "32px",
+                "corner-radius": 18,
+                "z-compound-depth": "bottom",
+            },
+        },
+    ]
+
+    for status, color in STATUS_COLORS.items():
+        stylesheet.append(
+            {
+                "selector": f".{status}",
+                "style": {"background-color": color},
+            }
+        )
+
+    return stylesheet
+
+
+def legend_item(status: str, color: str):
+    """Return one compact status legend item."""
+
+    return html.Div(
+        [
+            html.Span(style={"backgroundColor": color}),
+            html.Small(status),
+        ],
+        className="asset-dag-legend-item",
+    )
+
+
+def format_cache_path(cache_path: Any) -> str | None:
+    """Format a cache path value for display in Dash."""
+
+    if cache_path is None:
+        return None
+    if isinstance(cache_path, tuple):
+        return "\n".join(f"{key}: {path}" for key, path in cache_path)
+    return str(cache_path)
+
+
+def format_output_paths(output_paths: Any) -> str:
+    """Format existing or missing output paths for display in Dash."""
+
+    if not output_paths:
+        return ""
+    return "\n".join(f"{key}: {path}" for key, path in output_paths)
+
+
+def _raise_if_dash_is_missing() -> None:
+    if _DASH_IMPORT_ERROR is None:
+        return
+    raise ImportError(DASH_INSTALL_MESSAGE) from _DASH_IMPORT_ERROR
+
+
+def asset_dag_index_string() -> str:
+    """Return the HTML template and CSS used by the local Dash app."""
+
+    return """
+<!DOCTYPE html>
+<html>
+    <head>
+        {%metas%}
+        <title>{%title%}</title>
+        {%favicon%}
+        {%css%}
+        <style>
+            body {
+                margin: 0;
+                font-family: Arial, sans-serif;
+                color: #1F2933;
+                background: #F6F8FA;
+            }
+            .asset-dag-page {
+                height: 100vh;
+                display: flex;
+                flex-direction: column;
+                overflow: hidden;
+            }
+            .asset-dag-toolbar {
+                padding: 10px 14px 9px;
+                border-bottom: 1px solid #D9E2EC;
+                background: #FFFFFF;
+            }
+            .asset-dag-heading {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 16px;
+                margin-bottom: 8px;
+            }
+            .asset-dag-toolbar h1 {
+                margin: 0;
+                font-size: 17px;
+                line-height: 1.3;
+                font-weight: 600;
+            }
+            .asset-dag-summary {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: flex-end;
+                gap: 8px;
+                color: #52606D;
+                font-size: 12px;
+            }
+            .asset-dag-filters {
+                display: grid;
+                grid-template-columns: 1.4fr 0.8fr 0.65fr 0.75fr 128px;
+                gap: 10px;
+            }
+            .asset-dag-filter label {
+                display: block;
+                margin-bottom: 3px;
+                color: #52606D;
+                font-size: 11px;
+                font-weight: 600;
+            }
+            .asset-dag-checklist label {
+                display: inline-flex;
+                align-items: center;
+                gap: 5px;
+                min-height: 36px;
+                margin: 0;
+                color: #1F2933;
+                font-size: 12px;
+                font-weight: 400;
+            }
+            .asset-dag-legend {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 12px;
+                margin-top: 8px;
+            }
+            .asset-dag-legend-item {
+                display: inline-flex;
+                align-items: center;
+                gap: 5px;
+            }
+            .asset-dag-legend-item span {
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+                display: inline-block;
+            }
+            .asset-dag-main {
+                min-height: 0;
+                flex: 1;
+                display: grid;
+                grid-template-columns: minmax(0, 1fr) 300px;
+            }
+            .asset-dag-graph {
+                width: 100%;
+                height: 100%;
+                min-height: 0;
+                background: #FFFFFF;
+            }
+            .asset-dag-details {
+                padding: 14px;
+                border-left: 1px solid #D9E2EC;
+                background: #FFFFFF;
+                overflow: auto;
+            }
+            .asset-dag-details h2 {
+                margin: 0 0 12px;
+                font-size: 16px;
+            }
+            .asset-dag-details table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 12px;
+            }
+            .asset-dag-details th,
+            .asset-dag-details td {
+                vertical-align: top;
+                text-align: left;
+                padding: 7px 0;
+                border-bottom: 1px solid #E6EAF0;
+                word-break: break-word;
+            }
+            .asset-dag-details th {
+                width: 82px;
+                color: #52606D;
+                font-weight: 600;
+            }
+            .asset-dag-details details {
+                margin-top: 10px;
+                font-size: 12px;
+            }
+            .asset-dag-details summary {
+                cursor: pointer;
+                color: #334E68;
+                font-weight: 600;
+            }
+            .asset-dag-details pre {
+                max-height: 40vh;
+                overflow: auto;
+                white-space: pre-wrap;
+                word-break: break-word;
+                margin: 8px 0 0;
+                padding: 8px;
+                background: #F6F8FA;
+                border: 1px solid #D9E2EC;
+                font-family: Consolas, monospace;
+                font-size: 11px;
+                line-height: 1.35;
+            }
+            @media (max-width: 900px) {
+                .asset-dag-filters,
+                .asset-dag-main {
+                    grid-template-columns: 1fr;
+                }
+                .asset-dag-heading {
+                    align-items: flex-start;
+                    flex-direction: column;
+                }
+                .asset-dag-summary {
+                    justify-content: flex-start;
+                }
+                .asset-dag-graph {
+                    height: 65vh;
+                }
+                .asset-dag-details {
+                    border-left: 0;
+                    border-top: 1px solid #D9E2EC;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        {%app_entry%}
+        <footer>
+            {%config%}
+            {%scripts%}
+            {%renderer%}
+        </footer>
+    </body>
+</html>
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ dev = [
   "myst_parser>=3,<6",
 ]
 
+dag = [
+  "dash>=3,<4",
+  "dash-cytoscape>=1,<2",
+]
+
 spyder = [
     "spyder-kernels"
 ]

--- a/tests/back/unit/runtime/test_003_asset_graph.py
+++ b/tests/back/unit/runtime/test_003_asset_graph.py
@@ -1,0 +1,389 @@
+import pytest
+
+from mobility.runtime.assets.dag_ui import (
+    DEFAULT_LAYOUT_NAME,
+    asset_dag_layout,
+    asset_dag_layout_options,
+    asset_graph_cytoscape_elements,
+    create_asset_dag_app,
+    filter_asset_graph_elements,
+    group_asset_graph_elements_by_run_context,
+)
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.graph import (
+    build_asset_graph,
+    build_asset_graph_from_roots,
+    build_upstream_file_asset_graph,
+)
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+
+
+class _TextAsset(FileAsset):
+    create_calls = 0
+
+    def __init__(self, *, name, cache_folder):
+        super().__init__({"name": name}, cache_folder / "text_asset.txt")
+
+    def get_cached_asset(self):
+        return self.cache_path.read_text(encoding="utf-8")
+
+    def create_and_get_asset(self):
+        _TextAsset.create_calls += 1
+        self.cache_path.write_text("ready", encoding="utf-8")
+        return "ready"
+
+
+class _ParentAsset(FileAsset):
+    def __init__(self, *, children, cache_folder):
+        super().__init__({"children": children}, cache_folder / "parent_asset.txt")
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _MultiOutputAsset(FileAsset):
+    def __init__(self, *, cache_folder):
+        super().__init__(
+            {"name": "multi"},
+            {
+                "first": cache_folder / "first.txt",
+                "second": cache_folder / "second.txt",
+            },
+        )
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _StatusCountingAsset(FileAsset):
+    status_checks = 0
+
+    def __init__(self, *, child=None, cache_folder):
+        inputs = {"name": "status-counting", "child": child}
+        super().__init__(inputs, cache_folder / "status_counting.txt")
+
+    def is_update_needed(self):
+        _StatusCountingAsset.status_checks += 1
+        return False
+
+    def get_cached_asset(self):
+        return None
+
+    def create_and_get_asset(self):
+        return None
+
+
+class _MemoryAsset(InMemoryAsset):
+    def __init__(self, *, name):
+        super().__init__({"name": name})
+
+
+class _MemoryWrapperAsset(InMemoryAsset):
+    def __init__(self, *, child):
+        super().__init__({"child": child})
+
+
+def test_build_asset_graph_deduplicates_equivalent_file_assets(tmp_path):
+    """Show one node for two file assets that point to the same cached output."""
+    first_child = _TextAsset(name="same", cache_folder=tmp_path)
+    second_child = _TextAsset(name="same", cache_folder=tmp_path)
+    parent = _ParentAsset(
+        children=[first_child, second_child],
+        cache_folder=tmp_path,
+    )
+
+    graph = build_asset_graph(parent)
+
+    assert graph.number_of_nodes() == 2
+    assert graph.number_of_edges() == 1
+
+
+def test_build_upstream_file_asset_graph_leaves_out_the_root_asset(tmp_path):
+    """The rebuild graph contains only upstream assets, not the asset being read."""
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    graph = build_upstream_file_asset_graph(parent)
+
+    assert list(graph.nodes) == [child]
+
+
+def test_build_upstream_file_asset_graph_does_not_check_cache_status(tmp_path):
+    """Runtime graph building must not do viewer-only filesystem checks."""
+    _StatusCountingAsset.status_checks = 0
+    child = _StatusCountingAsset(cache_folder=tmp_path)
+    parent = _StatusCountingAsset(child=child, cache_folder=tmp_path)
+
+    build_upstream_file_asset_graph(parent)
+
+    assert _StatusCountingAsset.status_checks == 0
+
+
+def test_build_upstream_file_asset_graph_looks_through_in_memory_assets(tmp_path):
+    """Runtime graph building finds file assets nested below in-memory assets."""
+    child = _TextAsset(name="hidden-file", cache_folder=tmp_path)
+    wrapper = _MemoryWrapperAsset(child=child)
+    parent = _ParentAsset(children=[wrapper], cache_folder=tmp_path)
+
+    graph = build_upstream_file_asset_graph(parent)
+
+    assert list(graph.nodes) == [child]
+
+
+def test_build_upstream_file_asset_graph_looks_through_in_memory_file_inputs(tmp_path):
+    """Runtime graph building finds file assets nested below upstream FileAssets."""
+    child = _TextAsset(name="hidden-file", cache_folder=tmp_path / "child")
+    wrapper = _MemoryWrapperAsset(child=child)
+    bridge = _ParentAsset(children=[wrapper], cache_folder=tmp_path / "bridge")
+    parent = _ParentAsset(children=[bridge], cache_folder=tmp_path / "parent")
+
+    graph = build_upstream_file_asset_graph(parent)
+
+    assert set(graph.nodes) == {bridge, child}
+
+
+def test_build_asset_graph_reports_missing_cached_and_stale_assets(tmp_path):
+    """Expose simple cache states for the viewer."""
+    missing = _TextAsset(name="missing", cache_folder=tmp_path)
+    cached = _TextAsset(name="cached", cache_folder=tmp_path)
+    stale = _TextAsset(name="stale", cache_folder=tmp_path)
+    parent = _ParentAsset(
+        children=[missing, cached, stale],
+        cache_folder=tmp_path,
+    )
+
+    cached.create_and_get_asset()
+    stale.create_and_get_asset()
+    stale.hash_path.write_text("old-inputs", encoding="utf-8")
+
+    graph = build_asset_graph(parent)
+    statuses_by_name = {
+        asset.inputs["name"]: data["status"]
+        for asset, data in graph.nodes(data=True)
+        if isinstance(asset, _TextAsset)
+    }
+
+    assert statuses_by_name == {
+        "missing": "missing",
+        "cached": "cached",
+        "stale": "stale",
+    }
+
+
+def test_build_asset_graph_reports_which_outputs_are_missing(tmp_path):
+    """Show which file is missing when a multi-output asset is incomplete."""
+    asset = _MultiOutputAsset(cache_folder=tmp_path)
+    asset.cache_path["first"].write_text("ready", encoding="utf-8")
+
+    graph = build_asset_graph(asset)
+    node_data = graph.nodes[asset]
+
+    assert node_data["status"] == "missing"
+    assert node_data["existing_outputs"] == (("first", str(asset.cache_path["first"])),)
+    assert node_data["missing_outputs"] == (("second", str(asset.cache_path["second"])),)
+
+
+def test_asset_graph_cytoscape_elements_can_be_filtered(tmp_path):
+    """Build Cytoscape data without starting a Dash server."""
+    missing = _TextAsset(name="missing", cache_folder=tmp_path)
+    cached = _TextAsset(name="cached", cache_folder=tmp_path)
+    parent = _ParentAsset(
+        children=[missing, cached],
+        cache_folder=tmp_path,
+    )
+    cached.create_and_get_asset()
+
+    graph = build_asset_graph(parent)
+    elements = asset_graph_cytoscape_elements(graph)
+    filtered_elements = filter_asset_graph_elements(
+        elements,
+        selected_asset_types=["_TextAsset"],
+        selected_statuses=["cached"],
+        selected_iterations=None,
+    )
+
+    filtered_nodes = [
+        element
+        for element in filtered_elements
+        if "source" not in element["data"]
+    ]
+    assert len(filtered_nodes) == 1
+    assert filtered_nodes[0]["data"]["status"] == "cached"
+
+
+def test_empty_filters_keep_the_full_asset_graph(tmp_path):
+    """Empty filter values mean all nodes are visible."""
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    graph = build_asset_graph(parent)
+    elements = asset_graph_cytoscape_elements(graph)
+    filtered_elements = filter_asset_graph_elements(
+        elements,
+        selected_asset_types=[],
+        selected_statuses=[],
+        selected_iterations=[],
+    )
+
+    assert filtered_elements == elements
+
+
+def test_asset_dag_layout_options_include_the_default_layout():
+    """Expose several useful graph layouts without changing the Python API."""
+    options = asset_dag_layout_options()
+    option_values = {option["value"] for option in options}
+
+    assert DEFAULT_LAYOUT_NAME in option_values
+    assert asset_dag_layout(DEFAULT_LAYOUT_NAME)["rankDir"] == "TB"
+    assert asset_dag_layout("dagre_lr")["rankDir"] == "LR"
+
+
+def test_group_asset_graph_elements_by_run_context_adds_subgroup_nodes(tmp_path):
+    """Group graph nodes into scenario, day-type, and replication boxes."""
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+    child.iteration = 1
+    parent.scenario = "baseline"
+    parent.replication = 2
+    parent.is_weekday = True
+
+    graph = build_asset_graph_from_roots([parent])
+    elements = asset_graph_cytoscape_elements(graph)
+    grouped_elements = group_asset_graph_elements_by_run_context(elements)
+
+    node_data_by_id = {
+        element["data"]["id"]: element["data"]
+        for element in grouped_elements
+        if "source" not in element["data"]
+    }
+    scenario_id = "run-group-scenario-baseline"
+    day_type_id = "run-group-scenario-baseline-day-weekday"
+    replication_id = "run-group-scenario-baseline-day-weekday-replication-2"
+    run_level_id = "run-group-scenario-baseline-day-weekday-replication-2-run-level"
+    iteration_id = "run-group-scenario-baseline-day-weekday-replication-2-iteration-1"
+
+    assert scenario_id in node_data_by_id
+    assert node_data_by_id[day_type_id]["parent"] == scenario_id
+    assert node_data_by_id[replication_id]["parent"] == day_type_id
+    assert node_data_by_id[run_level_id]["parent"] == replication_id
+    assert node_data_by_id[iteration_id]["parent"] == replication_id
+    assert node_data_by_id["asset-0"]["parent"] == run_level_id
+    assert node_data_by_id["asset-1"]["parent"] == iteration_id
+
+
+def test_group_asset_graph_elements_by_run_context_groups_shared_iterations(tmp_path):
+    """Shared iteration assets still appear in an iteration subgroup."""
+    child = _TextAsset(name="shared-iteration", cache_folder=tmp_path)
+    child.iteration = 1
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    graph = build_asset_graph(parent)
+    elements = asset_graph_cytoscape_elements(graph)
+    for element in elements:
+        if element["data"].get("asset_type") == "_TextAsset":
+            element["data"]["run_contexts"] = [
+                "baseline|weekday|0",
+                "project|weekday|0",
+            ]
+    grouped_elements = group_asset_graph_elements_by_run_context(elements)
+
+    node_data_by_id = {
+        element["data"]["id"]: element["data"]
+        for element in grouped_elements
+        if "source" not in element["data"]
+    }
+    shared_id = "run-group-shared"
+    shared_day_type_id = "run-group-shared-day-weekday"
+    shared_replication_id = "run-group-shared-day-weekday-replication-0"
+    shared_iteration_id = "run-group-shared-day-weekday-replication-0-iteration-1"
+
+    assert node_data_by_id[shared_day_type_id]["parent"] == shared_id
+    assert node_data_by_id[shared_replication_id]["parent"] == shared_day_type_id
+    assert node_data_by_id[shared_iteration_id]["parent"] == shared_replication_id
+    assert node_data_by_id["asset-1"]["parent"] == shared_iteration_id
+
+
+def test_multi_root_asset_graph_marks_equivalent_children_as_shared(tmp_path):
+    """Equivalent assets reached from several roots get all run contexts."""
+    first_child = _TextAsset(name="same-survey-plans", cache_folder=tmp_path)
+    second_child = _TextAsset(name="same-survey-plans", cache_folder=tmp_path)
+    first_root = _ParentAsset(
+        children=[first_child],
+        cache_folder=tmp_path / "first-root",
+    )
+    second_root = _ParentAsset(
+        children=[second_child],
+        cache_folder=tmp_path / "second-root",
+    )
+    first_root.scenario = "baseline"
+    first_root.replication = 0
+    first_root.is_weekday = True
+    second_root.scenario = "project"
+    second_root.replication = 0
+    second_root.is_weekday = True
+
+    graph = build_asset_graph_from_roots([first_root, second_root])
+    shared_children = [
+        data
+        for asset, data in graph.nodes(data=True)
+        if isinstance(asset, _TextAsset)
+    ]
+
+    assert len(shared_children) == 1
+    assert shared_children[0]["run_contexts"] == (
+        "baseline|weekday|0",
+        "project|weekday|0",
+    )
+
+
+def test_multi_root_asset_graph_marks_equivalent_in_memory_assets_as_shared(tmp_path):
+    """Equivalent in-memory assets also get all run contexts."""
+    first_child = _MemoryAsset(name="same-generalized-cost")
+    second_child = _MemoryAsset(name="same-generalized-cost")
+    first_root = _ParentAsset(
+        children=[first_child],
+        cache_folder=tmp_path / "first-root",
+    )
+    second_root = _ParentAsset(
+        children=[second_child],
+        cache_folder=tmp_path / "second-root",
+    )
+    first_root.scenario = "baseline"
+    first_root.replication = 0
+    first_root.is_weekday = True
+    second_root.scenario = "project"
+    second_root.replication = 0
+    second_root.is_weekday = True
+
+    graph = build_asset_graph_from_roots([first_root, second_root])
+    shared_children = [
+        data
+        for asset, data in graph.nodes(data=True)
+        if isinstance(asset, _MemoryAsset)
+    ]
+
+    assert len(shared_children) == 1
+    assert shared_children[0]["run_contexts"] == (
+        "baseline|weekday|0",
+        "project|weekday|0",
+    )
+
+
+def test_create_asset_dag_app_builds_a_dash_layout(tmp_path):
+    """Smoke-test the static Dash app when optional UI packages are installed."""
+    pytest.importorskip("dash")
+    pytest.importorskip("dash_cytoscape")
+
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    app = create_asset_dag_app(parent, title="Asset DAG")
+
+    assert app.title == "Asset DAG"
+    assert app.layout is not None

--- a/tests/back/unit/runtime/test_003_asset_graph.py
+++ b/tests/back/unit/runtime/test_003_asset_graph.py
@@ -1,13 +1,29 @@
 import pytest
 
+import mobility.runtime.assets.dag_ui as dag_ui
 from mobility.runtime.assets.dag_ui import (
     DEFAULT_LAYOUT_NAME,
     asset_dag_layout,
+    asset_dag_index_string,
     asset_dag_layout_options,
     asset_graph_cytoscape_elements,
+    asset_graph_stylesheet,
     create_asset_dag_app,
+    create_asset_dag_app_from_graph,
+    create_group_day_trips_dag_app,
     filter_asset_graph_elements,
+    format_cache_path,
+    format_output_paths,
     group_asset_graph_elements_by_run_context,
+    group_day_trips_dag_roots,
+    parse_run_context,
+    run_group_id,
+    selected_group_day_trips_day_types,
+    selected_group_day_trips_replications,
+    selected_group_day_trips_scenarios,
+    shared_run_context_groups,
+    show_asset_dag,
+    show_group_day_trips_dag,
 )
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.runtime.assets.graph import (
@@ -87,6 +103,104 @@ class _MemoryAsset(InMemoryAsset):
 class _MemoryWrapperAsset(InMemoryAsset):
     def __init__(self, *, child):
         super().__init__({"child": child})
+
+
+class _FakeGroupDayTrips:
+    """Small setup object with the attributes used by the DAG viewer."""
+
+    def __init__(self, *, tmp_path, scenarios=None, n_replications=2, simulate_weekend=True):
+        self.tmp_path = tmp_path
+        self.run_calls = []
+        self.scenarios = type("Scenarios", (), {"names": scenarios or ["project"]})()
+        self.parameters = type(
+            "Parameters",
+            (),
+            {
+                "run": type("RunParameters", (), {"n_replications": n_replications})(),
+                "periods": type("Periods", (), {"simulate_weekend": simulate_weekend})(),
+            },
+        )()
+
+    def run(self, day_type, *, scenario, replication):
+        self.run_calls.append((scenario, replication, day_type))
+        asset = _ParentAsset(
+            children=[],
+            cache_folder=self.tmp_path / scenario / day_type / str(replication),
+        )
+        asset.scenario = scenario
+        asset.replication = replication
+        asset.is_weekday = day_type == "weekday"
+        return asset
+
+
+class _FakeDashApp:
+    def __init__(self):
+        self.run_calls = []
+        self.callback_calls = []
+        self.callback_functions = []
+        self.index_string = None
+        self.layout = None
+        self.title = None
+
+    def callback(self, *args, **kwargs):
+        self.callback_calls.append((args, kwargs))
+
+        def decorator(callback_function):
+            self.callback_functions.append(callback_function)
+            return callback_function
+
+        return decorator
+
+    def run(self, **kwargs):
+        self.run_calls.append(kwargs)
+
+
+class _FakeDashModule:
+    def __init__(self):
+        self.apps = []
+
+    def Dash(self, name):
+        app = _FakeDashApp()
+        app.name = name
+        self.apps.append(app)
+        return app
+
+
+class _FakeComponentNamespace:
+    def __getattr__(self, component_name):
+        def build(*children, **properties):
+            return {
+                "component": component_name,
+                "children": children,
+                "properties": properties,
+            }
+
+        return build
+
+
+class _FakeCytoscapeNamespace(_FakeComponentNamespace):
+    def __init__(self):
+        self.load_extra_layout_calls = 0
+
+    def load_extra_layouts(self):
+        self.load_extra_layout_calls += 1
+
+
+def _install_fake_dash(monkeypatch):
+    """Install small Dash stand-ins so tests can run without optional packages."""
+    fake_dash = _FakeDashModule()
+    fake_cyto = _FakeCytoscapeNamespace()
+    fake_html = _FakeComponentNamespace()
+    fake_dcc = _FakeComponentNamespace()
+
+    monkeypatch.setattr(dag_ui, "dash", fake_dash)
+    monkeypatch.setattr(dag_ui, "cyto", fake_cyto)
+    monkeypatch.setattr(dag_ui, "html", fake_html)
+    monkeypatch.setattr(dag_ui, "dcc", fake_dcc)
+    monkeypatch.setattr(dag_ui, "Input", lambda *args: ("Input", args))
+    monkeypatch.setattr(dag_ui, "Output", lambda *args: ("Output", args))
+    monkeypatch.setattr(dag_ui, "_DASH_IMPORT_ERROR", None)
+    return fake_dash, fake_cyto
 
 
 def test_build_asset_graph_deduplicates_equivalent_file_assets(tmp_path):
@@ -242,6 +356,35 @@ def test_asset_dag_layout_options_include_the_default_layout():
     assert DEFAULT_LAYOUT_NAME in option_values
     assert asset_dag_layout(DEFAULT_LAYOUT_NAME)["rankDir"] == "TB"
     assert asset_dag_layout("dagre_lr")["rankDir"] == "LR"
+    assert asset_dag_layout(None)["rankDir"] == "TB"
+    assert asset_dag_layout("cose_bilkent")["name"] == "cose-bilkent"
+    assert asset_dag_layout("unknown-layout")["name"] == "breadthfirst"
+
+
+def test_asset_graph_display_helpers_format_optional_values(tmp_path):
+    """Format cache metadata as text before it is sent to Dash."""
+    first_path = tmp_path / "first.parquet"
+    second_path = tmp_path / "second.parquet"
+
+    assert format_cache_path(None) is None
+    assert format_cache_path(first_path) == str(first_path)
+    assert format_cache_path((("first", first_path), ("second", second_path))) == (
+        f"first: {first_path}\nsecond: {second_path}"
+    )
+    assert format_output_paths(()) == ""
+    assert format_output_paths((("output", first_path),)) == f"output: {first_path}"
+
+
+def test_asset_graph_stylesheet_and_index_include_run_groups():
+    """Keep the CSS hooks used by the grouped graph view."""
+    stylesheet = asset_graph_stylesheet()
+    selectors = {rule["selector"] for rule in stylesheet}
+    index_string = asset_dag_index_string()
+
+    assert ".run_group" in selectors
+    assert ".cached" in selectors
+    assert ".missing" in selectors
+    assert "asset-dag-main" in index_string
 
 
 def test_group_asset_graph_elements_by_run_context_adds_subgroup_nodes(tmp_path):
@@ -307,6 +450,20 @@ def test_group_asset_graph_elements_by_run_context_groups_shared_iterations(tmp_
     assert node_data_by_id[shared_replication_id]["parent"] == shared_day_type_id
     assert node_data_by_id[shared_iteration_id]["parent"] == shared_replication_id
     assert node_data_by_id["asset-1"]["parent"] == shared_iteration_id
+
+
+def test_run_context_helpers_handle_unknown_and_shared_values():
+    """Use stable labels when assets are shared or have malformed contexts."""
+    assert parse_run_context("scenario|weekday|2") == ("scenario", "weekday", "2")
+    assert parse_run_context("bad-context") == ("unknown", "unknown", "unknown")
+    assert shared_run_context_groups(["a|weekday|0", "b|weekday|0"]) == ("weekday", "0")
+    assert shared_run_context_groups(["a|weekday|0", "b|weekend|1"]) == (
+        "several-day-types",
+        "several-replications",
+    )
+    assert run_group_id("scenario", "saleve jura", "path\\part") == (
+        "run-group-scenario-saleve-jura-path-part"
+    )
 
 
 def test_multi_root_asset_graph_marks_equivalent_children_as_shared(tmp_path):
@@ -375,6 +532,144 @@ def test_multi_root_asset_graph_marks_equivalent_in_memory_assets_as_shared(tmp_
     )
 
 
+def test_group_day_trips_dag_roots_build_selected_run_assets(tmp_path):
+    """Build one root asset for each selected scenario, replication, and day type."""
+    group_day_trips = _FakeGroupDayTrips(
+        tmp_path=tmp_path,
+        scenarios=["default", "project"],
+        n_replications=2,
+        simulate_weekend=True,
+    )
+
+    assert selected_group_day_trips_scenarios(group_day_trips, None) == [
+        "default",
+        "project",
+    ]
+    assert selected_group_day_trips_scenarios(group_day_trips, ["custom"]) == ["custom"]
+    assert selected_group_day_trips_replications(group_day_trips, None) == [0, 1]
+    assert selected_group_day_trips_replications(group_day_trips, range(1, 3)) == [1, 2]
+    assert selected_group_day_trips_day_types(group_day_trips, None) == [
+        "weekday",
+        "weekend",
+    ]
+    assert selected_group_day_trips_day_types(group_day_trips, ["weekday"]) == ["weekday"]
+
+    roots = group_day_trips_dag_roots(
+        group_day_trips,
+        scenarios=["project"],
+        replications=[1],
+        day_types=["weekend"],
+    )
+
+    assert len(roots) == 1
+    assert group_day_trips.run_calls == [("project", 1, "weekend")]
+    assert roots[0].scenario == "project"
+    assert roots[0].replication == 1
+    assert roots[0].is_weekday is False
+
+
+def test_group_day_trips_dag_app_uses_selected_roots(tmp_path, monkeypatch):
+    """Create the group-day-trips app from selected roots without computing outputs."""
+    group_day_trips = _FakeGroupDayTrips(tmp_path=tmp_path, simulate_weekend=False)
+    captured = {}
+
+    def fake_create_asset_dag_app_from_graph(graph, *, title):
+        captured["node_count"] = graph.number_of_nodes()
+        captured["title"] = title
+        return "app"
+
+    monkeypatch.setattr(dag_ui, "_raise_if_dash_is_missing", lambda: None)
+    monkeypatch.setattr(
+        dag_ui,
+        "create_asset_dag_app_from_graph",
+        fake_create_asset_dag_app_from_graph,
+    )
+
+    app = create_group_day_trips_dag_app(
+        group_day_trips,
+        title="Selected runs",
+        scenarios=["project"],
+        replications=[0, 1],
+        day_types=["weekday"],
+    )
+
+    assert app == "app"
+    assert captured == {"node_count": 2, "title": "Selected runs"}
+    assert group_day_trips.run_calls == [
+        ("project", 0, "weekday"),
+        ("project", 1, "weekday"),
+    ]
+
+
+def test_create_asset_dag_app_builds_layout_without_optional_dash(tmp_path, monkeypatch):
+    """Build the Dash app structure with fake components for CI coverage."""
+    fake_dash, fake_cyto = _install_fake_dash(monkeypatch)
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+
+    app = create_asset_dag_app(parent, title="Asset DAG")
+
+    assert app is fake_dash.apps[0]
+    assert app.title == "Asset DAG"
+    assert app.layout["component"] == "Div"
+    assert len(app.callback_calls) == 3
+    assert app.index_string.startswith("\n<!DOCTYPE html>")
+    assert fake_cyto.load_extra_layout_calls == 1
+
+    filter_elements, update_layout, show_node_details = app.callback_functions
+    filtered_elements = filter_elements(["_TextAsset"], ["missing"], [], [])
+    grouped_elements = filter_elements(None, None, None, ["run_context"])
+    grouped_nodes = [element for element in grouped_elements if "source" not in element["data"]]
+    grouped_node_ids = {element["data"]["id"] for element in grouped_nodes}
+    grouped_asset_nodes = [
+        element for element in grouped_nodes if element["data"].get("asset_type") != "RunGroup"
+    ]
+    selected_details = show_node_details(
+        {
+            "label": "_TextAsset",
+            "asset_type": "_TextAsset",
+            "status": "missing",
+            "iteration": None,
+            "scenario": None,
+            "replication": None,
+            "is_weekday": None,
+            "run_contexts": [],
+            "inputs_hash": "inputs",
+            "cached_hash": None,
+            "missing_outputs": "output: missing.parquet",
+            "existing_outputs": "",
+            "cache_path": "missing.parquet",
+        }
+    )
+
+    assert len([element for element in filtered_elements if "source" not in element["data"]]) == 1
+    assert "run-group-scenario-default" in grouped_node_ids
+    assert all("parent" in element["data"] for element in grouped_asset_nodes)
+    assert update_layout("dagre_tb", ["run_context"])["padding"] == 55
+    assert update_layout("dagre_lr", [])["rankDir"] == "LR"
+    assert show_node_details(None)["component"] == "Div"
+    assert selected_details["component"] == "Div"
+
+
+def test_create_asset_dag_app_from_graph_builds_layout_without_optional_dash(
+    tmp_path,
+    monkeypatch,
+):
+    """Build an app from a pre-built graph, as used by the multi-run viewer."""
+    fake_dash, fake_cyto = _install_fake_dash(monkeypatch)
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    parent = _ParentAsset(children=[child], cache_folder=tmp_path)
+    graph = build_asset_graph(parent)
+
+    app = create_asset_dag_app_from_graph(graph, title="Pre-built graph")
+
+    assert app is fake_dash.apps[0]
+    assert app.title == "Pre-built graph"
+    assert app.layout["component"] == "Div"
+    assert len(app.callback_calls) == 3
+    assert fake_cyto.load_extra_layout_calls == 1
+
+
 def test_create_asset_dag_app_builds_a_dash_layout(tmp_path):
     """Smoke-test the static Dash app when optional UI packages are installed."""
     pytest.importorskip("dash")
@@ -387,3 +682,67 @@ def test_create_asset_dag_app_builds_a_dash_layout(tmp_path):
 
     assert app.title == "Asset DAG"
     assert app.layout is not None
+
+
+def test_dash_app_creation_explains_missing_optional_dependencies(tmp_path, monkeypatch):
+    """Tell users which optional dependency group installs the DAG viewer."""
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    monkeypatch.setattr(dag_ui, "_DASH_IMPORT_ERROR", ImportError("dash missing"))
+
+    with pytest.raises(ImportError, match="pip install mobility\\[dag\\]"):
+        create_asset_dag_app(child)
+
+
+def test_show_asset_dag_passes_server_options(tmp_path, monkeypatch):
+    """Forward server options to the local Dash app."""
+    app = _FakeDashApp()
+    child = _TextAsset(name="child", cache_folder=tmp_path)
+    monkeypatch.setattr(dag_ui, "create_asset_dag_app", lambda *args, **kwargs: app)
+
+    show_asset_dag(
+        child,
+        title="Asset DAG",
+        host="0.0.0.0",
+        port=9090,
+        debug=True,
+    )
+
+    assert app.run_calls == [{"host": "0.0.0.0", "port": 9090, "debug": True}]
+
+
+def test_show_group_day_trips_dag_passes_server_options(tmp_path, monkeypatch):
+    """Forward selected runs and server options to the group-day-trips Dash app."""
+    app = _FakeDashApp()
+    group_day_trips = _FakeGroupDayTrips(tmp_path=tmp_path)
+    captured = {}
+
+    def fake_create_group_day_trips_dag_app(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return app
+
+    monkeypatch.setattr(
+        dag_ui,
+        "create_group_day_trips_dag_app",
+        fake_create_group_day_trips_dag_app,
+    )
+
+    show_group_day_trips_dag(
+        group_day_trips,
+        title="Runs",
+        scenarios=["project"],
+        replications=[1],
+        day_types=["weekday"],
+        host="0.0.0.0",
+        port=9091,
+        debug=True,
+    )
+
+    assert captured["args"] == (group_day_trips,)
+    assert captured["kwargs"] == {
+        "title": "Runs",
+        "scenarios": ["project"],
+        "replications": [1],
+        "day_types": ["weekday"],
+    }
+    assert app.run_calls == [{"host": "0.0.0.0", "port": 9091, "debug": True}]


### PR DESCRIPTION
### Motivation
Debugging grouped day-trip runs is difficult when asset dependencies are only visible through code and cache paths. We need a quick way to inspect the asset DAG, see which files are cached, missing, or stale, and understand how assets are shared across scenarios, day types, replications, and iterations.

This PR is stacked on #359, which adds the shared graph extraction used by the viewer.

### Changes
- Add a Dash and Cytoscape asset DAG viewer in `mobility.runtime.assets.dag_ui`.
- Add helpers to create a viewer for one root asset or for all selected `PopulationGroupDayTrips` runs.
- Add filters for asset type, cache status, and iteration.
- Add layered top-to-bottom layout as the default, with other layout choices available.
- Add a details panel showing status, hashes, run contexts, and existing or missing cache outputs.
- Add optional `dag` dependencies for Dash and dash-cytoscape.
- Add unit tests for graph elements, filtering, layout options, run-context grouping, multi-root sharing, and app construction.

### Example (if relevant)
```python
from mobility.runtime.assets.dag_ui import show_group_day_trips_dag

show_group_day_trips_dag(pop_group_day_trips)
```

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Built the Dash/Cytoscape viewer, grouping behavior, and focused tests.
- What you reviewed or changed: Reviewed asset graph shape with real grouped day-trip scenarios and adjusted the UI to show full DAGs, run contexts, iterations, and cache outputs clearly.
- How you validated it (tests, checks, manual verification): Ran the DAG viewer unit tests and `py_compile` for the new UI module.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior