### PR TITLE
Improve GTFS builder UX

### DIFF
--- a/docs/source/modes.rst
+++ b/docs/source/modes.rst
@@ -95,6 +95,41 @@ The public transport service from the Tuesday with the most operational services
 
 The GTFS data versions used for the Greater Geneva study are from late 2024.
 
+You can also create a small additional GTFS feed directly in Python, for example
+to test a new line or a service scenario before adding it to the public transport
+mode:
+
+.. code-block:: python
+
+    import mobility
+
+    builder = mobility.GTFSBuilder(
+        agency_id="test_agency",
+        agency_name="Test Agency",
+        route_id="test_line",
+        route_short_name="T1",
+        route_type="bus",
+        service_id="test_service",
+    )
+
+    builder.add_stops(
+        {
+            "first_stop": [6.151086, 46.209558],
+            "second_stop": [6.192774, 46.253015],
+        }
+    )
+    builder.add_line(
+        [("first_stop", "second_stop", 27 * 60)],
+        start_time=6 * 3600,
+        end_time=9 * 3600,
+        period=15 * 60,
+    )
+
+    gtfs_path = builder.write_project_zip("test_line.zip")
+
+Pass ``gtfs_path`` in ``additional_gtfs_files`` when configuring public
+transport routing.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Public Transport Graph Creation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mobility/__init__.py
+++ b/mobility/__init__.py
@@ -62,7 +62,9 @@ from .transport.modes.carpool import (
     DetailedCarpoolGeneralizedCostParameters,
 )
 from .transport.modes.public_transport import (
+    build_project_gtfs_zip,
     build_gtfs_zip,
+    GTFSBuilder,
     GTFSFeedSpec,
     GTFSLineSpec,
     GTFSStopSpec,

--- a/mobility/transport/modes/public_transport/__init__.py
+++ b/mobility/transport/modes/public_transport/__init__.py
@@ -4,7 +4,9 @@ from .public_transport import (
     PublicTransportParameters,
 )
 from .gtfs_builder import (
+    build_project_gtfs_zip,
     build_gtfs_zip,
+    GTFSBuilder,
     GTFSFeedSpec,
     GTFSLineSpec,
     GTFSStopSpec,
@@ -14,7 +16,9 @@ __all__ = [
     "PublicTransportMode",
     "PublicTransportParameters",
     "PublicTransportRoutingParameters",
+    "build_project_gtfs_zip",
     "build_gtfs_zip",
+    "GTFSBuilder",
     "GTFSFeedSpec",
     "GTFSLineSpec",
     "GTFSStopSpec",

--- a/mobility/transport/modes/public_transport/gtfs_builder.py
+++ b/mobility/transport/modes/public_transport/gtfs_builder.py
@@ -1,28 +1,50 @@
 from __future__ import annotations
 
 import io
+import os
 import shutil
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping, Sequence
 
-import numpy as np
 import pandas as pd
-import shortuuid
+
+
+GTFS_ROUTE_TYPES = {
+    "train": 2,
+    "bus": 3,
+    "boat": 4,
+}
 
 
 @dataclass(frozen=True)
 class GTFSStopSpec:
-    """One stop definition used by the simplified GTFS builder."""
+    """One stop used by a generated GTFS feed."""
 
     lon: float
     lat: float
     name: str | None = None
 
+    def validate(self, stop_id: str) -> None:
+        """Check that the stop has valid WGS84 coordinates."""
+
+        try:
+            lon = float(self.lon)
+            lat = float(self.lat)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"GTFS stop {stop_id!r} must use numeric lon and lat.") from exc
+
+        if not -180.0 <= lon <= 180.0:
+            raise ValueError(f"GTFS stop {stop_id!r} lon must be between -180 and 180.")
+
+        if not -90.0 <= lat <= 90.0:
+            raise ValueError(f"GTFS stop {stop_id!r} lat must be between -90 and 90.")
+
 
 @dataclass(frozen=True)
 class GTFSLineSpec:
-    """One simplified line with fixed stop order and timetable."""
+    """One line with a fixed stop order and a regular timetable."""
 
     stop_ids: list[str]
     segment_travel_times: list[float]
@@ -31,8 +53,92 @@ class GTFSLineSpec:
     period: float
     bidirectional: bool = True
 
+    @classmethod
+    def from_segments(
+        cls,
+        segments: Sequence[Sequence[float | str]],
+        *,
+        start_time: float,
+        end_time: float,
+        period: float,
+        bidirectional: bool = True,
+    ) -> GTFSLineSpec:
+        """Build a line from ``(from_stop_id, to_stop_id, travel_time)`` segments."""
+
+        if not segments:
+            raise ValueError("GTFSLineSpec.from_segments segments must not be empty.")
+
+        stop_ids = []
+        segment_travel_times = []
+        previous_to_stop_id = None
+        for segment in segments:
+            if len(segment) != 3:
+                raise ValueError("Each segment must contain from_stop_id, to_stop_id and travel_time.")
+
+            from_stop_id = str(segment[0])
+            to_stop_id = str(segment[1])
+            if previous_to_stop_id is None:
+                stop_ids.append(from_stop_id)
+
+            if previous_to_stop_id is not None and from_stop_id != previous_to_stop_id:
+                raise ValueError(
+                    "GTFSLineSpec.from_segments segments must be continuous: "
+                    f"expected {previous_to_stop_id!r}, got {from_stop_id!r}."
+                )
+
+            stop_ids.append(to_stop_id)
+            segment_travel_times.append(float(segment[2]))
+            previous_to_stop_id = to_stop_id
+
+        return cls(
+            stop_ids=stop_ids,
+            segment_travel_times=segment_travel_times,
+            start_time=start_time,
+            end_time=end_time,
+            period=period,
+            bidirectional=bidirectional,
+        )
+
+    @classmethod
+    def from_stop_ids(
+        cls,
+        stop_ids: Sequence[str],
+        segment_times: Mapping[tuple[str, str], float],
+        *,
+        start_time: float,
+        end_time: float,
+        period: float,
+        bidirectional: bool = False,
+    ) -> GTFSLineSpec:
+        """Build a line from an ordered stop list and a segment-time lookup."""
+
+        if len(stop_ids) < 2:
+            raise ValueError("GTFSLineSpec.from_stop_ids stop_ids must contain at least two stops.")
+
+        line_stop_ids = [str(stop_id) for stop_id in stop_ids]
+        segment_travel_times = []
+        for index in range(len(line_stop_ids) - 1):
+            from_stop_id = line_stop_ids[index]
+            to_stop_id = line_stop_ids[index + 1]
+            try:
+                segment_travel_times.append(float(segment_times[(from_stop_id, to_stop_id)]))
+            except KeyError as exc:
+                raise ValueError(
+                    "GTFSLineSpec.from_stop_ids is missing a segment time for "
+                    f"{from_stop_id!r} -> {to_stop_id!r}."
+                ) from exc
+
+        return cls(
+            stop_ids=line_stop_ids,
+            segment_travel_times=segment_travel_times,
+            start_time=start_time,
+            end_time=end_time,
+            period=period,
+            bidirectional=bidirectional,
+        )
+
     def validate(self) -> None:
-        """Validate the simplified line specification."""
+        """Check the line geometry and timetable."""
 
         if len(self.stop_ids) < 2:
             raise ValueError("GTFSLineSpec.stop_ids must contain at least two stops.")
@@ -42,22 +148,32 @@ class GTFSLineSpec:
                 "GTFSLineSpec.segment_travel_times must contain exactly len(stop_ids) - 1 values."
             )
 
+        if any(travel_time <= 0 for travel_time in self.segment_travel_times):
+            raise ValueError("GTFSLineSpec.segment_travel_times must be strictly positive.")
+
         if self.period <= 0:
             raise ValueError("GTFSLineSpec.period must be strictly positive.")
 
-    def to_travel_times(self) -> list[list[float | str]]:
-        """Return ``[from_stop_id, to_stop_id, travel_time]`` rows for one direction."""
+        if self.end_time < self.start_time:
+            raise ValueError("GTFSLineSpec.end_time must be greater than or equal to start_time.")
+
+    def reverse(self) -> GTFSLineSpec:
+        """Return the same line in the opposite direction."""
 
         self.validate()
-        return [
-            [self.stop_ids[index], self.stop_ids[index + 1], self.segment_travel_times[index]]
-            for index in range(len(self.segment_travel_times))
-        ]
+        return GTFSLineSpec(
+            stop_ids=list(reversed(self.stop_ids)),
+            segment_travel_times=list(reversed(self.segment_travel_times)),
+            start_time=self.start_time,
+            end_time=self.end_time,
+            period=self.period,
+            bidirectional=False,
+        )
 
 
 @dataclass(frozen=True)
 class GTFSFeedSpec:
-    """Declarative input for generating one simple GTFS zip feed."""
+    """Declarative input for one generated GTFS zip feed."""
 
     agency_id: str
     agency_name: str
@@ -67,15 +183,30 @@ class GTFSFeedSpec:
     service_id: str
     stops: dict[str, GTFSStopSpec]
     lines: list[GTFSLineSpec]
+    agency_timezone: str = "Europe/Paris"
+    agency_url: str = ""
 
     def validate(self) -> None:
-        """Validate the feed-level specification."""
+        """Check that the feed can be written as GTFS tables."""
 
         if not self.stops:
             raise ValueError("GTFSFeedSpec.stops must not be empty.")
 
         if not self.lines:
             raise ValueError("GTFSFeedSpec.lines must not be empty.")
+
+        if self.route_type not in GTFS_ROUTE_TYPES:
+            known_route_types = ", ".join(sorted(GTFS_ROUTE_TYPES))
+            raise ValueError(f"GTFSFeedSpec.route_type must be one of: {known_route_types}.")
+
+        if not self.agency_timezone:
+            raise ValueError("GTFSFeedSpec.agency_timezone must not be empty.")
+
+        for stop_id, stop in self.stops.items():
+            stop.validate(stop_id)
+
+        for line in self.lines:
+            line.validate()
 
         unknown_stop_ids = {
             stop_id
@@ -88,144 +219,209 @@ class GTFSFeedSpec:
             raise ValueError(f"GTFSFeedSpec.lines reference unknown stop ids: {unknown}")
 
 
-def create_gtfs_tables(
-    agency_id: str,
-    agency_name: str,
-    route_id: str,
-    route_short_name: str,
-    route_type: str,
-    service_id: str,
-    stops: dict[str, tuple[str, list[float]]],
-    stop_times: list[pd.DataFrame],
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Create the standard GTFS tables for one simplified feed."""
+class GTFSBuilder:
+    """Build one small GTFS feed with plain stops, lines and schedules."""
+
+    def __init__(
+        self,
+        agency_id: str,
+        agency_name: str,
+        route_id: str,
+        route_short_name: str,
+        route_type: str,
+        service_id: str,
+        *,
+        agency_timezone: str = "Europe/Paris",
+        agency_url: str = "",
+    ) -> None:
+        self.agency_id = agency_id
+        self.agency_name = agency_name
+        self.route_id = route_id
+        self.route_short_name = route_short_name
+        self.route_type = route_type
+        self.service_id = service_id
+        self.agency_timezone = agency_timezone
+        self.agency_url = agency_url
+        self.stops: dict[str, GTFSStopSpec] = {}
+        self.lines: list[GTFSLineSpec] = []
+
+    def add_stop(self, stop_id: str, lon: float, lat: float, name: str | None = None) -> GTFSBuilder:
+        """Add one stop to the feed."""
+
+        self.stops[str(stop_id)] = GTFSStopSpec(lon=lon, lat=lat, name=name)
+        return self
+
+    def add_stops(self, stops: Mapping[str, GTFSStopSpec | Sequence[float]]) -> GTFSBuilder:
+        """Add stops from ``GTFSStopSpec`` values or ``[lon, lat]`` lists."""
+
+        for stop_id, stop in stops.items():
+            if isinstance(stop, GTFSStopSpec):
+                self.stops[str(stop_id)] = stop
+                continue
+
+            if len(stop) not in (2, 3):
+                raise ValueError(f"Stop {stop_id!r} must be [lon, lat] or [lon, lat, name].")
+
+            name = str(stop[2]) if len(stop) == 3 else None
+            self.add_stop(str(stop_id), lon=float(stop[0]), lat=float(stop[1]), name=name)
+
+        return self
+
+    def add_line(
+        self,
+        segments: Sequence[Sequence[float | str]],
+        *,
+        start_time: float,
+        end_time: float,
+        period: float,
+        bidirectional: bool = True,
+    ) -> GTFSBuilder:
+        """Add a line from ``(from_stop_id, to_stop_id, travel_time)`` segments."""
+
+        self.lines.append(
+            GTFSLineSpec.from_segments(
+                segments,
+                start_time=start_time,
+                end_time=end_time,
+                period=period,
+                bidirectional=bidirectional,
+            )
+        )
+        return self
+
+    def add_line_from_stop_ids(
+        self,
+        stop_ids: Sequence[str],
+        segment_times: Mapping[tuple[str, str], float],
+        *,
+        start_time: float,
+        end_time: float,
+        period: float,
+        bidirectional: bool = False,
+    ) -> GTFSBuilder:
+        """Add a line from an ordered stop list and a segment-time lookup."""
+
+        self.lines.append(
+            GTFSLineSpec.from_stop_ids(
+                stop_ids,
+                segment_times,
+                start_time=start_time,
+                end_time=end_time,
+                period=period,
+                bidirectional=bidirectional,
+            )
+        )
+        return self
+
+    def build_feed(self) -> GTFSFeedSpec:
+        """Return this builder as a feed specification."""
+
+        return GTFSFeedSpec(
+            agency_id=self.agency_id,
+            agency_name=self.agency_name,
+            route_id=self.route_id,
+            route_short_name=self.route_short_name,
+            route_type=self.route_type,
+            service_id=self.service_id,
+            stops=self.stops,
+            lines=self.lines,
+            agency_timezone=self.agency_timezone,
+            agency_url=self.agency_url,
+        )
+
+    def write_zip(self, path: str | Path) -> Path:
+        """Write this feed as a GTFS zip file."""
+
+        return build_gtfs_zip(self.build_feed(), path)
+
+    def write_project_zip(self, file_name: str) -> Path:
+        """Write this feed under ``MOBILITY_PROJECT_DATA_FOLDER``."""
+
+        return build_project_gtfs_zip(self.build_feed(), file_name)
+
+
+def build_project_gtfs_zip(feed: GTFSFeedSpec, file_name: str) -> Path:
+    """Build one GTFS zip under ``MOBILITY_PROJECT_DATA_FOLDER``."""
+
+    project_data_folder = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+    if project_data_folder is None:
+        raise ValueError(
+            "MOBILITY_PROJECT_DATA_FOLDER is not set. "
+            "Use mobility.set_params(...) before write_project_zip()."
+        )
+
+    output_path = Path(project_data_folder) / file_name
+    return build_gtfs_zip(feed, output_path)
+
+
+def build_gtfs_zip(feed: GTFSFeedSpec, output_path: str | Path) -> Path:
+    """Build one GTFS zip from a feed specification."""
+
+    feed.validate()
+    tables = _create_gtfs_tables(feed)
+    output_path = Path(output_path)
+    _write_gtfs_zip(tables, output_path)
+    return output_path
+
+
+def _create_gtfs_tables(feed: GTFSFeedSpec) -> dict[str, pd.DataFrame]:
+    """Create the GTFS tables needed by Mobility routing."""
 
     agency = pd.DataFrame(
         {
-            "agency_id": agency_id,
-            "agency_name": agency_name,
-        },
-        index=[0],
+            "agency_id": [feed.agency_id],
+            "agency_name": [feed.agency_name],
+            "agency_url": [feed.agency_url],
+            "agency_timezone": [feed.agency_timezone],
+        }
     )
-
-    gtfs_route_types = {
-        "train": 2,
-        "bus": 3,
-        "boat": 4,
-    }
 
     routes = pd.DataFrame(
         {
-            "route_id": route_id,
-            "agency_id": agency_id,
-            "route_short_name": route_short_name,
-            "route_type": gtfs_route_types[route_type],
-        },
-        index=[0],
+            "route_id": [feed.route_id],
+            "agency_id": [feed.agency_id],
+            "route_short_name": [feed.route_short_name],
+            "route_type": [GTFS_ROUTE_TYPES[feed.route_type]],
+        }
     )
 
     calendar = pd.DataFrame(
         {
-            "service_id": service_id,
-            "monday": 1,
-            "tuesday": 1,
-            "wednesday": 1,
-            "thursday": 1,
-            "friday": 1,
-            "saturday": 1,
-            "sunday": 1,
-            "start_date": 20000101,
-            "end_date": 21001231,
-        },
-        index=[0],
-    )
-
-    stops_table = pd.DataFrame.from_dict(
-        [
-            {
-                "stop_id": stop_id,
-                "stop_name": stop_name,
-                "stop_lon": coords[0],
-                "stop_lat": coords[1],
-            }
-            for stop_id, (stop_name, coords) in stops.items()
-        ]
-    )
-
-    stop_times_table = pd.concat(stop_times)
-    trips = pd.DataFrame(
-        {
-            "route_id": route_id,
-            "service_id": service_id,
-            "trip_id": stop_times_table["trip_id"].unique(),
+            "service_id": [feed.service_id],
+            "monday": [1],
+            "tuesday": [1],
+            "wednesday": [1],
+            "thursday": [1],
+            "friday": [1],
+            "saturday": [1],
+            "sunday": [1],
+            "start_date": [20000101],
+            "end_date": [21001231],
         }
     )
 
-    return agency, routes, trips, calendar, stops_table, stop_times_table
-
-
-def create_stop_times(
-    travel_times: list[list[float | str]],
-    start_time: float,
-    end_time: float,
-    period: float,
-) -> pd.DataFrame:
-    """Create one GTFS ``stop_times`` table from a simple line description."""
-
-    travel_times_df = pd.DataFrame(
-        travel_times,
-        columns=["from_stop_id", "to_stop_id", "travel_time"],
-    )
-
-    travel_times_df["cum_travel_time"] = travel_times_df["travel_time"].cumsum()
-    travel_times_df["prev_cum_travel_time"] = travel_times_df["cum_travel_time"].shift(1, fill_value=0.0)
-
-    departure_times = np.arange(start_time, end_time + period, period)
-    trip_ids = [shortuuid.uuid() for _ in range(len(departure_times))]
-
-    stop_times = pd.concat([travel_times_df] * len(departure_times))
-    stop_times["trip_id"] = np.repeat(trip_ids, travel_times_df.shape[0])
-    stop_times["trip_departure_time"] = np.repeat(departure_times, travel_times_df.shape[0])
-
-    stop_times["departure_time"] = stop_times["trip_departure_time"] + stop_times["prev_cum_travel_time"]
-    stop_times["arrival_time"] = stop_times["trip_departure_time"] + stop_times["cum_travel_time"]
-
-    stop_times["departure_time"] = pd.to_datetime(stop_times["departure_time"], unit="s").dt.strftime("%H:%M:%S")
-    stop_times["arrival_time"] = pd.to_datetime(stop_times["arrival_time"], unit="s").dt.strftime("%H:%M:%S")
-
-    stop_times = pd.concat(
+    stops = pd.DataFrame(
         [
-            stop_times[["trip_id", "from_stop_id", "departure_time"]]
-            .rename({"from_stop_id": "stop_id", "departure_time": "time"}, axis=1)
-            .assign(var="departure"),
-            stop_times[["trip_id", "to_stop_id", "arrival_time"]]
-            .rename({"to_stop_id": "stop_id", "arrival_time": "time"}, axis=1)
-            .assign(var="arrival"),
+            {
+                "stop_id": stop_id,
+                "stop_name": stop.name or stop_id,
+                "stop_lon": stop.lon,
+                "stop_lat": stop.lat,
+            }
+            for stop_id, stop in feed.stops.items()
         ]
     )
 
-    stop_times = stop_times.pivot(columns="var", index=["trip_id", "stop_id"], values="time")
-    stop_times["arrival"] = stop_times["arrival"].fillna(stop_times["departure"])
-    stop_times["departure"] = stop_times["departure"].fillna(stop_times["arrival"])
-    stop_times = stop_times.sort_values(["trip_id", "departure"])
-    stop_times["stop_sequence"] = stop_times.groupby("trip_id").cumcount() + 1
-    stop_times = stop_times.rename({"arrival": "arrival_time", "departure": "departure_time"}, axis=1)
+    stop_times = pd.concat(_build_stop_times(feed.lines), ignore_index=True)
+    trips = pd.DataFrame(
+        {
+            "route_id": feed.route_id,
+            "service_id": feed.service_id,
+            "trip_id": stop_times["trip_id"].unique(),
+        }
+    )
 
-    return stop_times.reset_index()
-
-
-def zip_gtfs_tables(
-    agency: pd.DataFrame,
-    routes: pd.DataFrame,
-    trips: pd.DataFrame,
-    calendar: pd.DataFrame,
-    stops: pd.DataFrame,
-    stop_times: pd.DataFrame,
-    path: str | Path,
-) -> None:
-    """Write GTFS tables into one zip archive."""
-
-    tables = {
+    return {
         "agency.txt": agency,
         "trips.txt": trips,
         "routes.txt": routes,
@@ -233,6 +429,77 @@ def zip_gtfs_tables(
         "stops.txt": stops,
         "stop_times.txt": stop_times,
     }
+
+
+def _build_stop_times(lines: list[GTFSLineSpec]) -> list[pd.DataFrame]:
+    """Create stop times for all requested directions."""
+
+    stop_times = []
+    for line_index, line in enumerate(lines):
+        stop_times.append(_create_stop_times(line, trip_id_prefix=f"trip_{line_index}_0"))
+
+        if line.bidirectional:
+            stop_times.append(_create_stop_times(line.reverse(), trip_id_prefix=f"trip_{line_index}_1"))
+
+    return stop_times
+
+
+def _create_stop_times(line: GTFSLineSpec, trip_id_prefix: str) -> pd.DataFrame:
+    """Create ordered GTFS stop times for one line direction."""
+
+    rows = []
+    for departure_index, departure_time in enumerate(_departure_times(line.start_time, line.end_time, line.period)):
+        trip_id = f"{trip_id_prefix}_{departure_index}"
+        elapsed_time = 0.0
+
+        for stop_index, stop_id in enumerate(line.stop_ids):
+            stop_time = departure_time + elapsed_time
+            rows.append(
+                {
+                    "trip_id": trip_id,
+                    "stop_id": stop_id,
+                    "arrival_time": _format_gtfs_time(stop_time),
+                    "departure_time": _format_gtfs_time(stop_time),
+                    "stop_sequence": stop_index + 1,
+                }
+            )
+
+            if stop_index < len(line.segment_travel_times):
+                elapsed_time += line.segment_travel_times[stop_index]
+
+    return pd.DataFrame(
+        rows,
+        columns=["trip_id", "stop_id", "arrival_time", "departure_time", "stop_sequence"],
+    )
+
+
+def _departure_times(start_time: float, end_time: float, period: float) -> list[float]:
+    """Return regular departures between start and end, both in seconds."""
+
+    departures = []
+    departure_time = float(start_time)
+    while departure_time <= float(end_time) + 1e-9:
+        departures.append(departure_time)
+        departure_time += float(period)
+
+    return departures
+
+
+def _format_gtfs_time(seconds: float) -> str:
+    """Format seconds after midnight as a GTFS time string."""
+
+    if seconds < 0:
+        raise ValueError("GTFS times must not be negative.")
+
+    total_seconds = int(round(seconds))
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    remaining_seconds = total_seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{remaining_seconds:02d}"
+
+
+def _write_gtfs_zip(tables: Mapping[str, pd.DataFrame], path: Path) -> None:
+    """Write GTFS tables into one zip archive."""
 
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
@@ -242,65 +509,6 @@ def zip_gtfs_tables(
             zip_file.writestr(name, csv_buffer.getvalue())
 
     zip_buffer.seek(0)
-    path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as file:
         shutil.copyfileobj(zip_buffer, file)
-
-
-def build_gtfs_zip(feed: GTFSFeedSpec, output_path: str | Path) -> Path:
-    """Build one GTFS zip from a declarative feed specification."""
-
-    feed.validate()
-
-    stop_times_tables: list[pd.DataFrame] = []
-    for line in feed.lines:
-        travel_times = line.to_travel_times()
-        stop_times_tables.append(
-            create_stop_times(
-                travel_times=travel_times,
-                start_time=line.start_time,
-                end_time=line.end_time,
-                period=line.period,
-            )
-        )
-
-        if line.bidirectional:
-            reverse_travel_times = [[to_stop, from_stop, travel_time] for from_stop, to_stop, travel_time in travel_times]
-            reverse_travel_times.reverse()
-            stop_times_tables.append(
-                create_stop_times(
-                    travel_times=reverse_travel_times,
-                    start_time=line.start_time,
-                    end_time=line.end_time,
-                    period=line.period,
-                )
-            )
-
-    stops = {
-        stop_id: (spec.name or stop_id, [spec.lon, spec.lat])
-        for stop_id, spec in feed.stops.items()
-    }
-
-    agency, routes, trips, calendar, stops_table, stop_times_table = create_gtfs_tables(
-        agency_id=feed.agency_id,
-        agency_name=feed.agency_name,
-        route_id=feed.route_id,
-        route_short_name=feed.route_short_name,
-        route_type=feed.route_type,
-        service_id=feed.service_id,
-        stops=stops,
-        stop_times=stop_times_tables,
-    )
-
-    output_path = Path(output_path)
-    zip_gtfs_tables(
-        agency=agency,
-        routes=routes,
-        trips=trips,
-        calendar=calendar,
-        stops=stops_table,
-        stop_times=stop_times_table,
-        path=output_path,
-    )
-    return output_path

--- a/tests/back/unit/domain/transport_modes/test_002_gtfs_builder.py
+++ b/tests/back/unit/domain/transport_modes/test_002_gtfs_builder.py
@@ -1,0 +1,268 @@
+import csv
+import zipfile
+
+import pytest
+
+import mobility
+
+
+def _read_table(gtfs_zip, table_name):
+    with zipfile.ZipFile(gtfs_zip) as archive:
+        with archive.open(table_name) as file:
+            lines = (line.decode("utf-8") for line in file)
+            return list(csv.DictReader(lines))
+
+
+def _base_builder():
+    return mobility.GTFSBuilder(
+        agency_id="test_agency",
+        agency_name="Test Agency",
+        route_id="test_route",
+        route_short_name="T1",
+        route_type="bus",
+        service_id="test_service",
+    )
+
+
+def test_002_gtfs_builder_writes_bidirectional_feed_with_deterministic_trip_ids(tmp_path):
+    builder = _base_builder()
+    builder.add_stops(
+        {
+            "A": [2.0, 48.0],
+            "B": [2.1, 48.1],
+        }
+    )
+    builder.add_line(
+        [("A", "B", 300.0)],
+        start_time=6.0 * 3600.0,
+        end_time=6.0 * 3600.0 + 600.0,
+        period=300.0,
+    )
+
+    gtfs_zip = builder.write_zip(tmp_path / "test_gtfs.zip")
+
+    agency = _read_table(gtfs_zip, "agency.txt")
+    trips = _read_table(gtfs_zip, "trips.txt")
+    stop_times = _read_table(gtfs_zip, "stop_times.txt")
+
+    assert agency[0]["agency_timezone"] == "Europe/Paris"
+    assert [trip["trip_id"] for trip in trips] == [
+        "trip_0_0_0",
+        "trip_0_0_1",
+        "trip_0_0_2",
+        "trip_0_1_0",
+        "trip_0_1_1",
+        "trip_0_1_2",
+    ]
+    assert len(stop_times) == 12
+    assert stop_times[0] == {
+        "trip_id": "trip_0_0_0",
+        "stop_id": "A",
+        "arrival_time": "06:00:00",
+        "departure_time": "06:00:00",
+        "stop_sequence": "1",
+    }
+    assert stop_times[6] == {
+        "trip_id": "trip_0_1_0",
+        "stop_id": "B",
+        "arrival_time": "06:00:00",
+        "departure_time": "06:00:00",
+        "stop_sequence": "1",
+    }
+
+
+def test_002_gtfs_builder_represents_asymmetric_directions(tmp_path):
+    builder = _base_builder()
+    builder.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    builder.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+        bidirectional=False,
+    )
+    builder.add_line(
+        [("B", "A", 60.0)],
+        start_time=100.0,
+        end_time=100.0,
+        period=600.0,
+        bidirectional=False,
+    )
+
+    gtfs_zip = builder.write_zip(tmp_path / "test_gtfs.zip")
+
+    stop_times = _read_table(gtfs_zip, "stop_times.txt")
+
+    assert [row["trip_id"] for row in stop_times] == [
+        "trip_0_0_0",
+        "trip_0_0_0",
+        "trip_1_0_0",
+        "trip_1_0_0",
+    ]
+    assert [row["stop_id"] for row in stop_times] == ["A", "B", "B", "A"]
+    assert stop_times[2]["departure_time"] == "00:01:40"
+
+
+def test_002_gtfs_builder_keeps_repeated_stops_and_after_midnight_times(tmp_path):
+    builder = _base_builder()
+    builder.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    builder.add_line_from_stop_ids(
+        ["A", "B", "A"],
+        {
+            ("A", "B"): 300.0,
+            ("B", "A"): 300.0,
+        },
+        start_time=25.0 * 3600.0,
+        end_time=25.0 * 3600.0,
+        period=600.0,
+    )
+
+    gtfs_zip = builder.write_zip(tmp_path / "test_gtfs.zip")
+
+    stop_times = _read_table(gtfs_zip, "stop_times.txt")
+
+    assert [row["stop_id"] for row in stop_times] == ["A", "B", "A"]
+    assert [row["stop_sequence"] for row in stop_times] == ["1", "2", "3"]
+    assert [row["departure_time"] for row in stop_times] == [
+        "25:00:00",
+        "25:05:00",
+        "25:10:00",
+    ]
+
+
+def test_002_gtfs_builder_writes_project_zip(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    builder = _base_builder()
+    builder.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    builder.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+    )
+
+    gtfs_zip = builder.write_project_zip("project_gtfs.zip")
+
+    assert gtfs_zip == tmp_path / "project_gtfs.zip"
+    assert gtfs_zip.exists()
+
+
+def test_002_build_project_gtfs_zip_writes_under_project_data_folder(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    feed = _base_builder()
+    feed.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    feed.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+    )
+
+    gtfs_zip = mobility.build_project_gtfs_zip(feed.build_feed(), "direct_project_gtfs.zip")
+
+    assert gtfs_zip == tmp_path / "direct_project_gtfs.zip"
+    assert gtfs_zip.exists()
+
+
+def test_002_build_project_gtfs_zip_reports_missing_project_data_folder(monkeypatch):
+    monkeypatch.delenv("MOBILITY_PROJECT_DATA_FOLDER", raising=False)
+    feed = _base_builder()
+    feed.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    feed.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+    )
+
+    with pytest.raises(ValueError, match="mobility.set_params"):
+        mobility.build_project_gtfs_zip(feed.build_feed(), "missing_folder.zip")
+
+
+def test_002_gtfs_feed_spec_can_still_be_written_directly(tmp_path):
+    feed = mobility.GTFSFeedSpec(
+        agency_id="test_agency",
+        agency_name="Test Agency",
+        route_id="test_route",
+        route_short_name="T1",
+        route_type="train",
+        service_id="test_service",
+        stops={
+            "A": mobility.GTFSStopSpec(lon=2.0, lat=48.0, name="First stop"),
+            "B": mobility.GTFSStopSpec(lon=2.1, lat=48.1, name="Second stop"),
+        },
+        lines=[
+            mobility.GTFSLineSpec(
+                stop_ids=["A", "B"],
+                segment_travel_times=[60.0],
+                start_time=0.0,
+                end_time=0.0,
+                period=600.0,
+                bidirectional=False,
+            )
+        ],
+    )
+
+    gtfs_zip = mobility.build_gtfs_zip(feed, tmp_path / "test_gtfs.zip")
+
+    routes = _read_table(gtfs_zip, "routes.txt")
+    stops = _read_table(gtfs_zip, "stops.txt")
+
+    assert routes[0]["route_type"] == "2"
+    assert [stop["stop_name"] for stop in stops] == ["First stop", "Second stop"]
+
+
+def test_002_gtfs_builder_rejects_unknown_route_type(tmp_path):
+    builder = mobility.GTFSBuilder(
+        agency_id="test_agency",
+        agency_name="Test Agency",
+        route_id="test_route",
+        route_short_name="T1",
+        route_type="submarine",
+        service_id="test_service",
+    )
+    builder.add_stops({"A": [2.0, 48.0], "B": [2.1, 48.1]})
+    builder.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+    )
+
+    with pytest.raises(ValueError, match="route_type"):
+        builder.write_zip(tmp_path / "test_gtfs.zip")
+
+
+def test_002_gtfs_builder_rejects_unknown_stop_id(tmp_path):
+    builder = _base_builder()
+    builder.add_stops({"A": [2.0, 48.0]})
+    builder.add_line(
+        [("A", "B", 60.0)],
+        start_time=0.0,
+        end_time=0.0,
+        period=600.0,
+    )
+
+    with pytest.raises(ValueError, match="unknown stop ids: B"):
+        builder.write_zip(tmp_path / "test_gtfs.zip")
+
+
+def test_002_gtfs_line_from_stop_ids_reports_missing_segment_time():
+    with pytest.raises(ValueError, match="'A' -> 'B'"):
+        mobility.GTFSLineSpec.from_stop_ids(
+            ["A", "B"],
+            {},
+            start_time=0.0,
+            end_time=0.0,
+            period=600.0,
+        )
+
+
+def test_002_gtfs_line_from_segments_reports_malformed_first_segment():
+    with pytest.raises(ValueError, match="from_stop_id, to_stop_id and travel_time"):
+        mobility.GTFSLineSpec.from_segments(
+            [[]],
+            start_time=0.0,
+            end_time=0.0,
+            period=600.0,
+        )


### PR DESCRIPTION
### Motivation

This PR makes it easier to create small additional GTFS feeds from Python.

Before this change, users had to build `GTFSFeedSpec`, `GTFSLineSpec`, and `GTFSStopSpec` objects directly, and some common cases needed custom helper code. This was verbose for project scripts that only need to add a simple line, a branch service, or a test public transport scenario.

### Changes

This PR adds a higher-level `GTFSBuilder` API and improves the generated GTFS output.

Main changes:

- Add `mobility.GTFSBuilder`.
- Add `GTFSLineSpec.from_segments(...)` to define a line from `(from_stop, to_stop, travel_time)` rows.
- Add `GTFSLineSpec.from_stop_ids(...)` to define a line from an ordered stop list and a segment-time lookup.
- Add `build_project_gtfs_zip(...)` and `GTFSBuilder.write_project_zip(...)` to write GTFS files under `MOBILITY_PROJECT_DATA_FOLDER`.
- Export the new API from `mobility` and `mobility.transport.modes.public_transport`.
- Use deterministic trip ids instead of random ids, which makes generated GTFS files easier to test and compare.
- Format GTFS times manually so times after midnight remain valid, for example `25:10:00`.
- Preserve repeated stops in one trip by writing ordered stop-time rows directly.
- Add validation for route types, coordinates, unknown stops, travel times, periods, and service windows.
- Add `agency_timezone` and `agency_url` to `agency.txt`.
- Document the new builder API in the public transport modes documentation.
- Add focused unit tests for the new builder behavior.

### Example (if relevant)

```python
import mobility

builder = mobility.GTFSBuilder(
    agency_id="test_agency",
    agency_name="Test Agency",
    route_id="test_line",
    route_short_name="T1",
    route_type="bus",
    service_id="test_service",
)

builder.add_stops(
    {
        "first_stop": [6.151086, 46.209558],
        "second_stop": [6.192774, 46.253015],
    }
)
builder.add_line(
    [("first_stop", "second_stop", 27 * 60)],
    start_time=6 * 3600,
    end_time=9 * 3600,
    period=15 * 60,
)

gtfs_path = builder.write_project_zip("test_line.zip")
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: GTFS builder API changes, tests, and documentation draft.
- What you reviewed or changed: All generated code paths, public exports, validation behavior, and test expectations.
- How you validated it (tests, checks, manual verification): Ran `py_compile`, the focused GTFS builder pytest file, and `git diff --check`.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
