### PR TITLE
Add asset resolver context

### DIFF
--- a/mobility/runtime/assets/file_asset.py
+++ b/mobility/runtime/assets/file_asset.py
@@ -1,10 +1,11 @@
 import pathlib
 import os
-import logging
-import networkx as nx
 
 from mobility.runtime.assets.asset import Asset
-from mobility.runtime.assets.graph import build_upstream_file_asset_graph
+from mobility.runtime.assets.resolver import (
+    asset_resolution_context,
+    get_current_asset_resolver,
+)
 from typing import Any
 from abc import abstractmethod
 
@@ -78,28 +79,12 @@ class FileAsset(Asset):
             Any: The cached or newly created asset.
         """
         
-        logging.debug(
-            "Checking asset DAG for %s (%s)...",
-            self.__class__.__name__,
-            self.inputs_hash,
-        )
-        self.update_ancestors_if_needed()
-                
-        if self.is_update_needed():
-            logging.debug(
-                "Rebuilding asset %s (%s)...",
-                self.__class__.__name__,
-                self.inputs_hash,
-            )
-            asset = self.create_and_get_asset(*args, **kwargs)
-            self.update_hash(self.inputs_hash)
-            logging.debug(
-                "Asset %s (%s) is ready.",
-                self.__class__.__name__,
-                self.inputs_hash,
-            )
-            return asset
-        return self.get_cached_asset(*args, **kwargs)
+        resolver = get_current_asset_resolver()
+        if resolver is not None:
+            return resolver.get(self, *args, **kwargs)
+
+        with asset_resolution_context() as resolver:
+            return resolver.get(self, *args, **kwargs)
         
 
     def is_update_needed(self) -> bool:
@@ -149,51 +134,13 @@ class FileAsset(Asset):
             RuntimeError: If a dependency cycle is detected among FileAssets.
         """
         
-        # Build the graph of upstream file assets. The same graph builder is
-        # also used by the debug UI, so both paths see the same dependencies.
-        graph = build_upstream_file_asset_graph(self)
+        resolver = get_current_asset_resolver()
+        if resolver is not None:
+            resolver.prepare_upstream_assets(self)
+            return None
 
-        logging.debug(
-            "Asset DAG for %s (%s) has %s upstream assets and %s dependency edges.",
-            self.__class__.__name__,
-            self.inputs_hash,
-            str(graph.number_of_nodes()),
-            str(graph.number_of_edges()),
-        )
-        
-        # Find out which ones need to be updated and recompute them, as well
-        # as all their descendants
-        update_needed_assets = set()
-
-        for asset in graph.nodes:
-            if asset.is_update_needed():
-                update_needed_assets.add(asset)
-                for descendant in nx.descendants(graph, asset):
-                    update_needed_assets.add(descendant)
-    
-        try:
-            topo_order = list(nx.topological_sort(graph))
-        except nx.NetworkXUnfeasible:
-            raise RuntimeError("Dependency cycle detected among FileAssets")
-        
-        assets = [asset for asset in topo_order if asset in update_needed_assets]
-        
-        for asset in assets:
-            logging.debug(
-                "Rebuilding upstream asset %s (%s) for %s (%s)...",
-                asset.__class__.__name__,
-                asset.inputs_hash,
-                self.__class__.__name__,
-                self.inputs_hash,
-            )
-            asset.create_and_get_asset()
-            asset.update_hash(asset.inputs_hash)
-            logging.debug(
-                "Upstream asset %s (%s) is ready.",
-                asset.__class__.__name__,
-                asset.inputs_hash,
-            )
-        
+        with asset_resolution_context() as resolver:
+            resolver.prepare_upstream_assets(self)
         return None
         
     def get_cached_hash(self) -> str:

--- a/mobility/runtime/assets/resolver.py
+++ b/mobility/runtime/assets/resolver.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator
+
+import networkx as nx
+
+from mobility.runtime.assets.asset import Asset
+from mobility.runtime.assets.graph import asset_graph_key, build_asset_graph
+
+
+_current_asset_resolver: ContextVar["AssetResolver | None"] = ContextVar(
+    "current_asset_resolver",
+    default=None,
+)
+_REQUESTED_ASSET_WAS_NOT_REBUILT = object()
+
+
+class AssetResolver:
+    """Prepare file-backed assets inside one model execution.
+
+    A file-backed asset is a cached result, for example transport zones,
+    travel costs, or one group-day-trips iteration state. Before reading a
+    cached file, the package must check whether the asset inputs are still
+    valid and whether upstream cached files still exist.
+
+    The old code rebuilt the upstream dependency graph every time `.get()` was
+    called. During a model run, many assets ask for the same transport zones,
+    costs, survey files, and iteration states several times. This resolver keeps
+    a small memory of what was already checked during the current execution, so
+    repeated reads do not redo the same graph walk.
+
+    The resolver is intentionally short-lived. One run or one explicit
+    `asset_resolution_context()` gets one resolver. There is no global package
+    cache shared between unrelated runs.
+    """
+
+    def __init__(self) -> None:
+        # Asset keys that have already been checked or rebuilt in this resolver
+        # context. A key identifies the logical cached file, not just one Python
+        # object instance.
+        self.prepared_asset_keys = set()
+
+        # Dependency graphs already built during this context. These graphs are
+        # pure structure, so they can be reused safely while the same execution
+        # is resolving several assets.
+        self.saved_dependency_graphs = {}
+
+    def get(self, requested_asset: Asset, *args, **kwargs) -> Any:
+        """Return one cached asset after preparing the files it depends on."""
+        rebuilt_value = self.prepare_requested_asset(
+            requested_asset,
+            requested_asset_args=args,
+            requested_asset_kwargs=kwargs,
+        )
+        if rebuilt_value is not _REQUESTED_ASSET_WAS_NOT_REBUILT:
+            return rebuilt_value
+        return requested_asset.get_cached_asset(*args, **kwargs)
+
+    def prepare_requested_asset(
+        self,
+        requested_asset: Asset,
+        *,
+        requested_asset_args: tuple = (),
+        requested_asset_kwargs: dict | None = None,
+    ) -> Any:
+        """Prepare the requested asset and all upstream cached files.
+
+        The requested asset is the one whose `.get()` method the caller asked
+        for. If it needs to be rebuilt, its `create_and_get_asset()` return
+        value is passed back to the caller, preserving the old `FileAsset.get()`
+        behavior.
+        """
+        return self._prepare_dependency_graph(
+            requested_asset,
+            include_requested_asset=True,
+            requested_asset_args=requested_asset_args,
+            requested_asset_kwargs=requested_asset_kwargs or {},
+        )
+
+    def prepare_upstream_assets(self, asset: Asset) -> None:
+        """Prepare only the files that the given asset depends on.
+
+        This keeps the old `FileAsset.update_ancestors_if_needed()` contract:
+        rebuild stale dependencies, but do not rebuild the asset itself.
+        """
+        self._prepare_dependency_graph(
+            asset,
+            include_requested_asset=False,
+            requested_asset_args=(),
+            requested_asset_kwargs={},
+        )
+
+    def _prepare_dependency_graph(
+        self,
+        requested_asset: Asset,
+        *,
+        include_requested_asset: bool,
+        requested_asset_args: tuple,
+        requested_asset_kwargs: dict,
+    ) -> Any:
+        requested_asset_key = asset_graph_key(requested_asset)
+
+        # If this exact requested asset was already checked in this resolver,
+        # the caller can directly read its cached file. This removes repeated
+        # graph walks inside long model runs.
+        if (
+            include_requested_asset
+            and requested_asset_key in self.prepared_asset_keys
+        ):
+            return _REQUESTED_ASSET_WAS_NOT_REBUILT
+
+        dependency_graph = self._get_dependency_graph(
+            requested_asset,
+            include_requested_asset=include_requested_asset,
+        )
+        rebuilt_requested_asset_value = _REQUESTED_ASSET_WAS_NOT_REBUILT
+
+        logging.debug(
+            "Asset resolver graph for %s (%s) has %s file assets and %s dependency edges.",
+            requested_asset.__class__.__name__,
+            requested_asset.inputs_hash,
+            str(dependency_graph.number_of_nodes()),
+            str(dependency_graph.number_of_edges()),
+        )
+
+        asset_keys_to_rebuild = set()
+        for dependency_asset in dependency_graph.nodes:
+            dependency_asset_key = asset_graph_key(dependency_asset)
+
+            # This asset was already checked or rebuilt during the current
+            # execution. Do not ask the filesystem about it again.
+            if dependency_asset_key in self.prepared_asset_keys:
+                continue
+
+            if dependency_asset.is_update_needed():
+                # If one upstream file is stale or missing, every file asset
+                # that depends on it must be rebuilt in this request graph.
+                asset_keys_to_rebuild.add(dependency_asset_key)
+                for downstream_asset in nx.descendants(
+                    dependency_graph,
+                    dependency_asset,
+                ):
+                    asset_keys_to_rebuild.add(asset_graph_key(downstream_asset))
+
+        try:
+            assets_in_dependency_order = list(nx.topological_sort(dependency_graph))
+        except nx.NetworkXUnfeasible:
+            raise RuntimeError("Dependency cycle detected among FileAssets")
+
+        for dependency_asset in assets_in_dependency_order:
+            dependency_asset_key = asset_graph_key(dependency_asset)
+            if dependency_asset_key in asset_keys_to_rebuild:
+                if dependency_asset_key == requested_asset_key:
+                    rebuilt_requested_asset_value = self._rebuild_asset(
+                        dependency_asset,
+                        *requested_asset_args,
+                        **requested_asset_kwargs,
+                    )
+                else:
+                    self._rebuild_asset(dependency_asset)
+
+            # Mark the asset as prepared whether it was rebuilt or already
+            # valid. Later reads in the same execution can skip it.
+            self.prepared_asset_keys.add(dependency_asset_key)
+
+        return rebuilt_requested_asset_value
+
+    def _get_dependency_graph(
+        self,
+        requested_asset: Asset,
+        *,
+        include_requested_asset: bool,
+    ) -> nx.DiGraph:
+        dependency_graph_key = (
+            asset_graph_key(requested_asset),
+            include_requested_asset,
+        )
+        if dependency_graph_key not in self.saved_dependency_graphs:
+            dependency_graph = build_asset_graph(
+                requested_asset,
+                include_root=include_requested_asset,
+                file_assets_only=True,
+                include_node_data=False,
+            )
+            self.saved_dependency_graphs[dependency_graph_key] = dependency_graph
+        return self.saved_dependency_graphs[dependency_graph_key]
+
+    def _rebuild_asset(self, asset: Asset, *args, **kwargs) -> Any:
+        logging.debug(
+            "Rebuilding asset %s (%s)...",
+            asset.__class__.__name__,
+            asset.inputs_hash,
+        )
+        value = asset.create_and_get_asset(*args, **kwargs)
+        asset.update_hash(asset.inputs_hash)
+        logging.debug(
+            "Asset %s (%s) is ready.",
+            asset.__class__.__name__,
+            asset.inputs_hash,
+        )
+        return value
+
+
+def get_current_asset_resolver() -> AssetResolver | None:
+    """Return the resolver currently shared by nested asset reads."""
+    return _current_asset_resolver.get()
+
+
+@contextmanager
+def asset_resolution_context(
+    resolver: AssetResolver | None = None,
+) -> Iterator[AssetResolver]:
+    """Run asset reads with one shared resolver instance.
+
+    `contextvars` makes the resolver available to nested `.get()` calls without
+    passing an extra argument through every transport model class.
+    """
+    active_resolver = resolver or AssetResolver()
+    token = _current_asset_resolver.set(active_resolver)
+    try:
+        yield active_resolver
+    finally:
+        _current_asset_resolver.reset(token)

--- a/tests/back/unit/runtime/test_004_asset_resolver.py
+++ b/tests/back/unit/runtime/test_004_asset_resolver.py
@@ -1,0 +1,147 @@
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.resolver import asset_resolution_context
+
+
+class _CountingFileAsset(FileAsset):
+    create_calls = []
+    status_checks = {}
+
+    def __init__(self, *, name, cache_folder, child=None):
+        self.name = name
+        inputs = {"name": name, "child": child}
+        super().__init__(inputs, cache_folder / f"{name}.txt")
+
+    def is_update_needed(self):
+        _CountingFileAsset.status_checks[self.name] = (
+            _CountingFileAsset.status_checks.get(self.name, 0) + 1
+        )
+        return super().is_update_needed()
+
+    def get_cached_asset(self):
+        return self.cache_path.read_text(encoding="utf-8")
+
+    def create_and_get_asset(self):
+        _CountingFileAsset.create_calls.append(self.name)
+        value = f"created-{self.name}"
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_path.write_text(value, encoding="utf-8")
+        return value
+
+
+class _NestedReadAsset(_CountingFileAsset):
+    def create_and_get_asset(self):
+        self.inputs["child"].get()
+        self.inputs["child"].get()
+        return super().create_and_get_asset()
+
+
+class _ArgumentAsset(FileAsset):
+    def __init__(self, *, cache_folder):
+        super().__init__({"name": "argument"}, cache_folder / "argument.txt")
+
+    def get_cached_asset(self, token=None):
+        return f"cached-{token}-{self.cache_path.read_text(encoding='utf-8')}"
+
+    def create_and_get_asset(self, token=None):
+        self.cache_path.write_text(str(token), encoding="utf-8")
+        return f"created-{token}"
+
+
+def _reset_counts():
+    _CountingFileAsset.create_calls = []
+    _CountingFileAsset.status_checks = {}
+
+
+def _mark_cached(asset):
+    asset.create_and_get_asset()
+    asset.update_hash(asset.inputs_hash)
+
+
+def test_resolver_rebuilds_downstream_assets_when_upstream_is_stale(tmp_path):
+    """A stale upstream file asset invalidates all downstream file assets."""
+    _reset_counts()
+    child = _CountingFileAsset(name="child", cache_folder=tmp_path / "child")
+    bridge = _CountingFileAsset(
+        name="bridge",
+        cache_folder=tmp_path / "bridge",
+        child=child,
+    )
+    root = _CountingFileAsset(name="root", cache_folder=tmp_path / "root", child=bridge)
+    for asset in [child, bridge, root]:
+        _mark_cached(asset)
+    child.hash_path.write_text("old-child-inputs", encoding="utf-8")
+    _reset_counts()
+
+    value = root.get()
+
+    assert value == "created-root"
+    assert _CountingFileAsset.create_calls == ["child", "bridge", "root"]
+
+
+def test_resolver_reuses_ready_assets_for_nested_get_calls(tmp_path):
+    """Nested reads use the active resolver instead of rechecking the same child."""
+    _reset_counts()
+    child = _CountingFileAsset(name="child", cache_folder=tmp_path / "child")
+    root = _NestedReadAsset(name="root", cache_folder=tmp_path / "root", child=child)
+
+    root.get()
+
+    assert _CountingFileAsset.create_calls == ["child", "root"]
+    assert _CountingFileAsset.status_checks["child"] == 1
+
+
+def test_resolver_context_shares_ready_assets_across_root_reads(tmp_path):
+    """One explicit resolver context can cover several root asset reads."""
+    _reset_counts()
+    first_child = _CountingFileAsset(name="shared", cache_folder=tmp_path / "child")
+    second_child = _CountingFileAsset(name="shared", cache_folder=tmp_path / "child")
+    first_root = _CountingFileAsset(
+        name="first-root",
+        cache_folder=tmp_path / "first-root",
+        child=first_child,
+    )
+    second_root = _CountingFileAsset(
+        name="second-root",
+        cache_folder=tmp_path / "second-root",
+        child=second_child,
+    )
+
+    with asset_resolution_context():
+        first_root.get()
+        second_root.get()
+
+    assert _CountingFileAsset.create_calls == ["shared", "first-root", "second-root"]
+    assert _CountingFileAsset.status_checks["shared"] == 1
+
+
+def test_resolver_does_not_recheck_ready_root_asset(tmp_path):
+    """Repeated reads of the same root asset are cheap inside one context."""
+    _reset_counts()
+    asset = _CountingFileAsset(name="root", cache_folder=tmp_path)
+
+    with asset_resolution_context():
+        assert asset.get() == "created-root"
+        assert asset.get() == "created-root"
+
+    assert _CountingFileAsset.create_calls == ["root"]
+    assert _CountingFileAsset.status_checks["root"] == 1
+
+
+def test_update_ancestors_keeps_existing_upstream_only_contract(tmp_path):
+    """The compatibility method still rebuilds ancestors, not the root asset."""
+    _reset_counts()
+    child = _CountingFileAsset(name="child", cache_folder=tmp_path / "child")
+    root = _CountingFileAsset(name="root", cache_folder=tmp_path / "root", child=child)
+
+    root.update_ancestors_if_needed()
+
+    assert _CountingFileAsset.create_calls == ["child"]
+
+
+def test_resolver_passes_get_arguments_to_requested_root_asset(tmp_path):
+    """Root get arguments are preserved for assets that use them while creating."""
+    asset = _ArgumentAsset(cache_folder=tmp_path)
+
+    with asset_resolution_context():
+        assert asset.get(token="bbox") == "created-bbox"
+        assert asset.get(token="other") == "cached-other-bbox"


### PR DESCRIPTION
### Motivation
File-backed assets currently rebuild their upstream dependency graph every time .get() is called. In group-day-trips runs, many assets ask for the same transport zones, survey assets, costs, and iteration states repeatedly. This makes logs noisy and adds avoidable filesystem checks and graph walks.

This PR adds a short-lived asset resolver that is shared inside one execution context. It keeps the same cache correctness rule: if an upstream cached asset is stale or missing, every downstream file asset in the current request graph is rebuilt.

This PR is stacked on cleanup-travel-cost-selectors, because that PR first removes special travel-cost selector behavior that would otherwise obscure this runtime change.

### Changes
Added AssetResolver, a small runtime object that remembers which file-backed assets were already checked or rebuilt during the current execution. It also reuses dependency graphs that were already built in the same context.

FileAsset.get() now delegates to the active resolver. If there is no active resolver, it creates one for the single call, so standalone asset reads still work as before.

FileAsset.update_ancestors_if_needed() remains available for compatibility, but now uses the resolver path internally.

The resolver is exposed through sset_resolution_context(), backed by contextvars, so nested .get() calls can share the same resolver without passing an extra argument through transport model classes.

Added focused runtime tests for stale upstream invalidation, nested .get() calls, shared resolver contexts across several roots, repeated reads of an already-prepared asset, compatibility with update_ancestors_if_needed(), and .get() arguments used by assets such as GTFS stops.

### Example
A model run can read several cached assets inside one resolver context. Once transport zones or an iteration state were checked, later reads of the same logical cached asset in that context skip the repeated dependency graph walk. If an upstream asset is stale, the resolver rebuilds it and every downstream cached asset in the request graph.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Added the resolver, wired FileAsset through it, and added focused runtime tests.
- What you reviewed or changed: Reviewed cache invalidation semantics, nested asset reads, repeated resolver checks, and readability of comments/names for transport modellers.
- How you validated it (tests, checks, manual verification): Ran py_compile, runtime asset tests, focused travel-cost tests, and narrow group-day-trips integration tests during development.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior