### PR TITLE
Use default scenario as parameter fallback

### DIFF
--- a/mobility/runtime/parameter_values.py
+++ b/mobility/runtime/parameter_values.py
@@ -12,7 +12,12 @@ DEFAULT_SCENARIO = "default"
 
 
 class ParameterValue(BaseModel):
-    """Parameter value that can vary by scenario and by iteration."""
+    """Parameter value that can vary by scenario and by iteration.
+
+    Plain values apply to every scenario. When scenario-specific values include
+    an explicit ``default`` scenario, that value is used as the fallback for
+    scenarios that do not define their own value.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
@@ -151,14 +156,17 @@ class ParameterValue(BaseModel):
         if None in self.values_by_scenario:
             return self.values_by_scenario[None]
 
-        if scenario not in self.values_by_scenario:
-            scenarios = ", ".join(sorted(self.scenario_names()))
-            raise ValueError(
-                f"Scenario '{scenario}' is not defined for this ParameterValue. "
-                f"Available scenarios: {scenarios}."
-            )
+        if scenario in self.values_by_scenario:
+            return self.values_by_scenario[scenario]
 
-        return self.values_by_scenario[scenario]
+        if DEFAULT_SCENARIO in self.values_by_scenario:
+            return self.values_by_scenario[DEFAULT_SCENARIO]
+
+        scenarios = ", ".join(sorted(self.scenario_names()))
+        raise ValueError(
+            f"Scenario '{scenario}' is not defined for this ParameterValue. "
+            f"Available scenarios: {scenarios}."
+        )
 
     @staticmethod
     def _step_value(points: dict[int, Any], iteration: int) -> Any:

--- a/tests/back/unit/costs/travel_costs/test_001_routing_parameters.py
+++ b/tests/back/unit/costs/travel_costs/test_001_routing_parameters.py
@@ -97,7 +97,7 @@ def test_public_transport_routing_parameters_resolve_scenario_gtfs_files():
     assert saleve_jura_5.additional_gtfs_files == ["rer.zip"]
 
 
-def test_scenario_generalized_cost_parameter_resolves_to_plain_value():
+def test_scenario_generalized_cost_parameter_uses_default_fallback():
     generalized_cost_parameters = GeneralizedCostParameters(
         cost_constant=ParameterValue.by_scenario(default=1.0, zone30=2.0)
     )
@@ -119,11 +119,13 @@ def test_scenario_generalized_cost_parameter_resolves_to_plain_value():
         == 2.0
     )
 
-    with pytest.raises(ValueError, match="Scenario 'missing' is not defined"):
+    assert (
         resolve_parameter_values(
             generalized_cost_parameters,
             scenario="missing",
-        )
+        ).cost_constant
+        == 1.0
+    )
 
 
 def test_scenario_generalized_cost_parameter_requires_defined_default_scenario():

--- a/tests/back/unit/runtime/test_001_parameter_values.py
+++ b/tests/back/unit/runtime/test_001_parameter_values.py
@@ -35,6 +35,24 @@ def test_parameter_value_accepts_scenario_iteration_mapping():
     ]
 
 
+def test_parameter_value_uses_explicit_default_for_other_scenarios():
+    value = ParameterValue.by_scenario(default=0.0, carbon_tax=0.12)
+
+    assert resolve_parameter_values(value, scenario="ljls") == 0.0
+    assert resolve_parameter_values(value, scenario="carbon_tax") == 0.12
+
+
+def test_parameter_value_uses_explicit_default_iterations_for_other_scenarios():
+    value = ParameterValue.by_scenario_and_iteration(
+        default=0.0,
+        carbon_tax={1: 0.0, 5: 0.12},
+    )
+
+    assert resolve_parameter_values(value, scenario="ljls", iteration=1) == 0.0
+    assert resolve_parameter_values(value, scenario="ljls", iteration=5) == 0.0
+    assert resolve_parameter_values(value, scenario="carbon_tax", iteration=5) == 0.12
+
+
 def test_parameter_value_returns_deep_copied_mutable_values():
     value = ParameterValue.constant({"files": ["base.zip"]})
 


### PR DESCRIPTION
### Motivation
Scenario-specific parameter values needed an exact scenario match unless the value was plain and shared by all scenarios. That made it awkward to define one explicit default value and only override the scenarios that should differ.

### Changes
This PR makes an explicit `default` scenario work as the fallback for other scenario names.

Plain values still apply to every scenario. When a parameter is defined by scenario and includes `default`, unknown scenario names now use that default value instead of raising an error. Scenario-specific overrides still take priority over the default.

This makes parameter configuration easier to read because common values can be written once and only changed scenarios need their own entry.

### Example
```python
value = ParameterValue.by_scenario(default=0.0, carbon_tax=0.12)

resolve_parameter_values(value, scenario="baseline")  # 0.0
resolve_parameter_values(value, scenario="carbon_tax")  # 0.12
```

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: implementation, tests, and PR description.
- What you reviewed or changed: scenario lookup order and the unit tests for default fallback behavior.
- How you validated it (tests, checks, manual verification): `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/runtime/test_001_parameter_values.py`

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
