### PR TITLE
Clean up travel-cost selectors

### DIFF
--- a/mobility/transport/costs/path/path_travel_costs.py
+++ b/mobility/transport/costs/path/path_travel_costs.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os
 import pathlib
 import logging
-import shutil
 import pandas as pd
-import geopandas as gpd
 
 from importlib import resources
 from mobility.transport.graphs.core.path_graph import PathGraph
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
 from mobility.transport.costs.parameters.path_routing_parameters import PathRoutingParameters
@@ -21,7 +21,69 @@ from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 
 from typing import List
 
-class PathTravelCosts(TravelCostsAsset):
+
+class PathTravelCostsTable(TravelCostsBase, FileAsset):
+    """Single path travel-cost table for one routing graph."""
+
+    def __init__(
+        self,
+        *,
+        mode_name: str,
+        transport_zones: TransportZones,
+        routing_graph,
+        routing_parameters: PathRoutingParameters,
+        cost_kind: str,
+    ) -> None:
+        self.mode_name = mode_name
+        self.transport_zones = transport_zones
+        self.routing_graph = routing_graph
+        self.routing_parameters = routing_parameters
+        self.cost_kind = cost_kind
+        inputs = {
+            "version": 1,
+            "mode_name": mode_name,
+            "transport_zones": transport_zones,
+            "routing_graph": routing_graph,
+            "routing_parameters": routing_parameters,
+            "cost_kind": cost_kind,
+        }
+        cache_path = (
+            pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+            / f"travel_costs_{cost_kind}_{mode_name}.parquet"
+        )
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pd.DataFrame:
+        """Return the cached OD travel-cost table."""
+        logging.debug("Travel costs already prepared. Reusing the file : %s", str(self.cache_path))
+        return pd.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pd.DataFrame:
+        """Compute this OD travel-cost table from its routing graph."""
+        logging.info("Preparing travel costs for mode %s", self.mode_name)
+        self.transport_zones.get()
+        return self._compute_costs_by_od()
+
+    def _compute_costs_by_od(self) -> pd.DataFrame:
+        """Compute path travel times and distances by OD."""
+        logging.info("Computing travel times and distances by OD...")
+        script = RScriptRunner(
+            resources.files('mobility.transport.costs.path').joinpath(
+                'prepare_dodgr_costs.R'
+            )
+        )
+        script.run(
+            args=[
+                str(self.transport_zones.cache_path),
+                str(self.routing_graph.get()),
+                str(self.routing_parameters.max_beeline_distance),
+                str(self.cache_path),
+            ]
+        )
+        return pd.read_parquet(self.cache_path)
+
+
+class PathTravelCosts(TravelCostsBase, InMemoryAsset):
     """
     A class for managing travel cost calculations for certain modes using OpenStreetMap (OSM) data, inheriting from the Asset class.
 
@@ -55,6 +117,7 @@ class PathTravelCosts(TravelCostsAsset):
             congestion_assignment_retained_volume_share: float = 0.95,
             speed_modifiers: List[SpeedModifier] = [],
             contracted_graph: ContractedPathGraph | None = None,
+            default_congestion: bool = False,
         ):
         """
         Initializes a TravelCosts object with the given transport zones and travel mode.
@@ -87,6 +150,28 @@ class PathTravelCosts(TravelCostsAsset):
             congested_path_graph = contracted_graph.inputs["congested_graph"]
             modified_path_graph = congested_path_graph.inputs["modified_graph"]
             simplified_path_graph = None
+
+        self.mode_name = mode_name
+        self.transport_zones = transport_zones
+        self.simplified_path_graph = simplified_path_graph
+        self.modified_path_graph = modified_path_graph
+        self.congested_path_graph = congested_path_graph
+        self.contracted_path_graph = contracted_path_graph
+        self.freeflow_costs = PathTravelCostsTable(
+            mode_name=mode_name,
+            transport_zones=transport_zones,
+            routing_graph=contracted_path_graph,
+            routing_parameters=routing_parameters,
+            cost_kind="free_flow",
+        )
+        self.congested_costs = PathTravelCostsTable(
+            mode_name=mode_name,
+            transport_zones=transport_zones,
+            routing_graph=contracted_path_graph,
+            routing_parameters=routing_parameters,
+            cost_kind="congested",
+        )
+        self.default_congestion = bool(default_congestion)
         
         inputs = {
             "transport_zones": transport_zones,
@@ -101,131 +186,45 @@ class PathTravelCosts(TravelCostsAsset):
             "congestion_assignment_max_iterations": congestion_assignment_max_iterations,
             "congestion_assignment_max_gap": congestion_assignment_max_gap,
             "congestion_assignment_retained_volume_share": congestion_assignment_retained_volume_share,
+            "default_congestion": self.default_congestion,
         }
-
-        cache_path = {
-            "freeflow": pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / ("travel_costs_free_flow_" + mode_name + ".parquet"),
-            "congested": pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / ("travel_costs_congested_" + mode_name + ".parquet")
-        }
-
-        super().__init__(inputs, cache_path)
+        super().__init__(inputs)
 
     def get(self, congestion: bool = False, road_flow_asset: VehicleODFlowsAsset | None = None) -> pd.DataFrame:
-        requested_congestion = congestion and road_flow_asset is None
-        self.update_ancestors_if_needed()
-
-        if self.is_update_needed():
-            asset = self.create_and_get_asset(congestion=requested_congestion)
-            self.update_hash(self.inputs_hash)
-            if road_flow_asset is None:
-                return asset
+        if congestion and self._handles_congestion() is False:
+            return self.freeflow_costs.get()
 
         if congestion and road_flow_asset is not None:
             asset = self.asset_for_road_flows(road_flow_asset)
             if asset is not None:
                 return asset.get()
 
-        return self.get_cached_asset(congestion=congestion)
-
-    def get_cached_asset(self, congestion: bool = False) -> pd.DataFrame:
-        """
-        Retrieves the travel costs DataFrame from the cache.
-
-        Returns:
-            pd.DataFrame: The cached DataFrame of travel costs.
-        """
-        
-        if congestion is False:
-            path = self.cache_path["freeflow"]
-        else:
-            path = self.cache_path["congested"]
-
-        logging.debug("Travel costs already prepared. Reusing the file : " + str(path))
-        costs = pd.read_parquet(path)
-
-        return costs
-
-    def create_and_get_asset(self, congestion: bool = False) -> pd.DataFrame:
-        """
-        Creates and retrieves travel costs based on the current inputs.
-
-        Returns:
-            pd.DataFrame: A DataFrame of calculated travel costs.
-        """
-        
-        mode = self.inputs["mode_name"]
-        
-        logging.info("Preparing travel costs for mode " + mode)
-        
-        self.inputs["transport_zones"].get()
-        
-        if congestion is False:
-            self.inputs["contracted_path_graph"].get()
-            output_path = self.cache_path["freeflow"]
-            path_graph = self.inputs["contracted_path_graph"]
-        else:
-            self.inputs["congested_path_graph"].get()
-            output_path = self.cache_path["congested"]
-            path_graph = self.inputs["congested_path_graph"]
-        
-        costs = self.compute_costs_by_OD(
-            self.inputs["transport_zones"],
-            path_graph,
-            output_path,
-        )
-        
-        if congestion is False:
-            shutil.copy(self.cache_path["freeflow"], self.cache_path["congested"])
-
-        return costs
-
-
-
-    def compute_costs_by_OD(
-            self,
-            transport_zones: TransportZones,
-            path_graph: PathGraph,
-            output_path: pathlib.Path
-        ) -> pd.DataFrame:
-        """
-        Calculates travel costs for the specified mode of transportation using the created graph.
-
-        Args:
-            transport_zones (gpd.GeoDataFrame): GeoDataFrame containing transport zone geometries.
-            graph (str): Path to the routable graph file.
-
-        Returns:
-            pd.DataFrame: A DataFrame containing calculated travel costs.
-        """
-
-        logging.info("Computing travel times and distances by OD...")
-        
-        script = RScriptRunner(resources.files('mobility.transport.costs.path').joinpath('prepare_dodgr_costs.R'))
-        script.run(
-            args=[
-                str(transport_zones.cache_path),
-                str(path_graph.cache_path),
-                str(self.inputs["routing_parameters"].max_beeline_distance),
-                str(output_path)
-            ]
-        )
-        
-        costs = pd.read_parquet(output_path)
-
-        return costs
+        # A congested cost table only differs from free-flow costs when it is
+        # tied to an explicit road-flow asset.
+        if self.default_congestion:
+            return self.congested_costs.get()
+        return self.freeflow_costs.get()
     
     def get_congested_graph_path(self, flow_asset=None) -> pathlib.Path:
         """Return the graph path backing the current congested cost view."""
         if flow_asset is not None:
-            return self.asset_for_flow_asset(flow_asset).inputs["contracted_path_graph"].inputs["congested_graph"].get()
-        return self.inputs["congested_path_graph"].get()
+            return self.asset_for_flow_asset(flow_asset).congested_path_graph.get()
+        return self.congested_path_graph.get()
 
     def asset_for_road_flows(self, road_flow_asset: VehicleODFlowsAsset | None):
         if road_flow_asset is None:
             return None
-        if self.inputs["congested_path_graph"].inputs["handles_congestion"] is False:
+        if self._handles_congestion() is False:
             return None
         return self.asset_for_flow_asset(road_flow_asset)
+
+    def _handles_congestion(self) -> bool:
+        """Return whether this path mode can use congestion-sensitive costs."""
+        if hasattr(self, "congested_path_graph"):
+            congested_path_graph = self.congested_path_graph
+        else:
+            congested_path_graph = self.inputs["congested_path_graph"]
+        return bool(congested_path_graph.inputs["handles_congestion"])
 
     def asset_for_flow_asset(self, flow_asset):
         congested_graph = CongestedPathGraph(
@@ -251,8 +250,14 @@ class PathTravelCosts(TravelCostsAsset):
             congestion_assignment_max_gap=self.inputs["congestion_assignment_max_gap"],
             congestion_assignment_retained_volume_share=self.inputs["congestion_assignment_retained_volume_share"],
             contracted_graph=contracted_graph,
+            default_congestion=True,
         )
         return variant
+
+    def remove(self) -> None:
+        """Remove path travel-cost tables owned by this selector."""
+        self.freeflow_costs.remove()
+        self.congested_costs.remove()
 
     def remove_congestion_artifacts(self, road_flow_asset: VehicleODFlowsAsset) -> None:
         """Remove one congestion-specific travel-cost variant and owned graph caches."""
@@ -268,4 +273,3 @@ class PathTravelCosts(TravelCostsAsset):
             congested_graph = getattr(contracted_graph, "inputs", {}).get("congested_graph")
             if congested_graph is not None:
                 congested_graph.remove()
-        

--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -12,7 +12,7 @@ from mobility.runtime.parameter_values import resolve_parameter_values
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.costs.road_flow_manager import RoadFlowManager
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
 
 
 class TransportCosts(FileAsset):
@@ -353,6 +353,6 @@ class TransportCosts(FileAsset):
 
         for mode in self.modes:
             travel_costs = mode.inputs.get("travel_costs")
-            if travel_costs is None or isinstance(travel_costs, TravelCostsAsset) is False:
+            if travel_costs is None or isinstance(travel_costs, TravelCostsBase) is False:
                 continue
             travel_costs.remove_congestion_artifacts(road_flow_asset)

--- a/mobility/transport/costs/travel_costs_asset.py
+++ b/mobility/transport/costs/travel_costs_asset.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from mobility.runtime.assets.file_asset import FileAsset
 
-
-class TravelCostsAsset(FileAsset):
-    """Base class for per-mode travel-cost assets with congestion helpers."""
+class TravelCostsBase:
+    """Shared helpers for travel-cost selectors and file-backed assets."""
 
     def asset_for_road_flows(self, road_flow_asset):
         """Return the effective asset for one road-flow asset."""

--- a/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
+++ b/mobility/transport/modes/carpool/detailed/detailed_carpool_travel_costs.py
@@ -5,19 +5,89 @@ import os
 import logging
 import json
 import pandas as pd
-import shutil
 from typing import Annotated
 
 from importlib import resources
 from pydantic import BaseModel, ConfigDict, Field
 
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.modes.core.modal_transfer import IntermodalTransfer
 from mobility.transport.costs.path.path_travel_costs import PathTravelCosts
 
-class DetailedCarpoolTravelCosts(TravelCostsAsset):
+
+class DetailedCarpoolTravelCostsTable(TravelCostsBase, FileAsset):
+    """Single detailed carpool travel-cost table."""
+
+    def __init__(
+        self,
+        *,
+        car_travel_costs: PathTravelCosts,
+        parameters: "DetailedCarpoolRoutingParameters",
+        modal_transfer: IntermodalTransfer,
+        congestion: bool,
+        road_flow_asset: VehicleODFlowsAsset | None = None,
+    ) -> None:
+        self.car_travel_costs = car_travel_costs
+        self.parameters = parameters
+        self.modal_transfer = modal_transfer
+        self.congestion = bool(congestion)
+        self.road_flow_asset = road_flow_asset
+        inputs = {
+            "version": 1,
+            "car_travel_costs": car_travel_costs,
+            "parameters": parameters,
+            "modal_transfer": modal_transfer,
+            "congestion": bool(congestion),
+            "road_flow_asset": road_flow_asset,
+        }
+        cost_kind = "congested" if congestion else "free_flow"
+        cache_path = (
+            pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+            / f"travel_costs_{cost_kind}_carpool.parquet"
+        )
+        super().__init__(inputs, cache_path)
+
+    def get_cached_asset(self) -> pd.DataFrame:
+        """Return the cached detailed carpool OD costs."""
+        logging.debug("Travel costs already prepared. Reusing the file : %s", str(self.cache_path))
+        return pd.read_parquet(self.cache_path)
+
+    def create_and_get_asset(self) -> pd.DataFrame:
+        """Compute this detailed carpool OD cost table."""
+        logging.info("Preparing carpool travel costs for occupants...")
+        return self._compute_travel_costs()
+
+    def _compute_travel_costs(self) -> pd.DataFrame:
+        """Compute detailed carpool OD travel costs."""
+        script = RScriptRunner(
+            resources.files('mobility.transport.modes.carpool.detailed').joinpath(
+                'compute_carpool_travel_costs.R'
+            )
+        )
+
+        if self.congestion:
+            graph = self.car_travel_costs.get_congested_graph_path(self.road_flow_asset)
+        else:
+            graph = self.car_travel_costs.modified_path_graph.get()
+
+        script.run(
+            args=[
+                str(self.car_travel_costs.transport_zones.cache_path),
+                str(self.car_travel_costs.transport_zones.study_area.cache_path["polygons"]),
+                str(graph),
+                str(graph),
+                json.dumps(self.modal_transfer.model_dump(mode="json")),
+                self.cache_path,
+            ]
+        )
+        return pd.read_parquet(self.cache_path)
+
+
+class DetailedCarpoolTravelCosts(TravelCostsBase, InMemoryAsset):
 
     def __init__(
             self,
@@ -27,102 +97,45 @@ class DetailedCarpoolTravelCosts(TravelCostsAsset):
             road_flow_asset: VehicleODFlowsAsset | None = None,
         ):
 
+        self.car_travel_costs = car_travel_costs
+        self.parameters = parameters
+        self.modal_transfer = modal_transfer
+        self.road_flow_asset = road_flow_asset
+        self.freeflow_costs = DetailedCarpoolTravelCostsTable(
+            car_travel_costs=car_travel_costs,
+            parameters=parameters,
+            modal_transfer=modal_transfer,
+            congestion=False,
+            road_flow_asset=None,
+        )
+        self.congested_costs = DetailedCarpoolTravelCostsTable(
+            car_travel_costs=car_travel_costs,
+            parameters=parameters,
+            modal_transfer=modal_transfer,
+            congestion=True,
+            road_flow_asset=road_flow_asset,
+        )
+        self.default_congestion = road_flow_asset is not None
         inputs = {
             "car_travel_costs": car_travel_costs,
             "parameters": parameters,
             "modal_transfer": modal_transfer,
             "road_flow_asset": road_flow_asset,
+            "default_congestion": self.default_congestion,
         }
-        
-        cache_path = {
-            "freeflow": pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / ("travel_costs_free_flow_carpool.parquet"),
-            "congested": pathlib.Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"]) / ("travel_costs_congested_carpool.parquet")
-        }
-
-
-        super().__init__(inputs, cache_path)
+        super().__init__(inputs)
 
     def get(self, congestion: bool = False, road_flow_asset: VehicleODFlowsAsset | None = None) -> pd.DataFrame:
-        requested_congestion = congestion and road_flow_asset is None
-        self.update_ancestors_if_needed()
-
-        if self.is_update_needed():
-            asset = self.create_and_get_asset(congestion=requested_congestion)
-            self.update_hash(self.inputs_hash)
-            if road_flow_asset is None:
-                return asset
-
         if congestion and road_flow_asset is not None:
             asset = self.asset_for_road_flows(road_flow_asset)
             if asset is not None:
                 return asset.get()
 
-        return self.get_cached_asset(congestion=congestion)
-
-    def get_cached_asset(self, congestion: bool = False) -> pd.DataFrame:
-
-        if congestion is False:
-            path = self.cache_path["freeflow"]
-        else:
-            path = self.cache_path["congested"]
-
-        logging.debug("Travel costs already prepared. Reusing the file : " + str(path))
-        costs = pd.read_parquet(path)
-
-        return costs
-
-    def create_and_get_asset(self, congestion: bool = False) -> pd.DataFrame:
-        
-        logging.info("Preparing carpool travel costs for occupants...")
-        
-        if congestion is False:
-            output_path = self.cache_path["freeflow"]
-        else:
-            output_path = self.cache_path["congested"]
-        
-        costs = self.compute_travel_costs(
-            self.inputs["car_travel_costs"],
-            self.inputs["parameters"],
-            self.inputs["modal_transfer"],
-            congestion,
-            output_path
-        )
-        
-        if congestion is False:
-            shutil.copy(self.cache_path["freeflow"], self.cache_path["congested"])
-
-        return costs
-
-    def compute_travel_costs(
-            self,
-            car_travel_costs: PathTravelCosts,
-            params: "DetailedCarpoolRoutingParameters",
-            modal_transfer: IntermodalTransfer,
-            congestion: bool,
-            output_path: pathlib.Path
-        ) -> pd.DataFrame:
-        
-        script = RScriptRunner(resources.files('mobility.transport.modes.carpool.detailed').joinpath('compute_carpool_travel_costs.R'))
-        
-        if congestion is True:
-            graph = car_travel_costs.get_congested_graph_path(self.inputs["road_flow_asset"])
-        else:
-            graph = car_travel_costs.modified_path_graph.get()
-        
-        script.run(
-            args=[
-                str(car_travel_costs.transport_zones.cache_path),
-                str(car_travel_costs.transport_zones.study_area.cache_path["polygons"]),
-                str(graph),
-                str(graph),
-                json.dumps(modal_transfer.model_dump(mode="json")),
-                output_path
-            ]
-        )
-
-        costs = pd.read_parquet(output_path)
-        
-        return costs
+        # Without an explicit road-flow asset, the congested and free-flow
+        # carpool costs are the same logical state.
+        if self.default_congestion:
+            return self.congested_costs.get()
+        return self.freeflow_costs.get()
     
     
     def asset_for_road_flows(
@@ -141,6 +154,18 @@ class DetailedCarpoolTravelCosts(TravelCostsAsset):
             modal_transfer=self.inputs["modal_transfer"],
             road_flow_asset=flow_asset,
         )
+
+    def remove(self) -> None:
+        """Remove detailed carpool travel-cost tables owned by this selector."""
+        self.freeflow_costs.remove()
+        self.congested_costs.remove()
+
+    def remove_congestion_artifacts(self, road_flow_asset: VehicleODFlowsAsset) -> None:
+        """Remove only the carpool costs tied to one road-flow asset."""
+        variant = self.asset_for_road_flows(road_flow_asset)
+        if variant is self or variant is None:
+            return
+        variant.congested_costs.remove()
 
 
 class DetailedCarpoolRoutingParameters(BaseModel):

--- a/mobility/transport/modes/public_transport/public_transport_travel_costs.py
+++ b/mobility/transport/modes/public_transport/public_transport_travel_costs.py
@@ -8,14 +8,15 @@ import pandas as pd
 
 from importlib import resources
 
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
+from mobility.runtime.assets.file_asset import FileAsset
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
 from mobility.transport.modes.public_transport.public_transport_graph import PublicTransportRoutingParameters
 from mobility.transport.modes.public_transport.intermodal_transport_graph import IntermodalTransportGraph
 from mobility.transport.modes.core.modal_transfer import IntermodalTransfer
 
-class PublicTransportTravelCosts(TravelCostsAsset):
+class PublicTransportTravelCosts(TravelCostsBase, FileAsset):
     """
     A class for managing public transport travel costs calculations using GTFS files, inheriting from the FileAsset class.
 
@@ -202,7 +203,7 @@ class PublicTransportTravelCosts(TravelCostsAsset):
     @staticmethod
     def _travel_costs_for_road_flows(travel_costs: Any, road_flow_asset):
         """Resolve one leg travel-cost asset for the requested road flows."""
-        if isinstance(travel_costs, TravelCostsAsset) is False:
+        if isinstance(travel_costs, TravelCostsBase) is False:
             return travel_costs
 
         variant = travel_costs.asset_for_road_flows(road_flow_asset)

--- a/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
+++ b/tests/back/unit/choice_models/test_002_transport_costs_cleanup.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
 
 from mobility.transport.costs.transport_costs import TransportCosts
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
 
 
-class _FakeTravelCostsAsset(TravelCostsAsset):
+class _FakeTravelCosts(TravelCostsBase):
     def __init__(self):
         self.inputs = {}
         self.remove_calls = []
@@ -50,7 +50,7 @@ def test_remove_congestion_artifacts_removes_variant_and_delegates_to_mode_asset
     project_dir,
     monkeypatch,
 ):
-    travel_costs = _FakeTravelCostsAsset()
+    travel_costs = _FakeTravelCosts()
     aggregator = TransportCosts(
         modes=[
             _make_mode(name="car", congestion=True, travel_costs=travel_costs),

--- a/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
+++ b/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
@@ -1,7 +1,10 @@
 import pytest
 
 from mobility.transport.costs.path.path_travel_costs import PathTravelCosts
-from mobility.transport.costs.travel_costs_asset import TravelCostsAsset
+from mobility.transport.costs.travel_costs_asset import TravelCostsBase
+from mobility.transport.modes.carpool.detailed.detailed_carpool_travel_costs import (
+    DetailedCarpoolTravelCosts,
+)
 from mobility.transport.modes.public_transport.public_transport_travel_costs import (
     PublicTransportTravelCosts,
 )
@@ -16,7 +19,22 @@ class _Removable:
         self.remove_calls += 1
 
 
-class _LegTravelCosts(TravelCostsAsset):
+class _CostTable:
+    def __init__(self, value):
+        self.value = value
+        self.get_calls = 0
+
+    def get(self):
+        self.get_calls += 1
+        return self.value
+
+
+class _CongestedPathGraph:
+    def __init__(self, *, handles_congestion):
+        self.inputs = {"handles_congestion": handles_congestion}
+
+
+class _LegTravelCosts(TravelCostsBase):
     def __init__(self, variant):
         self.variant = variant
         self.inputs = {}
@@ -123,6 +141,76 @@ def _make_path_travel_costs():
     asset = object.__new__(PathTravelCosts)
     asset.inputs = {"mode_name": "car"}
     return asset
+
+
+def test_path_get_uses_freeflow_without_road_flow_asset():
+    asset = _make_path_travel_costs()
+    asset.freeflow_costs = _CostTable("free-flow")
+    asset.congested_costs = _CostTable("congested")
+    asset.default_congestion = False
+    asset.congested_path_graph = _CongestedPathGraph(handles_congestion=True)
+
+    assert asset.get() == "free-flow"
+    assert asset.get(congestion=True) == "free-flow"
+    assert asset.freeflow_costs.get_calls == 2
+    assert asset.congested_costs.get_calls == 0
+
+
+def test_path_get_defaults_to_congested_for_road_flow_variant():
+    asset = _make_path_travel_costs()
+    asset.freeflow_costs = _CostTable("free-flow")
+    asset.congested_costs = _CostTable("congested")
+    asset.default_congestion = True
+
+    assert asset.get() == "congested"
+    assert asset.freeflow_costs.get_calls == 0
+    assert asset.congested_costs.get_calls == 1
+
+
+def test_path_get_uses_freeflow_when_mode_does_not_handle_congestion():
+    asset = _make_path_travel_costs()
+    asset.freeflow_costs = _CostTable("free-flow")
+    asset.congested_costs = _CostTable("congested")
+    asset.default_congestion = False
+    asset.congested_path_graph = _CongestedPathGraph(handles_congestion=False)
+
+    assert asset.get(congestion=True) == "free-flow"
+    assert asset.freeflow_costs.get_calls == 1
+    assert asset.congested_costs.get_calls == 0
+
+
+def test_detailed_carpool_get_uses_freeflow_without_road_flow_asset():
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.freeflow_costs = _CostTable("free-flow")
+    asset.congested_costs = _CostTable("congested")
+    asset.default_congestion = False
+
+    assert asset.get() == "free-flow"
+    assert asset.get(congestion=True) == "free-flow"
+
+
+def test_detailed_carpool_get_defaults_to_congested_for_road_flow_variant():
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.freeflow_costs = _CostTable("free-flow")
+    asset.congested_costs = _CostTable("congested")
+    asset.default_congestion = True
+
+    assert asset.get() == "congested"
+
+
+def test_detailed_carpool_remove_congestion_artifacts_keeps_shared_freeflow_table():
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    freeflow_costs = _Removable()
+    congested_costs = _Removable()
+    variant = object.__new__(DetailedCarpoolTravelCosts)
+    variant.freeflow_costs = freeflow_costs
+    variant.congested_costs = congested_costs
+    asset.asset_for_road_flows = lambda road_flow_asset: variant
+
+    asset.remove_congestion_artifacts(object())
+
+    assert freeflow_costs.remove_calls == 0
+    assert congested_costs.remove_calls == 1
 
 
 def test_path_asset_for_road_flows_ignores_modes_that_do_not_handle_congestion():

--- a/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
+++ b/tests/back/unit/costs/travel_costs/test_002_congestion_cleanup.py
@@ -2,8 +2,16 @@ import pytest
 
 from mobility.transport.costs.path.path_travel_costs import PathTravelCosts
 from mobility.transport.costs.travel_costs_asset import TravelCostsBase
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+from mobility.transport.modes.carpool.detailed import (
+    detailed_carpool_travel_costs as detailed_carpool_module,
+)
 from mobility.transport.modes.carpool.detailed.detailed_carpool_travel_costs import (
     DetailedCarpoolTravelCosts,
+)
+from mobility.transport.modes.carpool.detailed.detailed_carpool_travel_costs import (
+    DetailedCarpoolTravelCostsTable,
 )
 from mobility.transport.modes.public_transport.public_transport_travel_costs import (
     PublicTransportTravelCosts,
@@ -32,6 +40,36 @@ class _CostTable:
 class _CongestedPathGraph:
     def __init__(self, *, handles_congestion):
         self.inputs = {"handles_congestion": handles_congestion}
+
+
+class _FakeAsset:
+    def __init__(self, *, inputs=None):
+        self.inputs = inputs or {}
+        for name, value in self.inputs.items():
+            setattr(self, name, value)
+
+    def get_cached_hash(self):
+        return "fake-hash"
+
+
+class _PathReturningAsset:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class _FakeScriptRunner:
+    instances = []
+
+    def __init__(self, script_path):
+        self.script_path = script_path
+        self.args = None
+        _FakeScriptRunner.instances.append(self)
+
+    def run(self, *, args):
+        self.args = args
 
 
 class _LegTravelCosts(TravelCostsBase):
@@ -143,6 +181,46 @@ def _make_path_travel_costs():
     return asset
 
 
+def _patch_asset_initializers(monkeypatch):
+    def fake_file_asset_init(self, inputs, cache_path):
+        self.inputs = inputs
+        self.cache_path = cache_path
+
+    def fake_in_memory_asset_init(self, inputs):
+        self.inputs = inputs
+        for name, value in inputs.items():
+            setattr(self, name, value)
+
+    monkeypatch.setattr(FileAsset, "__init__", fake_file_asset_init)
+    monkeypatch.setattr(InMemoryAsset, "__init__", fake_in_memory_asset_init)
+
+
+def test_path_constructor_can_reuse_congested_graph_chain(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    modified_graph = _FakeAsset()
+    congested_graph = _FakeAsset(
+        inputs={
+            "modified_graph": modified_graph,
+            "handles_congestion": True,
+        }
+    )
+    contracted_graph = _FakeAsset(inputs={"congested_graph": congested_graph})
+
+    asset = PathTravelCosts(
+        mode_name="car",
+        transport_zones=_FakeAsset(),
+        routing_parameters=_FakeAsset(),
+        osm_capacity_parameters=_FakeAsset(),
+        contracted_graph=contracted_graph,
+        default_congestion=True,
+    )
+
+    assert asset.modified_path_graph is modified_graph
+    assert asset.congested_path_graph is congested_graph
+    assert asset.contracted_path_graph is contracted_graph
+    assert asset.default_congestion is True
+
+
 def test_path_get_uses_freeflow_without_road_flow_asset():
     asset = _make_path_travel_costs()
     asset.freeflow_costs = _CostTable("free-flow")
@@ -165,6 +243,15 @@ def test_path_get_defaults_to_congested_for_road_flow_variant():
     assert asset.get() == "congested"
     assert asset.freeflow_costs.get_calls == 0
     assert asset.congested_costs.get_calls == 1
+
+
+def test_path_get_uses_road_flow_variant_when_requested():
+    asset = _make_path_travel_costs()
+    variant = _CostTable("road-flow-costs")
+    asset._handles_congestion = lambda: True
+    asset.asset_for_road_flows = lambda road_flow_asset: variant
+
+    assert asset.get(congestion=True, road_flow_asset=object()) == "road-flow-costs"
 
 
 def test_path_get_uses_freeflow_when_mode_does_not_handle_congestion():
@@ -198,6 +285,16 @@ def test_detailed_carpool_get_defaults_to_congested_for_road_flow_variant():
     assert asset.get() == "congested"
 
 
+def test_detailed_carpool_get_uses_road_flow_variant_when_requested():
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    variant = _CostTable("road-flow-carpool")
+    asset.asset_for_road_flows = lambda road_flow_asset: variant
+    asset.default_congestion = False
+    asset.freeflow_costs = _CostTable("free-flow")
+
+    assert asset.get(congestion=True, road_flow_asset=object()) == "road-flow-carpool"
+
+
 def test_detailed_carpool_remove_congestion_artifacts_keeps_shared_freeflow_table():
     asset = object.__new__(DetailedCarpoolTravelCosts)
     freeflow_costs = _Removable()
@@ -211,6 +308,188 @@ def test_detailed_carpool_remove_congestion_artifacts_keeps_shared_freeflow_tabl
 
     assert freeflow_costs.remove_calls == 0
     assert congested_costs.remove_calls == 1
+
+
+def test_path_get_congested_graph_path_uses_flow_variant():
+    asset = _make_path_travel_costs()
+    variant = _FakeAsset(
+        inputs={
+            "congested_path_graph": _PathReturningAsset("variant-graph.gpkg"),
+        }
+    )
+    asset.asset_for_flow_asset = lambda flow_asset: variant
+
+    assert asset.get_congested_graph_path(object()) == "variant-graph.gpkg"
+
+
+def test_path_get_congested_graph_path_uses_base_graph_without_flow():
+    asset = _make_path_travel_costs()
+    asset.congested_path_graph = _PathReturningAsset("base-graph.gpkg")
+
+    assert asset.get_congested_graph_path() == "base-graph.gpkg"
+
+
+def test_path_remove_removes_both_cost_tables():
+    asset = _make_path_travel_costs()
+    asset.freeflow_costs = _Removable()
+    asset.congested_costs = _Removable()
+
+    asset.remove()
+
+    assert asset.freeflow_costs.remove_calls == 1
+    assert asset.congested_costs.remove_calls == 1
+
+
+def test_detailed_carpool_table_init_builds_congested_cache_path(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    road_flow_asset = _FakeAsset()
+
+    table = DetailedCarpoolTravelCostsTable(
+        car_travel_costs=_FakeAsset(),
+        parameters=_FakeAsset(),
+        modal_transfer=_FakeAsset(),
+        congestion=True,
+        road_flow_asset=road_flow_asset,
+    )
+
+    assert table.inputs["road_flow_asset"] is road_flow_asset
+    assert table.cache_path == project_dir / "travel_costs_congested_carpool.parquet"
+
+
+def test_detailed_carpool_table_get_cached_asset_reads_cache(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    table = DetailedCarpoolTravelCostsTable(
+        car_travel_costs=_FakeAsset(),
+        parameters=_FakeAsset(),
+        modal_transfer=_FakeAsset(),
+        congestion=False,
+    )
+    monkeypatch.setattr(
+        detailed_carpool_module.pd,
+        "read_parquet",
+        lambda cache_path: f"read {cache_path.name}",
+    )
+
+    assert table.get_cached_asset() == f"read {table.cache_path.name}"
+
+
+def test_detailed_carpool_table_create_and_get_asset_delegates(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    table = DetailedCarpoolTravelCostsTable(
+        car_travel_costs=_FakeAsset(),
+        parameters=_FakeAsset(),
+        modal_transfer=_FakeAsset(),
+        congestion=False,
+    )
+    table._compute_travel_costs = lambda: "computed-carpool-costs"
+
+    assert table.create_and_get_asset() == "computed-carpool-costs"
+
+
+def test_detailed_carpool_table_compute_uses_congested_graph(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    _FakeScriptRunner.instances = []
+    road_flow_asset = _FakeAsset()
+    car_travel_costs = _FakeAsset(
+        inputs={
+            "transport_zones": _FakeAsset(
+                inputs={
+                    "cache_path": project_dir / "zones.gpkg",
+                    "study_area": _FakeAsset(
+                        inputs={"cache_path": {"polygons": project_dir / "area.gpkg"}}
+                    ),
+                }
+            )
+        }
+    )
+    car_travel_costs.get_congested_graph_path = lambda flow_asset: project_dir / "congested.gpkg"
+    modal_transfer = _FakeAsset()
+    modal_transfer.model_dump = lambda mode: {"access": "walk"}
+    table = DetailedCarpoolTravelCostsTable(
+        car_travel_costs=car_travel_costs,
+        parameters=_FakeAsset(),
+        modal_transfer=modal_transfer,
+        congestion=True,
+        road_flow_asset=road_flow_asset,
+    )
+    monkeypatch.setattr(detailed_carpool_module, "RScriptRunner", _FakeScriptRunner)
+    monkeypatch.setattr(
+        detailed_carpool_module.pd,
+        "read_parquet",
+        lambda cache_path: "computed-carpool-costs",
+    )
+
+    assert table._compute_travel_costs() == "computed-carpool-costs"
+    assert _FakeScriptRunner.instances[0].args[2] == str(project_dir / "congested.gpkg")
+
+
+def test_detailed_carpool_table_compute_uses_modified_graph(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    car_travel_costs = _FakeAsset(
+        inputs={
+            "transport_zones": _FakeAsset(
+                inputs={
+                    "cache_path": project_dir / "zones.gpkg",
+                    "study_area": _FakeAsset(
+                        inputs={"cache_path": {"polygons": project_dir / "area.gpkg"}}
+                    ),
+                }
+            ),
+            "modified_path_graph": _PathReturningAsset(project_dir / "modified.gpkg"),
+        }
+    )
+    modal_transfer = _FakeAsset()
+    modal_transfer.model_dump = lambda mode: {"access": "walk"}
+    table = DetailedCarpoolTravelCostsTable(
+        car_travel_costs=car_travel_costs,
+        parameters=_FakeAsset(),
+        modal_transfer=modal_transfer,
+        congestion=False,
+    )
+    monkeypatch.setattr(detailed_carpool_module, "RScriptRunner", _FakeScriptRunner)
+    monkeypatch.setattr(
+        detailed_carpool_module.pd,
+        "read_parquet",
+        lambda cache_path: "computed-carpool-costs",
+    )
+
+    assert table._compute_travel_costs() == "computed-carpool-costs"
+
+
+def test_detailed_carpool_constructor_marks_road_flow_variant(project_dir, monkeypatch):
+    _patch_asset_initializers(monkeypatch)
+    road_flow_asset = _FakeAsset()
+
+    asset = DetailedCarpoolTravelCosts(
+        car_travel_costs=_FakeAsset(),
+        parameters=_FakeAsset(),
+        modal_transfer=_FakeAsset(),
+        road_flow_asset=road_flow_asset,
+    )
+
+    assert asset.road_flow_asset is road_flow_asset
+    assert asset.default_congestion is True
+    assert asset.congested_costs.road_flow_asset is road_flow_asset
+    assert asset.freeflow_costs.road_flow_asset is None
+
+
+def test_detailed_carpool_remove_removes_both_cost_tables():
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.freeflow_costs = _Removable()
+    asset.congested_costs = _Removable()
+
+    asset.remove()
+
+    assert asset.freeflow_costs.remove_calls == 1
+    assert asset.congested_costs.remove_calls == 1
+
+
+@pytest.mark.parametrize("variant_factory", [lambda asset: None, lambda asset: asset])
+def test_detailed_carpool_remove_congestion_artifacts_returns_early(variant_factory):
+    asset = object.__new__(DetailedCarpoolTravelCosts)
+    asset.asset_for_road_flows = lambda road_flow_asset: variant_factory(asset)
+
+    asset.remove_congestion_artifacts(object())
 
 
 def test_path_asset_for_road_flows_ignores_modes_that_do_not_handle_congestion():


### PR DESCRIPTION
### Motivation
The path and detailed carpool travel-cost assets had custom multi-output get logic. That made the file-asset DAG walk through cost tables that were not needed for the current request, for example trying to build congested walk costs when only free-flow walk costs should be used.

This cleanup makes the travel-cost choice explicit before the larger asset resolver work. It keeps downstream assets correct while avoiding eager rebuilds of unused travel-cost outputs.

This PR is stacked on the asset-dag-dash-viewer branch so the diff only contains the travel-cost cleanup.

### Changes
Path travel costs now use a small in-memory selector and one file-backed table per selected output. The selector chooses free-flow costs by default, and only uses a congested table when it is bound to an explicit road-flow asset.

Detailed carpool costs now follow the same shape. Congestion cleanup removes only the flow-specific congested carpool table, so the shared free-flow table is not deleted by mistake.

The shared travel-cost base class now only contains the small congestion helper behavior that is common to selectors and file-backed travel-cost assets. Public transport and transport-cost cleanup code now use that base class.

Tests were updated to cover selector choice, modes that do not handle congestion, public transport leg rebinding, and cleanup of congestion-specific artifacts.

### Example
A downstream transport-cost asset can still call generalized costs with congestion=True. Path and carpool selectors now resolve that request to the one table that is actually needed. Modes without a road-flow-bound congestion variant keep using free-flow costs.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Refactored the travel-cost selector and table structure, updated cleanup behavior, and added focused tests.
- What you reviewed or changed: Reviewed the affected asset DAG behavior, path costs, detailed carpool costs, public transport rebinding, and transport-cost cleanup.
- How you validated it (tests, checks, manual verification): Ran py_compile on touched files, focused unit tests, and the R-backed congestion integration pair.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior