### PR TITLE
Add group day trips sensitivity analysis

### DIFF
--- a/mobility/__init__.py
+++ b/mobility/__init__.py
@@ -73,7 +73,7 @@ from .transport.modes.public_transport import (
     PublicTransportRoutingParameters,
 )
 from .transport.modes.core import IntermodalTransfer, ModeRegistry
-from .runtime.parameter_values import DEFAULT_SCENARIO, ParameterValue
+from .runtime.parameter_values import DEFAULT_SCENARIO, ParameterValue, SensitivityValue
 from .runtime.scenarios import Scenario, Scenarios
 
 from .transport.graphs.modified.modifiers import (

--- a/mobility/activities/activity.py
+++ b/mobility/activities/activity.py
@@ -6,7 +6,12 @@ import polars as pl
 from typing import Annotated, List, Dict
 
 from mobility.runtime.assets.in_memory_asset import InMemoryAsset
-from mobility.runtime.parameter_values import ParameterValue, resolve_parameter_values
+from mobility.runtime.parameter_values import (
+    ParameterValue,
+    SensitivityCase,
+    SensitivityValue,
+    resolve_parameter_values,
+)
 from pydantic import BaseModel, ConfigDict, Field
 from mobility.runtime.validation_types import NonNegativeFloat, UnitIntervalFloat
 
@@ -86,6 +91,7 @@ class Activity(InMemoryAsset):
         self,
         iteration: int,
         scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> "ActivityParameters":
         """Returns the activity parameters in effect at one simulation iteration.
 
@@ -101,6 +107,7 @@ class Activity(InMemoryAsset):
             self.inputs["parameters"],
             scenario=scenario,
             iteration=iteration,
+            sensitivity_case=sensitivity_case,
         )
 
     def enforce_opportunities_schema(self, opportunities):
@@ -126,7 +133,7 @@ class ActivityParameters(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     value_of_time: Annotated[
-        NonNegativeFloat | ParameterValue,
+        NonNegativeFloat | ParameterValue | SensitivityValue,
         Field(
             default=10.0,
             title="Value of time",
@@ -153,7 +160,7 @@ class ActivityParameters(BaseModel):
     ]
 
     value_of_time_v2: Annotated[
-        NonNegativeFloat | ParameterValue | None,
+        NonNegativeFloat | ParameterValue | SensitivityValue | None,
         Field(
             default=None,
             title="Alternative value of time",
@@ -264,7 +271,7 @@ class ActivityParameters(BaseModel):
     ]
 
     arrival_time_rigidity: Annotated[
-        UnitIntervalFloat | ParameterValue | None,
+        UnitIntervalFloat | ParameterValue | SensitivityValue | None,
         Field(
             default=None,
             title="Arrival time rigidity",
@@ -281,6 +288,7 @@ def resolve_activity_parameters(
     activities: list[Activity],
     iteration: int,
     scenario: str | None = None,
+    sensitivity_case: SensitivityCase | None = None,
 ) -> dict[str, ActivityParameters]:
     """Resolve all activity parameter models for one simulation iteration."""
 
@@ -288,6 +296,7 @@ def resolve_activity_parameters(
         activity.name: activity.get_parameters_for_iteration(
             iteration,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
         )
         for activity in activities
     }
@@ -297,6 +306,7 @@ def resolve_activity_arrival_time_rigidity(
     activities: list[Activity],
     iteration: int,
     scenario: str | None = None,
+    sensitivity_case: SensitivityCase | None = None,
 ) -> dict[str, float]:
     """Resolve per-activity arrival-time rigidity with anchor-based defaults."""
 
@@ -305,6 +315,7 @@ def resolve_activity_arrival_time_rigidity(
         parameters = activity.get_parameters_for_iteration(
             iteration,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
         )
         rigidity = parameters.arrival_time_rigidity
         if rigidity is None:

--- a/mobility/activities/home.py
+++ b/mobility/activities/home.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, List
 
 from pydantic import Field
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 
 from mobility.activities.activity import Activity, ActivityParameters
 
@@ -49,12 +49,12 @@ class HomeParameters(ActivityParameters):
     """Parameters specific to the home activity."""
 
     value_of_time: Annotated[
-        float | ParameterValue,
+        float | ParameterValue | SensitivityValue,
         Field(default=10.0),
     ]
 
     value_of_time_stay_home: Annotated[
-        float | ParameterValue,
+        float | ParameterValue | SensitivityValue,
         Field(default=0.0),
     ]
 

--- a/mobility/activities/leisure/leisure.py
+++ b/mobility/activities/leisure/leisure.py
@@ -11,7 +11,7 @@ from typing import Annotated, List
 from pydantic import Field
 from mobility.activities.activity import Activity, ActivityParameters
 from mobility.activities.leisure.leisure_facilities_distribution import LeisureFacilitiesDistribution
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.validation_types import UnitIntervalFloat
 
 
@@ -174,7 +174,7 @@ class LeisureActivity(Activity):
 class LeisureParameters(ActivityParameters):
     """Parameters specific to the leisure activity."""
 
-    value_of_time: Annotated[float | ParameterValue, Field(default=10.0)]
+    value_of_time: Annotated[float | ParameterValue | SensitivityValue, Field(default=10.0)]
     saturation_fun_ref_level: Annotated[float, Field(default=1.5, ge=0.0)]
     saturation_fun_beta: Annotated[float, Field(default=4.0, ge=0.0)]
     survey_ids: Annotated[

--- a/mobility/activities/other.py
+++ b/mobility/activities/other.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 from mobility.activities.activity import Activity, ActivityParameters
 from mobility.population import Population
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.validation_types import NonNegativeFloat, UnitIntervalFloat
 
 
@@ -97,7 +97,7 @@ class OtherParameters(ActivityParameters):
     """Parameters specific to the other activity."""
 
     value_of_time: Annotated[
-        float | ParameterValue,
+        float | ParameterValue | SensitivityValue,
         Field(default=10.0),
     ]
 

--- a/mobility/activities/shopping/shop.py
+++ b/mobility/activities/shopping/shop.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from mobility.activities.activity import Activity, ActivityParameters
 from mobility.activities.shopping.shops_turnover_distribution import ShopsTurnoverDistribution
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.validation_types import UnitIntervalFloat
 
 
@@ -100,7 +100,7 @@ class ShopActivity(Activity):
 class ShopParameters(ActivityParameters):
     """Parameters specific to the shopping activity."""
 
-    value_of_time: Annotated[float | ParameterValue, Field(default=10.0)]
+    value_of_time: Annotated[float | ParameterValue | SensitivityValue, Field(default=10.0)]
     saturation_fun_ref_level: Annotated[float, Field(default=1.5, ge=0.0)]
     saturation_fun_beta: Annotated[float, Field(default=4.0, ge=0.0)]
     survey_ids: Annotated[list[str], Field(default_factory=lambda: ["2.20", "2.21"])]

--- a/mobility/activities/studies/study.py
+++ b/mobility/activities/studies/study.py
@@ -11,7 +11,7 @@ from pydantic import Field
 
 from mobility.activities.activity import Activity, ActivityParameters
 from mobility.activities.studies.schools_capacity_distribution import SchoolsCapacityDistribution
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.validation_types import UnitIntervalFloat
 
 
@@ -177,7 +177,7 @@ class StudyActivity(Activity):
 class StudyParameters(ActivityParameters):
     """Parameters specific to the studies activity."""
 
-    value_of_time: Annotated[float | ParameterValue, Field(default=10.0)]
+    value_of_time: Annotated[float | ParameterValue | SensitivityValue, Field(default=10.0)]
     saturation_fun_ref_level: Annotated[float, Field(default=1.5, ge=0.0)]
     saturation_fun_beta: Annotated[float, Field(default=4.0, ge=0.0)]
     survey_ids: Annotated[list[str], Field(default_factory=lambda: ["1.11"])]

--- a/mobility/activities/work/work.py
+++ b/mobility/activities/work/work.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from mobility.activities.activity import Activity, ActivityParameters
 from mobility.activities.work.jobs_active_population_distribution import JobsActivePopulationDistribution
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.validation_types import UnitIntervalFloat
 
 
@@ -105,7 +105,7 @@ class WorkParameters(ActivityParameters):
     """Parameters specific to the work activity."""
 
     value_of_time: Annotated[
-        float | ParameterValue,
+        float | ParameterValue | SensitivityValue,
         Field(default=10.0),
     ]
 

--- a/mobility/runtime/__init__.py
+++ b/mobility/runtime/__init__.py
@@ -2,8 +2,12 @@
 
 from .parameter_values import (
     DEFAULT_SCENARIO,
+    DEFAULT_SENSITIVITY_CASE,
     ParameterValue,
+    SensitivityCase,
+    SensitivityValue,
     collect_parameter_value_scenarios,
+    collect_sensitivity_values,
     resolve_parameter_values,
 )
 from .scenarios import (
@@ -15,11 +19,15 @@ from .scenarios import (
 
 __all__ = [
     "DEFAULT_SCENARIO",
+    "DEFAULT_SENSITIVITY_CASE",
     "ParameterValue",
+    "SensitivityCase",
+    "SensitivityValue",
     "Scenario",
     "ScenarioParameterChange",
     "Scenarios",
     "collect_parameter_value_changes",
     "collect_parameter_value_scenarios",
+    "collect_sensitivity_values",
     "resolve_parameter_values",
 ]

--- a/mobility/runtime/parameter_values.py
+++ b/mobility/runtime/parameter_values.py
@@ -9,6 +9,199 @@ from pydantic import BaseModel, ConfigDict, model_validator
 from mobility.runtime.assets.asset import Asset
 
 DEFAULT_SCENARIO = "default"
+DEFAULT_SENSITIVITY_CASE = "base"
+
+
+class SensitivityCase(BaseModel):
+    """One parameter variation used during a sensitivity run."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    case_id: str
+    parameter_name: str | None = None
+    parameter_label: str | None = None
+    variation_type: Literal["values", "relative", "absolute"] | None = None
+    variation_value: Any = None
+    variation_label: str | None = None
+
+    @property
+    def is_base(self) -> bool:
+        """Return whether this case leaves all sensitivity values unchanged."""
+        return self.parameter_name is None
+
+    def matches(self, parameter_name: str) -> bool:
+        """Return whether this case applies to one sensitivity parameter."""
+        return self.parameter_name == parameter_name
+
+
+class SensitivityValue(BaseModel):
+    """Value that can be varied during a sensitivity analysis.
+
+    A sensitivity value behaves like its base value in normal runs. During a
+    sensitivity run, it applies the active sensitivity case when the case targets
+    this value's ``name``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    value: Any
+    name: str
+    label: str | None = None
+    variation_type: Literal["values", "relative", "absolute"]
+    variation_values: tuple[Any, ...]
+    variation_labels: tuple[str, ...] | None = None
+
+    @classmethod
+    def values(
+        cls,
+        value: Any,
+        values: list[Any] | tuple[Any, ...],
+        *,
+        name: str,
+        label: str | None = None,
+        labels: list[str] | tuple[str, ...] | None = None,
+    ) -> "SensitivityValue":
+        """Return a value with explicit candidate values for sensitivity runs."""
+        return cls._build(
+            value,
+            variation_type="values",
+            variation_values=tuple(values),
+            name=name,
+            label=label,
+            labels=labels,
+        )
+
+    @classmethod
+    def relative(
+        cls,
+        value: Any,
+        changes: list[float] | tuple[float, ...],
+        *,
+        name: str,
+        label: str | None = None,
+        labels: list[str] | tuple[str, ...] | None = None,
+    ) -> "SensitivityValue":
+        """Return a value varied by relative changes around its base value."""
+        return cls._build(
+            value,
+            variation_type="relative",
+            variation_values=tuple(changes),
+            name=name,
+            label=label,
+            labels=labels,
+        )
+
+    @classmethod
+    def absolute(
+        cls,
+        value: Any,
+        changes: list[float] | tuple[float, ...],
+        *,
+        name: str,
+        label: str | None = None,
+        labels: list[str] | tuple[str, ...] | None = None,
+    ) -> "SensitivityValue":
+        """Return a value varied by absolute changes around its base value."""
+        return cls._build(
+            value,
+            variation_type="absolute",
+            variation_values=tuple(changes),
+            name=name,
+            label=label,
+            labels=labels,
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        value: Any,
+        *,
+        variation_type: Literal["values", "relative", "absolute"],
+        variation_values: tuple[Any, ...],
+        name: str,
+        label: str | None,
+        labels: list[str] | tuple[str, ...] | None,
+    ) -> "SensitivityValue":
+        if not name:
+            raise ValueError("SensitivityValue.name should not be empty.")
+        if not variation_values:
+            raise ValueError("SensitivityValue needs at least one variation value.")
+        if labels is not None and len(labels) != len(variation_values):
+            raise ValueError("SensitivityValue labels should match the number of variation values.")
+        if _contains_parameter_value(value) or _contains_parameter_value(variation_values):
+            raise ValueError(
+                "SensitivityValue should wrap final values, not ParameterValue. "
+                "Put SensitivityValue inside the relevant ParameterValue scenario or iteration point."
+            )
+        return cls(
+            value=value,
+            name=name,
+            label=label,
+            variation_type=variation_type,
+            variation_values=variation_values,
+            variation_labels=tuple(labels) if labels is not None else None,
+        )
+
+    @model_validator(mode="after")
+    def validate_final_values(self) -> "SensitivityValue":
+        """Check sensitivity values wrap final values, not scenario rules."""
+        if _contains_parameter_value(self.value) or _contains_parameter_value(self.variation_values):
+            raise ValueError(
+                "SensitivityValue should wrap final values, not ParameterValue. "
+                "Put SensitivityValue inside the relevant ParameterValue scenario or iteration point."
+            )
+        return self
+
+    def cases(self) -> list[SensitivityCase]:
+        """Return sensitivity cases generated from this value."""
+        cases = []
+        for index, variation_value in enumerate(self.variation_values):
+            if self.variation_labels is not None:
+                variation_label = self.variation_labels[index]
+            else:
+                variation_label = self._default_variation_label(variation_value)
+            cases.append(
+                SensitivityCase(
+                    case_id=f"{self.name}_{index + 1}",
+                    parameter_name=self.name,
+                    parameter_label=self.label or self.name,
+                    variation_type=self.variation_type,
+                    variation_value=variation_value,
+                    variation_label=variation_label,
+                )
+            )
+        return cases
+
+    def at(
+        self,
+        *,
+        sensitivity_case: SensitivityCase | None = None,
+    ) -> Any:
+        """Return the base value or the value for the active sensitivity case."""
+        base_value = self._copy_plain_value(self.value)
+        if sensitivity_case is None or not sensitivity_case.matches(self.name):
+            return self._copy_plain_value(base_value)
+        if sensitivity_case.variation_type == "values":
+            return self._copy_plain_value(sensitivity_case.variation_value)
+        if sensitivity_case.variation_type == "relative":
+            return base_value * (1.0 + sensitivity_case.variation_value)
+        if sensitivity_case.variation_type == "absolute":
+            return base_value + sensitivity_case.variation_value
+        return self._copy_plain_value(base_value)
+
+    @staticmethod
+    def _copy_plain_value(value: Any) -> Any:
+        if isinstance(value, (list, dict, set, tuple)):
+            return deepcopy(value)
+        return value
+
+    @staticmethod
+    def _default_variation_label(value: Any) -> str:
+        if isinstance(value, (int, float)):
+            if value > 0:
+                return f"+{value:g}"
+            return f"{value:g}"
+        return str(value)
 
 
 class ParameterValue(BaseModel):
@@ -97,7 +290,12 @@ class ParameterValue(BaseModel):
 
         return self
 
-    def at(self, *, scenario: str | None = None, iteration: int = 1) -> Any:
+    def at(
+        self,
+        *,
+        scenario: str | None = None,
+        iteration: int = 1,
+    ) -> Any:
         """Return the plain value for one scenario and one iteration."""
         scenario_name = DEFAULT_SCENARIO if scenario is None else scenario
         points = self._points_for_scenario(scenario_name)
@@ -119,6 +317,8 @@ class ParameterValue(BaseModel):
 
     @classmethod
     def _points_from_value(cls, value: Any) -> dict[int, Any]:
+        if isinstance(value, SensitivityValue):
+            return {1: value}
         if isinstance(value, ParameterValue):
             if value.has_scenarios():
                 raise ValueError(
@@ -193,15 +393,73 @@ class ParameterValue(BaseModel):
         return value
 
 
+def _contains_parameter_value(value: Any) -> bool:
+    """Return whether a value contains a ParameterValue object."""
+    seen = set()
+
+    def contains(item: Any) -> bool:
+        if isinstance(item, ParameterValue):
+            return True
+
+        if isinstance(item, (Asset, BaseModel, dict, list, tuple, set)):
+            item_id = id(item)
+            if item_id in seen:
+                return False
+            seen.add(item_id)
+
+        if isinstance(item, Asset):
+            return contains(item.inputs)
+
+        if isinstance(item, BaseModel):
+            return any(
+                contains(getattr(item, field_name))
+                for field_name in item.__class__.model_fields
+            )
+
+        if isinstance(item, dict):
+            return any(
+                contains(key) or contains(dict_value)
+                for key, dict_value in item.items()
+            )
+
+        if isinstance(item, (list, tuple, set)):
+            return any(contains(list_value) for list_value in item)
+
+        return False
+
+    return contains(value)
+
+
 def resolve_parameter_values(
     value: Any,
     *,
     scenario: str | None = None,
     iteration: int = 1,
+    sensitivity_case: SensitivityCase | None = None,
 ) -> Any:
     """Return a copy of ``value`` where ParameterValue objects are plain values."""
+    if isinstance(value, SensitivityValue):
+        resolved_value = value.at(
+            sensitivity_case=sensitivity_case,
+        )
+        return resolve_parameter_values(
+            resolved_value,
+            scenario=scenario,
+            iteration=iteration,
+            sensitivity_case=sensitivity_case,
+        )
+
     if isinstance(value, ParameterValue):
-        return value.at(scenario=scenario, iteration=iteration)
+        resolved_value = value.at(
+            scenario=scenario,
+            iteration=iteration,
+        )
+        return resolve_parameter_values(
+            resolved_value,
+            scenario=scenario,
+            iteration=iteration,
+            sensitivity_case=sensitivity_case,
+        )
 
     if isinstance(value, BaseModel):
         resolved_data = {
@@ -209,6 +467,7 @@ def resolve_parameter_values(
                 getattr(value, field_name),
                 scenario=scenario,
                 iteration=iteration,
+                sensitivity_case=sensitivity_case,
             )
             for field_name in value.__class__.model_fields
         }
@@ -216,27 +475,52 @@ def resolve_parameter_values(
 
     if isinstance(value, dict):
         return {
-            resolve_parameter_values(key, scenario=scenario, iteration=iteration): (
-                resolve_parameter_values(item, scenario=scenario, iteration=iteration)
+            resolve_parameter_values(
+                key,
+                scenario=scenario,
+                iteration=iteration,
+                sensitivity_case=sensitivity_case,
+            ): (
+                resolve_parameter_values(
+                    item,
+                    scenario=scenario,
+                    iteration=iteration,
+                    sensitivity_case=sensitivity_case,
+                )
             )
             for key, item in value.items()
         }
 
     if isinstance(value, list):
         return [
-            resolve_parameter_values(item, scenario=scenario, iteration=iteration)
+            resolve_parameter_values(
+                item,
+                scenario=scenario,
+                iteration=iteration,
+                sensitivity_case=sensitivity_case,
+            )
             for item in value
         ]
 
     if isinstance(value, tuple):
         return tuple(
-            resolve_parameter_values(item, scenario=scenario, iteration=iteration)
+            resolve_parameter_values(
+                item,
+                scenario=scenario,
+                iteration=iteration,
+                sensitivity_case=sensitivity_case,
+            )
             for item in value
         )
 
     if isinstance(value, set):
         return {
-            resolve_parameter_values(item, scenario=scenario, iteration=iteration)
+            resolve_parameter_values(
+                item,
+                scenario=scenario,
+                iteration=iteration,
+                sensitivity_case=sensitivity_case,
+            )
             for item in value
         }
 
@@ -282,3 +566,53 @@ def collect_parameter_value_scenarios(value: Any) -> set[str]:
         return set()
 
     return collect(value)
+
+
+def collect_sensitivity_values(value: Any) -> list[SensitivityValue]:
+    """Return sensitivity values found inside a setup object."""
+    seen = set()
+    sensitivity_values: list[SensitivityValue] = []
+
+    def collect(item: Any) -> None:
+        if isinstance(item, SensitivityValue):
+            sensitivity_values.append(item)
+            collect(item.value)
+            return
+
+        if isinstance(item, ParameterValue):
+            item_id = id(item)
+            if item_id in seen:
+                return
+            seen.add(item_id)
+            for points in item.values_by_scenario.values():
+                for point_value in points.values():
+                    collect(point_value)
+            return
+
+        if isinstance(item, (Asset, BaseModel, dict, list, tuple, set)):
+            item_id = id(item)
+            if item_id in seen:
+                return
+            seen.add(item_id)
+
+        if isinstance(item, Asset):
+            collect(item.inputs)
+            return
+
+        if isinstance(item, BaseModel):
+            for field_name in item.__class__.model_fields:
+                collect(getattr(item, field_name))
+            return
+
+        if isinstance(item, dict):
+            for key, dict_value in item.items():
+                collect(key)
+                collect(dict_value)
+            return
+
+        if isinstance(item, (list, tuple, set)):
+            for list_value in item:
+                collect(list_value)
+
+    collect(value)
+    return sensitivity_values

--- a/mobility/transport/costs/parameters/cost_of_time_parameters.py
+++ b/mobility/transport/costs/parameters/cost_of_time_parameters.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 
 
 class CostOfTimeParameters(BaseModel):
@@ -12,13 +12,13 @@ class CostOfTimeParameters(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    intercept: Annotated[float | ParameterValue, Field(default=20.0)]
-    breaks: Annotated[list[float] | ParameterValue, Field(default_factory=lambda: [0.0, 10000000.0])]
-    slopes: Annotated[list[float] | ParameterValue, Field(default_factory=lambda: [0.0])]
-    max_value: Annotated[float | ParameterValue, Field(default=20.0)]
+    intercept: Annotated[float | ParameterValue | SensitivityValue, Field(default=20.0)]
+    breaks: Annotated[list[float] | ParameterValue | SensitivityValue, Field(default_factory=lambda: [0.0, 10000000.0])]
+    slopes: Annotated[list[float] | ParameterValue | SensitivityValue, Field(default_factory=lambda: [0.0])]
+    max_value: Annotated[float | ParameterValue | SensitivityValue, Field(default=20.0)]
 
-    country_coeff_fr: Annotated[float | ParameterValue, Field(default=1.0)]
-    country_coeff_ch: Annotated[float | ParameterValue, Field(default=1.0)]
+    country_coeff_fr: Annotated[float | ParameterValue | SensitivityValue, Field(default=1.0)]
+    country_coeff_ch: Annotated[float | ParameterValue | SensitivityValue, Field(default=1.0)]
 
     @model_validator(mode="after")
     def validate_breaks_and_slopes(self) -> "CostOfTimeParameters":
@@ -30,7 +30,7 @@ class CostOfTimeParameters(BaseModel):
         Raises:
             ValueError: If slope count does not match break count minus one.
         """
-        if isinstance(self.breaks, ParameterValue) or isinstance(self.slopes, ParameterValue):
+        if isinstance(self.breaks, (ParameterValue, SensitivityValue)) or isinstance(self.slopes, (ParameterValue, SensitivityValue)):
             return self
 
         if len(self.slopes) != len(self.breaks) - 1:

--- a/mobility/transport/costs/parameters/generalized_cost_parameters.py
+++ b/mobility/transport/costs/parameters/generalized_cost_parameters.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.transport.costs.parameters.cost_of_time_parameters import CostOfTimeParameters
 
 
@@ -11,6 +11,6 @@ class GeneralizedCostParameters(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    cost_constant: Annotated[float | ParameterValue, Field(default=0.0)]
+    cost_constant: Annotated[float | ParameterValue | SensitivityValue, Field(default=0.0)]
     cost_of_time: Annotated[CostOfTimeParameters, Field(default_factory=CostOfTimeParameters)]
-    cost_of_distance: Annotated[float | ParameterValue, Field(default=0.0)]
+    cost_of_distance: Annotated[float | ParameterValue | SensitivityValue, Field(default=0.0)]

--- a/mobility/transport/costs/parameters/path_routing_parameters.py
+++ b/mobility/transport/costs/parameters/path_routing_parameters.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 
 
 class PathRoutingParameters(BaseModel):
@@ -19,7 +19,7 @@ class PathRoutingParameters(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    max_beeline_distance: Annotated[float | ParameterValue | None, Field(default=None)]  # km
+    max_beeline_distance: Annotated[float | ParameterValue | SensitivityValue | None, Field(default=None)]  # km
     filter_max_speed: Annotated[float | None, Field(default=None, gt=0.0)]  # km/h
     filter_max_time: Annotated[float | None, Field(default=None, gt=0.0)]  # h
 
@@ -59,7 +59,7 @@ class PathRoutingParameters(BaseModel):
     @model_validator(mode="after")
     def validate_max_beeline_distance(self) -> "PathRoutingParameters":
         """Validate plain distance values while allowing unresolved scenario values."""
-        if isinstance(self.max_beeline_distance, ParameterValue):
+        if isinstance(self.max_beeline_distance, (ParameterValue, SensitivityValue)):
             return self
         if self.max_beeline_distance is None or self.max_beeline_distance <= 0.0:
             raise ValueError("max_beeline_distance should be greater than 0.")

--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import os
 import pathlib
@@ -8,7 +7,7 @@ import pathlib
 import polars as pl
 
 from mobility.runtime.assets.in_memory_asset import InMemoryAsset
-from mobility.runtime.parameter_values import resolve_parameter_values
+from mobility.runtime.parameter_values import SensitivityCase, resolve_parameter_values
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.costs.road_flow_manager import RoadFlowManager
@@ -52,6 +51,7 @@ class TransportCosts(FileAsset):
         self,
         iteration: int,
         scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> "TransportCosts":
         """Return the static transport-cost variant for one iteration.
 
@@ -70,6 +70,7 @@ class TransportCosts(FileAsset):
                 mode,
                 iteration=iteration,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
             )
             for mode in self.modes
         ]
@@ -85,14 +86,16 @@ class TransportCosts(FileAsset):
         *,
         iteration: int,
         scenario: str | None,
+        sensitivity_case: SensitivityCase | None,
     ):
         """Return one mode with iteration and scenario values resolved."""
         for_iteration = getattr(mode, "for_iteration", None)
         if callable(for_iteration):
-            parameters = inspect.signature(for_iteration).parameters
-            if "scenario" in parameters:
-                return for_iteration(iteration, scenario=scenario)
-            return for_iteration(iteration)
+            return for_iteration(
+                iteration,
+                scenario=scenario,
+                sensitivity_case=sensitivity_case,
+            )
 
         generalized_cost = mode.inputs.get("generalized_cost")
         if not isinstance(generalized_cost, InMemoryAsset):
@@ -102,6 +105,7 @@ class TransportCosts(FileAsset):
             generalized_cost.inputs,
             scenario=scenario,
             iteration=iteration,
+            sensitivity_case=sensitivity_case,
         )
         if resolved_gc_inputs == generalized_cost.inputs:
             return mode

--- a/mobility/transport/modes/public_transport/public_transport.py
+++ b/mobility/transport/modes/public_transport/public_transport.py
@@ -2,7 +2,7 @@ import logging
 
 from typing import List
 
-from mobility.runtime.parameter_values import resolve_parameter_values
+from mobility.runtime.parameter_values import SensitivityCase, resolve_parameter_values
 from mobility.spatial.transport_zones import TransportZones
 from mobility.transport.modes.core.transport_mode import TransportMode, TransportModeParameters
 from mobility.transport.modes.core.mode_registry import ModeRegistry
@@ -161,6 +161,7 @@ class PublicTransportMode(TransportMode):
         self,
         iteration: int,
         scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> "PublicTransportMode":
         """Return a PT mode with routing parameters resolved for one iteration."""
         
@@ -169,12 +170,14 @@ class PublicTransportMode(TransportMode):
             routing_parameters,
             scenario=scenario,
             iteration=iteration,
+            sensitivity_case=sensitivity_case,
         )
         generalized_cost = self.inputs["generalized_cost"]
         resolved_mid_parameters = resolve_parameter_values(
             generalized_cost.inputs["mid_parameters"],
             scenario=scenario,
             iteration=iteration,
+            sensitivity_case=sensitivity_case,
         )
 
         if (

--- a/mobility/transport/modes/public_transport/public_transport_graph.py
+++ b/mobility/transport/modes/public_transport/public_transport_graph.py
@@ -11,7 +11,7 @@ from importlib import resources
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from mobility.runtime.assets.file_asset import FileAsset
-from mobility.runtime.parameter_values import ParameterValue
+from mobility.runtime.parameter_values import ParameterValue, SensitivityValue
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.spatial.transport_zones import TransportZones
 from mobility.transport.modes.core.defaults import (
@@ -143,7 +143,7 @@ class PublicTransportRoutingParameters(BaseModel):
         Field(default=DEFAULT_LONG_RANGE_MOTORIZED_MAX_BEELINE_DISTANCE_KM, gt=0.0),
     ]
     additional_gtfs_files: Annotated[
-        ParameterValue | list[str] | None,
+        ParameterValue | SensitivityValue | list[str] | None,
         Field(default=None),
     ]
     expected_agencies: Annotated[list[str] | None, Field(default=None)]

--- a/mobility/trips/group_day_trips/core/group_day_trips.py
+++ b/mobility/trips/group_day_trips/core/group_day_trips.py
@@ -1,9 +1,10 @@
 from enum import StrEnum
 
-from mobility.runtime.parameter_values import DEFAULT_SCENARIO
+from mobility.runtime.parameter_values import DEFAULT_SCENARIO, SensitivityCase
 from mobility.runtime.scenarios import Scenarios
 from mobility.transport.costs.transport_costs import TransportCosts
 from ..results import GroupDayTripsResults
+from ..sensitivity import GroupDayTripsSensitivityAnalysis
 from .parameters import GroupDayTripsParameters
 from .run import Run
 from mobility.activities import Activity, HomeActivity, OtherActivity
@@ -87,13 +88,14 @@ class PopulationGroupDayTrips:
             activities=self.activities,
             parameters=self.parameters,
         )
-        self._runs: dict[tuple[str, int, DayType], Run] = {}
+        self._runs: dict[tuple[str, str, int, DayType], Run] = {}
 
     def run(
         self,
         day_type: str | DayType,
         *,
         scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
         replication: int = 0,
     ) -> Run:
         """Return one weekday or weekend run.
@@ -116,8 +118,9 @@ class PopulationGroupDayTrips:
         """
         day_type = DayType(day_type)
         scenario = DEFAULT_SCENARIO if scenario is None else scenario
+        sensitivity_case_id = "base" if sensitivity_case is None else sensitivity_case.case_id
         self.scenarios.validate_requested([scenario])
-        key = (scenario, replication, day_type)
+        key = (scenario, sensitivity_case_id, replication, day_type)
         if key not in self._runs:
             parameters = self.parameters.with_replication(replication)
             survey_plan_assets = SurveyPlanAssets(
@@ -138,6 +141,7 @@ class PopulationGroupDayTrips:
                 is_weekday=is_weekday,
                 enabled=is_weekday or parameters.periods.simulate_weekend,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
                 replication=replication,
             )
         return self._runs[key]
@@ -147,6 +151,7 @@ class PopulationGroupDayTrips:
         day_type: str | DayType = DayType.WEEKDAY,
         *,
         scenarios: str | list[str] | tuple[str, ...] | None = None,
+        sensitivity_cases: list[SensitivityCase | None] | None = None,
         replication: int | None = None,
         replications: list[int] | range | None = None,
     ) -> GroupDayTripsResults:
@@ -163,9 +168,22 @@ class PopulationGroupDayTrips:
             day_type=day_type.value,
             scenarios=scenarios,
             scenario_manifest=self.scenarios,
+            sensitivity_cases=sensitivity_cases,
             n_replications=self.parameters.run.n_replications,
             replication=replication,
             replications=replications,
+        )
+
+    def sensitivity(
+        self,
+        *,
+        scenarios: str | list[str] | tuple[str, ...] | None = None,
+    ):
+        """Return sensitivity-analysis helpers for selected scenarios."""
+        self.scenarios.validate_requested(Scenarios.selected_names(scenarios))
+        return GroupDayTripsSensitivityAnalysis(
+            setup=self,
+            scenarios=Scenarios.selected_names(scenarios),
         )
 
     def remove(self):
@@ -177,24 +195,32 @@ class PopulationGroupDayTrips:
         """
         scenarios = {DEFAULT_SCENARIO}
         scenarios.update(self.scenarios.names)
-        scenarios.update(scenario for scenario, _, _ in self._runs)
+        scenarios.update(scenario for scenario, _, _, _ in self._runs)
 
         replications = set(range(self.parameters.run.n_replications))
-        replications.update(replication for _, replication, _ in self._runs)
+        replications.update(replication for _, _, replication, _ in self._runs)
+
+        sensitivity_cases = [None]
+        for run in self._runs.values():
+            sensitivity_case = getattr(run, "sensitivity_case", None)
+            if sensitivity_case is not None and sensitivity_case not in sensitivity_cases:
+                sensitivity_cases.append(sensitivity_case)
 
         day_types = {DayType.WEEKDAY}
         if self.parameters.periods.simulate_weekend:
             day_types.add(DayType.WEEKEND)
-        day_types.update(day_type for _, _, day_type in self._runs)
+        day_types.update(day_type for _, _, _, day_type in self._runs)
 
         for scenario in scenarios:
-            for replication in replications:
-                for day_type in day_types:
-                    self.run(
-                        day_type,
-                        scenario=scenario,
-                        replication=replication,
-                    ).remove()
+            for sensitivity_case in sensitivity_cases:
+                for replication in replications:
+                    for day_type in day_types:
+                        self.run(
+                            day_type,
+                            scenario=scenario,
+                            sensitivity_case=sensitivity_case,
+                            replication=replication,
+                        ).remove()
 
         self._runs = {}
 

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -41,6 +41,7 @@ from .run_state import RunState
 from mobility.transport.costs.transport_costs import TransportCosts
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.runtime.assets.input_hashing import hash_inputs
+from mobility.runtime.parameter_values import SensitivityCase
 from mobility.activities import Activity
 from mobility.surveys import SurveyPlanAssets
 from mobility.surveys.mobility_survey import MobilitySurvey
@@ -73,11 +74,17 @@ class Run(FileAsset):
         is_weekday: bool,
         enabled: bool = True,
         scenario: str,
+        sensitivity_case: SensitivityCase | None = None,
         replication: int = 0,
     ) -> None:
         """Initialize a single weekday or weekend PopulationGroupDayTrips run."""
+        sensitivity_case_id = (
+            "base"
+            if sensitivity_case is None
+            else sensitivity_case.case_id
+        )
         run_context_inputs = {
-            "version": 17,
+            "version": 18,
             "population": population,
             "activities": activities,
             "modes": modes,
@@ -87,6 +94,7 @@ class Run(FileAsset):
             "is_weekday": is_weekday,
             "enabled": enabled,
             "scenario": scenario,
+            "sensitivity_case": sensitivity_case,
         }
         run_context_hash = hash_inputs(run_context_inputs)
         self.run_context = SimpleNamespace(
@@ -94,6 +102,7 @@ class Run(FileAsset):
             parameters=parameters,
             is_weekday=is_weekday,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
             replication=replication,
         )
         self.population = population
@@ -105,6 +114,8 @@ class Run(FileAsset):
         self.is_weekday = is_weekday
         self.enabled = enabled
         self.scenario = scenario
+        self.sensitivity_case = sensitivity_case
+        self.sensitivity_case_id = sensitivity_case_id
         self.replication = int(replication)
 
         self.transport_costs = transport_costs
@@ -126,12 +137,14 @@ class Run(FileAsset):
             modes=modes,
             parameters=parameters,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
             initial_transport_costs=IterationTransportCostsAsset(
                 is_weekday=is_weekday,
                 iteration=1,
                 base_folder=group_day_trips_folder,
                 transport_costs=transport_costs,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
                 previous_state=None,
                 n_iter_per_cost_update=parameters.run.n_iter_per_cost_update,
             ),
@@ -146,6 +159,7 @@ class Run(FileAsset):
             modes=modes,
             parameters=parameters,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
             initial_state=self.initial_iteration_state,
         )
         self.final_iteration_state = (
@@ -178,7 +192,8 @@ class Run(FileAsset):
         day_type = "weekday" if self.is_weekday else "weekend"
         label = (
             f"GroupDayTrips {day_type} "
-            f"scenario={self.scenario} repl={self.replication}"
+            f"scenario={self.scenario} sensitivity={self.sensitivity_case_id} "
+            f"repl={self.replication}"
         )
         with GroupDayTripsProgressReporter(
             label=label,
@@ -197,6 +212,7 @@ class Run(FileAsset):
         modes: List[TransportMode],
         parameters: GroupDayTripsParameters,
         scenario: str,
+        sensitivity_case: SensitivityCase | None,
         initial_state: FileAsset,
     ) -> list[IterationStateAsset]:
         """Build the content-addressed state asset chain for the run iterations."""
@@ -217,6 +233,7 @@ class Run(FileAsset):
                 base_folder=base_folder,
                 transport_costs=transport_costs,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
                 previous_state=(None if iteration_index == 1 else previous_state),
                 n_iter_per_cost_update=parameters.run.n_iter_per_cost_update,
             )
@@ -239,6 +256,7 @@ class Run(FileAsset):
                 activity_sequences=activity_sequences,
                 activities=activities,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
                 transport_zones=population.transport_zones,
                 transport_costs=resolved_transport_costs,
                 parameters=parameters,
@@ -268,6 +286,7 @@ class Run(FileAsset):
                 modes=modes,
                 parameters=parameters,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
                 cache_iteration_events=parameters.outputs.cache_iteration_events,
             )
             state_assets.append(state_asset)

--- a/mobility/trips/group_day_trips/iterations/iteration_assets.py
+++ b/mobility/trips/group_day_trips/iterations/iteration_assets.py
@@ -12,6 +12,7 @@ from mobility.activities.activity import (
     resolve_activity_arrival_time_rigidity,
     resolve_activity_parameters,
 )
+from mobility.runtime.parameter_values import SensitivityCase
 from mobility.trips.group_day_trips.core.run_state import RunState
 from mobility.trips.group_day_trips.evaluation.population_weighted_plan_steps import (
     PopulationWeightedPlanSteps,
@@ -134,6 +135,7 @@ class InitialIterationStateAsset(FileAsset):
         parameters: Any,
         scenario: str,
         initial_transport_costs: Any,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> None:
         self.population = population
         self.survey_plan_assets = survey_plan_assets
@@ -141,6 +143,7 @@ class InitialIterationStateAsset(FileAsset):
         self.modes = modes
         self.parameters = parameters
         self.scenario = scenario
+        self.sensitivity_case = sensitivity_case
         self.initial_transport_costs = initial_transport_costs
         self.initializer = PlanInitializer()
         self.population_weighted_plan_steps = PopulationWeightedPlanSteps(
@@ -152,10 +155,12 @@ class InitialIterationStateAsset(FileAsset):
             activities,
             1,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
         )
         inputs = {
-            "version": 3,
+            "version": 4,
             "is_weekday": is_weekday,
+            "sensitivity_case": sensitivity_case,
             "population": population,
             "survey_plan_assets": survey_plan_assets,
             "population_weighted_plan_steps": self.population_weighted_plan_steps,
@@ -522,12 +527,14 @@ class IterationTransportCostsAsset(FileAsset):
         scenario: str,
         previous_state: FileAsset | None,
         n_iter_per_cost_update: int,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> None:
         self.is_weekday = is_weekday
         self.iteration = iteration
         self.transport_costs = transport_costs.for_iteration(
             iteration,
             scenario=scenario,
+            sensitivity_case=sensitivity_case,
         )
         self.congestion_flows = CongestionFlowsAsset(
             is_weekday=is_weekday,
@@ -539,9 +546,10 @@ class IterationTransportCostsAsset(FileAsset):
         )
         self.modes = self.transport_costs.modes
         inputs = {
-            "version": 1,
+            "version": 2,
             "is_weekday": is_weekday,
             "iteration": iteration,
+            "sensitivity_case": sensitivity_case,
             "transport_costs": self.transport_costs,
             "congestion_flows": self.congestion_flows,
         }
@@ -628,6 +636,7 @@ class IterationStateAsset(FileAsset):
         parameters: Any,
         scenario: str,
         cache_iteration_events: bool,
+        sensitivity_case: SensitivityCase | None = None,
     ) -> None:
         self.previous_state = previous_state
         self.seeds = seeds
@@ -640,12 +649,14 @@ class IterationStateAsset(FileAsset):
         self.modes = modes
         self.parameters = parameters
         self.scenario = scenario
+        self.sensitivity_case = sensitivity_case
         self.cache_iteration_events = cache_iteration_events
         self.updater = PlanUpdater()
         inputs = {
-            "version": 3,
+            "version": 4,
             "is_weekday": is_weekday,
             "iteration": iteration,
+            "sensitivity_case": sensitivity_case,
             "previous_state": previous_state,
             "seeds": seeds,
             "activity_sequences": activity_sequences,
@@ -658,11 +669,13 @@ class IterationStateAsset(FileAsset):
                 activities,
                 iteration,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
             ),
             "arrival_time_rigidity_by_activity": resolve_activity_arrival_time_rigidity(
                 activities,
                 iteration,
                 scenario=scenario,
+                sensitivity_case=sensitivity_case,
             ),
             "plan_update_parameters": parameters.plan_update,
             "behavior_change_scope": parameters.behavior_change.scope_at(iteration),

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -13,6 +13,7 @@ from .debug_logs import (
 from .stable_key_index import StableKeyIndex
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities.activity import resolve_activity_parameters
+from mobility.runtime.parameter_values import SensitivityCase
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
 
 class DestinationSequences(FileAsset):
@@ -45,6 +46,7 @@ class DestinationSequences(FileAsset):
         activities: list[Any] | None = None,
         resolved_activity_parameters: dict[str, Any] | None = None,
         scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
         transport_zones: Any = None,
         transport_costs: Any = None,
         current_plans: pl.DataFrame | None = None,
@@ -68,12 +70,14 @@ class DestinationSequences(FileAsset):
                     activities,
                     iteration,
                     scenario=scenario,
+                    sensitivity_case=sensitivity_case,
                 )
                 if activities is not None
                 else None
             )
         )
         self.scenario = scenario
+        self.sensitivity_case = sensitivity_case
         self.transport_zones = transport_zones
         self.transport_costs = transport_costs
         self.current_plans = current_plans
@@ -84,9 +88,10 @@ class DestinationSequences(FileAsset):
         self.parameters = parameters
         self.seed = seed
         inputs = {
-            "version": 7,
+            "version": 8,
             "is_weekday": is_weekday,
             "iteration": iteration,
+            "sensitivity_case": sensitivity_case,
             "activity_sequences_asset": activity_sequences if isinstance(activity_sequences, FileAsset) else None,
             "previous_state": previous_state,
             "previous_destination_sequences": previous_destination_sequences,

--- a/mobility/trips/group_day_trips/results/assets/person_metrics.py
+++ b/mobility/trips/group_day_trips/results/assets/person_metrics.py
@@ -7,7 +7,7 @@ from mobility.trips.group_day_trips.evaluation.calibration_plan_steps import (
 )
 
 
-RESULT_COLUMNS = ["scenario", "day_type", "iteration"]
+RESULT_COLUMNS = ["scenario", "sensitivity_case", "day_type", "iteration"]
 SCOPE_COLUMNS = RESULT_COLUMNS + ["replication"]
 DEMAND_GROUP_COLUMNS = ["home_zone_id", "csp", "n_cars"]
 

--- a/mobility/trips/group_day_trips/results/assets/scoped_tables.py
+++ b/mobility/trips/group_day_trips/results/assets/scoped_tables.py
@@ -59,6 +59,7 @@ class ScopedRunTable(FileAsset):
             "scope": tuple(
                 (
                     run_context.scenario,
+                    run_context.sensitivity_case_id,
                     run_context.day_type,
                     run_context.replication,
                 )
@@ -97,6 +98,7 @@ class ScopedRunTable(FileAsset):
             scoped_tables.append(
                 table.with_columns(
                     scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                    sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
                     day_type=pl.lit(run_context.day_type, dtype=pl.String),
                     iteration=iteration_expr,
                     replication=pl.lit(run_context.replication, dtype=pl.Int32),
@@ -144,6 +146,7 @@ class ScopedRunTable(FileAsset):
                 scoped_tables.append(
                     current_plan_steps.with_columns(
                         scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
                         day_type=pl.lit(run_context.day_type, dtype=pl.String),
                         replication=pl.lit(run_context.replication, dtype=pl.Int32),
                         iteration=pl.lit(iteration, dtype=pl.Int32),
@@ -188,6 +191,7 @@ class ScopedRunTable(FileAsset):
                 scoped_tables.append(
                     table.with_columns(
                         scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
                         day_type=pl.lit(run_context.day_type, dtype=pl.String),
                         replication=pl.lit(run_context.replication, dtype=pl.Int32),
                         iteration=pl.lit(iteration, dtype=pl.Int32),
@@ -211,6 +215,7 @@ class ScopedRunTable(FileAsset):
                 .filter(pl.col("iteration").is_in(self.selected_iterations))
                 .with_columns(
                     scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                    sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
                     day_type=pl.lit(run_context.day_type, dtype=pl.String),
                     replication=pl.lit(run_context.replication, dtype=pl.Int32),
                     iteration=pl.col("iteration").cast(pl.Int32),

--- a/mobility/trips/group_day_trips/results/assets/survey_time_diagnostics.py
+++ b/mobility/trips/group_day_trips/results/assets/survey_time_diagnostics.py
@@ -253,6 +253,7 @@ def _with_result_scope(
                 scoped_tables.append(
                     plan_steps.with_columns(
                         scenario=pl.lit(scenario, dtype=pl.String),
+                        sensitivity_case=pl.lit("base", dtype=pl.String),
                         day_type=pl.lit(day_type, dtype=pl.String),
                         iteration=pl.lit(iteration, dtype=pl.Int32),
                         replication=pl.lit(replication, dtype=pl.Int64),

--- a/mobility/trips/group_day_trips/results/results.py
+++ b/mobility/trips/group_day_trips/results/results.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable
 
-from mobility.runtime.parameter_values import DEFAULT_SCENARIO
+from mobility.runtime.parameter_values import DEFAULT_SCENARIO, SensitivityCase
 from mobility.runtime.scenarios import Scenarios
 
 from .diagnostics import GroupDayTripsResultDiagnostics
@@ -19,6 +19,8 @@ class ResultRun:
 
     run: object
     scenario: str
+    sensitivity_case: SensitivityCase | None
+    sensitivity_case_id: str
     day_type: str
     replication: int
 
@@ -34,6 +36,7 @@ class GroupDayTripsResults:
         scenarios: str | list[str] | tuple[str, ...] | None,
         n_replications: int,
         scenario_manifest: Scenarios | None = None,
+        sensitivity_cases: list[SensitivityCase | None] | None = None,
         replication: int | None = None,
         replications: list[int] | range | None = None,
     ) -> None:
@@ -48,6 +51,13 @@ class GroupDayTripsResults:
         if self.scenario_manifest is not None:
             self.scenario_manifest.validate_requested(self.scenarios)
         self.n_replications = int(n_replications)
+        self.sensitivity_cases = (
+            [None]
+            if sensitivity_cases is None
+            else list(sensitivity_cases)
+        )
+        if not self.sensitivity_cases:
+            raise ValueError("GroupDayTripsResults needs at least one sensitivity case.")
         self.replications = self._validate_replications(
             replication=replication,
             replications=replications,
@@ -67,13 +77,21 @@ class GroupDayTripsResults:
                     run=self._run(
                         self.day_type,
                         scenario=scenario,
+                        sensitivity_case=sensitivity_case,
                         replication=replication,
                     ),
                     scenario=scenario,
+                    sensitivity_case=sensitivity_case,
+                    sensitivity_case_id=(
+                        "base"
+                        if sensitivity_case is None
+                        else sensitivity_case.case_id
+                    ),
                     day_type=self.day_type,
                     replication=replication,
                 )
                 for scenario in self.scenarios
+                for sensitivity_case in self.sensitivity_cases
                 for replication in self.replications
             ]
         return self._run_contexts

--- a/mobility/trips/group_day_trips/sensitivity.py
+++ b/mobility/trips/group_day_trips/sensitivity.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from typing import Any
+
+import plotly.graph_objects as go
+import polars as pl
+
+from mobility.runtime.parameter_values import (
+    SensitivityCase,
+    SensitivityValue,
+    collect_sensitivity_values,
+)
+from mobility.trips.group_day_trips.results.metrics import (
+    METRIC_SPECS,
+    GroupDayTripsResultMetrics,
+    MetricName,
+)
+from mobility.trips.group_day_trips.results.assets.person_metrics import SCOPE_COLUMNS
+
+
+class SensitivityResult:
+    """Sensitivity metric table with plotting helpers."""
+
+    def __init__(self, table: pl.DataFrame, *, metric_column: str) -> None:
+        self.table = table
+        self.metric_column = metric_column
+
+    def filter(self, *predicates, **constraints) -> "SensitivityResult":
+        """Return a filtered sensitivity result."""
+        return SensitivityResult(
+            self.table.filter(*predicates, **constraints),
+            metric_column=self.metric_column,
+        )
+
+    def plot_tornado(
+        self,
+        *,
+        value_column: str = "gap",
+        width: int = 760,
+        height: int = 460,
+    ) -> go.Figure:
+        """Plot one tornado chart from a one-row-per-case sensitivity table."""
+        values = self.table
+        if values.is_empty():
+            raise ValueError("No sensitivity rows are available to plot.")
+
+        case_counts = values.group_by("sensitivity_case").len()
+        repeated_cases = case_counts.filter(pl.col("len") > 1)
+        if not repeated_cases.is_empty():
+            raise ValueError(
+                "Tornado charts need one row per sensitivity case. "
+                "Filter the sensitivity table first, then call plot_tornado()."
+            )
+
+        plot_values = (
+            values
+            .with_columns(abs_value=pl.col(value_column).abs())
+            .sort("abs_value")
+        )
+        labels = [
+            f"{parameter} ({variation})"
+            for parameter, variation in zip(
+                plot_values["parameter"].to_list(),
+                plot_values["variation"].to_list(),
+            )
+        ]
+        fig = go.Figure()
+        fig.add_bar(
+            x=plot_values[value_column].to_list(),
+            y=labels,
+            orientation="h",
+            marker_color="#2B6CB0",
+        )
+        fig.update_layout(
+            title="Sensitivity tornado chart",
+            width=width,
+            height=height,
+            xaxis_title=value_column.replace("_", " "),
+            yaxis_title="Parameter variation",
+            template="plotly_white",
+        )
+        return fig
+
+
+class GroupDayTripsSensitivityAnalysis:
+    """Sensitivity analysis for grouped day-trip results."""
+
+    def __init__(
+        self,
+        *,
+        setup: Any,
+        scenarios: list[str],
+    ) -> None:
+        self.setup = setup
+        self.scenarios = scenarios
+        self.cases = self._collect_cases()
+        if len(self.cases) == 1:
+            raise ValueError(
+                "No sensitivity values were found. "
+                "Use mobility.SensitivityValue.values(), "
+                "mobility.SensitivityValue.relative(), or "
+                "mobility.SensitivityValue.absolute() in the setup."
+            )
+
+    def trip_count(self, **kwargs) -> SensitivityResult:
+        """Return trip-count sensitivity results."""
+        return self.metric("trip_count", **kwargs)
+
+    def travel_distance(self, **kwargs) -> SensitivityResult:
+        """Return travel-distance sensitivity results."""
+        return self.metric("travel_distance", **kwargs)
+
+    def travel_time(self, **kwargs) -> SensitivityResult:
+        """Return travel-time sensitivity results."""
+        return self.metric("travel_time", **kwargs)
+
+    def cost(self, **kwargs) -> SensitivityResult:
+        """Return generalized-cost sensitivity results."""
+        return self.metric("cost", **kwargs)
+
+    def ghg_emissions(self, **kwargs) -> SensitivityResult:
+        """Return greenhouse-gas-emission sensitivity results."""
+        return self.metric("ghg_emissions", **kwargs)
+
+    def metric(
+        self,
+        name: MetricName,
+        *,
+        day_type: str = "weekday",
+        output: str = "table",
+        **kwargs,
+    ) -> SensitivityResult | go.Figure:
+        """Return one metric compared to the base sensitivity case."""
+        if output not in {"table", "tornado"}:
+            raise ValueError('output should be either "table" or "tornado".')
+        if "reference" in kwargs or "reference_view" in kwargs:
+            raise ValueError(
+                "Sensitivity metrics already compare each variation to the base case. "
+                "Do not pass `reference` or `reference_view`."
+            )
+        if name not in METRIC_SPECS:
+            raise ValueError(
+                "Unknown metric name. Expected one of: "
+                + ", ".join(sorted(METRIC_SPECS))
+                + "."
+            )
+
+        spec = METRIC_SPECS[name]
+        by_zone = kwargs.get("by_zone")
+        by_variable = kwargs.get("by_variable")
+        normalize_by = kwargs.get("normalize_by")
+        normalize_scope = kwargs.get("normalize_scope")
+        inner_zone_residents_only = kwargs.get("inner_zone_residents_only", False)
+        iterations = kwargs.get("iterations", "last")
+        metric_column = GroupDayTripsResultMetrics._metric_column(
+            spec.quantity,
+            normalize_by,
+        )
+        results = self.setup.results(
+            day_type,
+            scenarios=self.scenarios,
+            sensitivity_cases=self.cases,
+        )
+        values = results.metrics.metric(
+            name,
+            output="table",
+            **kwargs,
+        )
+        zone_columns = GroupDayTripsResultMetrics._zone_columns(by_zone)
+        zone_column = zone_columns[0] if len(zone_columns) == 1 else None
+        variable_column = (
+            GroupDayTripsResultMetrics._variable_column(by_variable)
+            if by_variable is not None
+            else None
+        )
+        group_columns = zone_columns + ([variable_column] if variable_column is not None else [])
+        per_replication_values = results.metrics._metric_by_replication(
+            quantity=spec.quantity,
+            quantity_column=spec.quantity_column,
+            metric_column=metric_column,
+            group_columns=group_columns,
+            zone_column=zone_column,
+            normalize_by=normalize_by,
+            normalize_scope=normalize_scope,
+            inner_zone_residents_only=inner_zone_residents_only,
+            iterations=iterations,
+        )
+        table = self._with_base_gap(
+            values,
+            per_replication_values=per_replication_values,
+            metric_column=metric_column,
+        )
+        result = SensitivityResult(table, metric_column=metric_column)
+        if output == "tornado":
+            return result.plot_tornado()
+        return result
+
+    def _collect_cases(self) -> list[SensitivityCase | None]:
+        """Collect unique sensitivity cases from the setup."""
+        sensitivity_values = collect_sensitivity_values(
+            {
+                "modes": self.setup.modes,
+                "activities": self.setup.activities,
+                "parameters": self.setup.parameters,
+            }
+        )
+        by_name: dict[str, SensitivityValue] = {}
+        for value in sensitivity_values:
+            existing = by_name.get(value.name)
+            if existing is None:
+                by_name[value.name] = value
+                continue
+            if (
+                existing.label != value.label
+                or existing.variation_type != value.variation_type
+                or existing.variation_values != value.variation_values
+                or existing.variation_labels != value.variation_labels
+            ):
+                raise ValueError(
+                    "SensitivityValue names should be unique unless all "
+                    f"settings match. Conflicting name: {value.name!r}."
+                )
+
+        cases: list[SensitivityCase | None] = [None]
+        for name in sorted(by_name):
+            cases.extend(by_name[name].cases())
+        return cases
+
+    def _metadata(self) -> pl.DataFrame:
+        """Return display metadata for non-base sensitivity cases."""
+        rows = []
+        for case in self.cases:
+            if case is None:
+                continue
+            rows.append(
+                {
+                    "sensitivity_case": case.case_id,
+                    "parameter": case.parameter_label or case.parameter_name,
+                    "parameter_name": case.parameter_name,
+                    "variation_type": case.variation_type,
+                    "variation": case.variation_label,
+                    "variation_value": case.variation_value,
+                }
+            )
+        return pl.DataFrame(rows)
+
+    def _with_base_gap(
+        self,
+        values: pl.DataFrame,
+        *,
+        per_replication_values: pl.DataFrame,
+        metric_column: str,
+    ) -> pl.DataFrame:
+        """Compare every sensitivity case to the base case within each scenario."""
+        std_column = f"{metric_column}_std"
+        reference_column = f"{metric_column}_reference"
+        excluded_columns = {
+            "sensitivity_case",
+            metric_column,
+            std_column,
+            "n_replications",
+        }
+        join_columns = [
+            column
+            for column in values.columns
+            if column not in excluded_columns
+        ]
+        dimension_columns = [
+            column
+            for column in per_replication_values.columns
+            if column not in SCOPE_COLUMNS + [metric_column]
+        ]
+        pairing_columns = [
+            "scenario",
+            "day_type",
+            "iteration",
+            "replication",
+        ] + dimension_columns
+        paired_output_columns = [
+            "scenario",
+            "sensitivity_case",
+            "day_type",
+            "iteration",
+        ] + dimension_columns
+        base_rows = (
+            values
+            .filter(pl.col("sensitivity_case") == "base")
+            .select(join_columns + [pl.col(metric_column).alias(reference_column)])
+        )
+        sensitivity_rows = values.filter(pl.col("sensitivity_case") != "base")
+        output_columns = [
+            column
+            for column in sensitivity_rows.columns
+            if column not in {"n_replications"}
+        ]
+        if "n_replications" in sensitivity_rows.columns:
+            output_columns.append("n_replications")
+
+        base_replications = (
+            per_replication_values
+            .filter(pl.col("sensitivity_case") == "base")
+            .select(pairing_columns + [pl.col(metric_column).alias(reference_column)])
+        )
+        sensitivity_replications = per_replication_values.filter(
+            pl.col("sensitivity_case") != "base"
+        )
+        paired_gaps = (
+            sensitivity_replications
+            .join(base_replications, on=pairing_columns, how="inner")
+            .with_columns(
+                paired_gap=pl.col(metric_column) - pl.col(reference_column),
+            )
+            .group_by(paired_output_columns)
+            .agg(
+                pl.col("paired_gap").mean().alias("gap"),
+                pl.col("paired_gap").std().alias("gap_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_paired_replications"),
+            )
+        )
+
+        joined = (
+            sensitivity_rows
+            .join(base_rows, on=join_columns, how="left")
+            .join(paired_gaps, on=paired_output_columns, how="left")
+            .join(self._metadata(), on="sensitivity_case", how="left")
+            .with_columns(
+                relative_gap=(
+                    pl.col("gap")
+                    / pl.col(reference_column).abs().clip(1e-12)
+                ),
+            )
+        )
+        if "n_replications" in joined.columns:
+            joined = (
+                joined
+                .with_columns(pl.col("n_paired_replications").alias("n_replications"))
+                .drop("n_paired_replications")
+            )
+
+        return joined.select(
+            [
+                "scenario",
+                "sensitivity_case",
+                "parameter",
+                "parameter_name",
+                "variation",
+                "variation_type",
+                "variation_value",
+            ]
+            + [
+                column
+                for column in output_columns
+                if column not in {"scenario", "sensitivity_case"}
+            ]
+            + [reference_column, "gap", "gap_std", "relative_gap"]
+        )

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -11,9 +11,11 @@ from shapely.geometry import Polygon
 
 from mobility.reports import TransportZoneMaps
 from mobility.runtime import Scenario, Scenarios
+from mobility.runtime.parameter_values import SensitivityCase, SensitivityValue
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.trips.group_day_trips.core.group_day_trips import PopulationGroupDayTrips
 from mobility.trips.group_day_trips.results import GroupDayTripsResults
+from mobility.trips.group_day_trips.sensitivity import GroupDayTripsSensitivityAnalysis
 from mobility.trips.group_day_trips.results.plots import (
     plot_metric_by_zone,
     plot_metric_grid_by_zone,
@@ -169,7 +171,14 @@ def _run_factory(base_folder: Path):
         },
     )
 
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+    def run(
+        day_type: str,
+        *,
+        scenario: str | None = None,
+        sensitivity_case=None,
+        replication: int = 0,
+    ):
+        sensitivity_case_id = "base" if sensitivity_case is None else sensitivity_case.case_id
         scenario_distance_shift = 3.0 if scenario == "test" else 0.0
         demand_groups = pl.DataFrame(
             {
@@ -233,7 +242,7 @@ def _run_factory(base_folder: Path):
         )
         return _FakeRun(
             base_folder=base_folder,
-            name=f"{scenario}-{day_type}-{replication}",
+            name=f"{scenario}-{sensitivity_case_id}-{day_type}-{replication}",
             plan_steps=plan_steps,
             demand_groups=demand_groups,
             costs=costs,
@@ -355,7 +364,71 @@ def test_results_object_no_longer_accepts_iterations(tmp_path, monkeypatch):
             scenarios="default",
             iterations=[1, 2],
             n_replications=2,
-        )
+    )
+
+
+def test_sensitivity_metric_compares_cases_to_base(tmp_path, monkeypatch):
+    """Check sensitivity metrics keep scenario and compare each case to base."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    base_factory = _run_factory(tmp_path)
+
+    def run(day_type: str, *, scenario: str | None = None, sensitivity_case=None, replication: int = 0):
+        fake_scenario = scenario
+        if sensitivity_case is not None:
+            fake_scenario = f"{scenario}-{sensitivity_case.case_id}"
+        run_asset = base_factory(day_type, scenario=fake_scenario, replication=replication)
+        if sensitivity_case is not None:
+            run_asset.frames["plan_steps"] = run_asset.frames["plan_steps"].with_columns(
+                pl.when(pl.col("mode") == "car")
+                .then(pl.col("distance") + 2.0)
+                .otherwise(pl.col("distance"))
+                .alias("distance")
+            )
+        return run_asset
+
+    setup = SimpleNamespace(
+        modes=[],
+        activities=[],
+        parameters={
+            "car_cost": SensitivityValue.relative(
+                1.0,
+                changes=[0.2],
+                name="car_cost",
+                label="Car cost",
+                labels=["+20%"],
+            )
+        },
+        results=lambda day_type, scenarios, sensitivity_cases: GroupDayTripsResults(
+            run=run,
+            day_type=day_type,
+            scenarios=scenarios,
+            n_replications=1,
+            sensitivity_cases=sensitivity_cases,
+        ),
+    )
+    analysis = GroupDayTripsSensitivityAnalysis(
+        setup=setup,
+        scenarios=["default"],
+    )
+    analysis.cases = [
+        None,
+        SensitivityCase(
+            case_id="car_cost_1",
+            parameter_name="car_cost",
+            parameter_label="Car cost",
+            variation_type="relative",
+            variation_value=0.2,
+            variation_label="+20%",
+        ),
+    ]
+
+    result = analysis.travel_distance(by_variable="mode")
+    car_result = result.filter(pl.col("mode") == "car").table
+
+    assert car_result["scenario"].to_list() == ["default"]
+    assert car_result["parameter"].to_list() == ["Car cost"]
+    assert car_result["variation"].to_list() == ["+20%"]
+    assert car_result["gap"].to_list() == [4.0]
 
 
 def test_result_tables_add_scope_columns(tmp_path, monkeypatch):
@@ -542,7 +615,13 @@ def test_multi_zone_grouping_rejects_normalization(tmp_path, monkeypatch):
 def test_zone_person_count_normalization_aligns_zone_id_types(tmp_path, monkeypatch):
     """Check zone normalization works when run tables store zone ids differently."""
 
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+    def run(
+        day_type: str,
+        *,
+        scenario: str | None = None,
+        sensitivity_case=None,
+        replication: int = 0,
+    ):
         demand_groups = pl.DataFrame(
             {
                 "home_zone_id": ["1", "2"],
@@ -600,7 +679,13 @@ def test_metrics_can_filter_to_inner_zone_residents(tmp_path, monkeypatch):
             super().__init__(base_folder=base_folder)
             self.frame["is_inner_zone"] = [True, False]
 
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+    def run(
+        day_type: str,
+        *,
+        scenario: str | None = None,
+        sensitivity_case=None,
+        replication: int = 0,
+    ):
         transport_zones = TransportZonesWithOuterZone(base_folder=tmp_path)
         demand_groups = pl.DataFrame(
             {
@@ -802,7 +887,13 @@ def test_external_reference_person_count_uses_reference_population(tmp_path, mon
         ),
     )
 
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+    def run(
+        day_type: str,
+        *,
+        scenario: str | None = None,
+        sensitivity_case=None,
+        replication: int = 0,
+    ):
         demand_groups = pl.DataFrame(
             {
                 "demand_group_id": [1, 2],
@@ -953,7 +1044,13 @@ def test_immobility_and_demand_group_metrics_remain_special_methods(tmp_path, mo
 def test_sparse_dimension_groups_count_missing_seed_as_zero(tmp_path, monkeypatch):
     """Check that a group missing in one seed still contributes a zero."""
 
-    def run(day_type: str, *, scenario: str | None = None, replication: int = 0):
+    def run(
+        day_type: str,
+        *,
+        scenario: str | None = None,
+        sensitivity_case=None,
+        replication: int = 0,
+    ):
         demand_groups = pl.DataFrame(
             {
                 "home_zone_id": ["z1", "z2"],

--- a/tests/back/unit/domain/group_day_trips/test_016_run_inputs.py
+++ b/tests/back/unit/domain/group_day_trips/test_016_run_inputs.py
@@ -123,7 +123,7 @@ def test_initial_state_inputs_keep_full_modes_out_of_dependencies(tmp_path, monk
     monkeypatch.setattr(
         iteration_assets,
         "resolve_activity_parameters",
-        lambda activities, iteration, scenario=None: {},
+        lambda activities, iteration, scenario=None, sensitivity_case=None: {},
     )
 
     initial_state = iteration_assets.InitialIterationStateAsset(

--- a/tests/back/unit/runtime/test_001_parameter_values.py
+++ b/tests/back/unit/runtime/test_001_parameter_values.py
@@ -1,6 +1,11 @@
 import pytest
 
-from mobility.runtime.parameter_values import ParameterValue, resolve_parameter_values
+from mobility.runtime.parameter_values import (
+    ParameterValue,
+    SensitivityCase,
+    SensitivityValue,
+    resolve_parameter_values,
+)
 
 
 def test_parameter_value_accepts_scenario_mapping_with_non_identifier_names():
@@ -67,3 +72,74 @@ def test_parameter_value_returns_deep_copied_mutable_values():
 def test_parameter_value_requires_at_least_one_scenario():
     with pytest.raises(ValueError, match="needs at least one scenario"):
         ParameterValue.by_scenario()
+
+
+def test_sensitivity_value_resolves_to_base_value_without_case():
+    value = SensitivityValue.relative(
+        3.0,
+        changes=[-0.2, 0.2],
+        name="cost_constant",
+    )
+
+    assert resolve_parameter_values(value) == 3.0
+
+
+def test_sensitivity_value_applies_matching_relative_case():
+    value = SensitivityValue.relative(
+        3.0,
+        changes=[-0.2, 0.2],
+        name="cost_constant",
+    )
+    case = value.cases()[1]
+
+    assert resolve_parameter_values(value, sensitivity_case=case) == pytest.approx(3.6)
+
+
+def test_sensitivity_value_ignores_non_matching_case():
+    value = SensitivityValue.absolute(
+        3.0,
+        changes=[-1.0, 1.0],
+        name="cost_constant",
+    )
+    other_case = SensitivityCase(
+        case_id="other_1",
+        parameter_name="other",
+        variation_type="absolute",
+        variation_value=10.0,
+    )
+
+    assert resolve_parameter_values(value, sensitivity_case=other_case) == 3.0
+
+
+def test_sensitivity_value_rejects_wrapping_parameter_value():
+    with pytest.raises(ValueError, match="inside the relevant ParameterValue"):
+        SensitivityValue.relative(
+            ParameterValue.by_scenario(default=1.0, carbon_tax=2.0),
+            changes=[-0.2, 0.2],
+            name="carbon_tax",
+        )
+
+
+def test_sensitivity_value_inside_scenario_iteration_value():
+    value = ParameterValue.by_scenario_and_iteration(
+        default=0.0,
+        carbon_tax={
+            1: 0.0,
+            5: SensitivityValue.relative(
+                0.12,
+                changes=[-0.2, 0.2],
+                name="pt_carbon_tax",
+                label="PT carbon tax",
+            ),
+        },
+    )
+    case = value.values_by_scenario["carbon_tax"][5].cases()[1]
+
+    assert resolve_parameter_values(value, scenario="carbon_tax", iteration=1) == 0.0
+    assert resolve_parameter_values(value, scenario="carbon_tax", iteration=5) == 0.12
+    assert resolve_parameter_values(
+        value,
+        scenario="carbon_tax",
+        iteration=5,
+        sensitivity_case=case,
+    ) == pytest.approx(0.144)


### PR DESCRIPTION
### Motivation
Transport modellers need a simple way to test how much one parameter changes model results.

The package already lets a parameter vary by scenario and iteration. This PR adds sensitivity runs as another axis of the same model run: scenario, sensitivity case, replication, day type.

A modeller can now put a sensitivity value next to the final value they want to vary. This keeps policy timing in `ParameterValue` and local variation in `SensitivityValue`.

### Changes
- Adds `mobility.SensitivityValue` with `values`, `relative`, and `absolute` constructors.
- Adds `SensitivityCase` as a run context with its own result column: `sensitivity_case`.
- Lets `ParameterValue` contain `SensitivityValue` at one scenario or iteration point.
- Rejects `SensitivityValue(ParameterValue(...))` with a clear error. The supported API puts `SensitivityValue` inside the relevant `ParameterValue` point.
- Passes `sensitivity_case` through group day trip runs, transport costs, public transport costs, destination sequences, activity parameters, and result tables.
- Adds `PopulationGroupDayTrips.sensitivity(...)` with metric methods for trip count, travel distance, travel time, cost, and GHG emissions.
- Adds sensitivity tables with the model value, base value, paired gap, paired gap standard deviation, relative gap, and parameter labels.
- Adds `plot_tornado()` on filtered sensitivity tables.

### Example
```python
cost_of_distance = mobility.ParameterValue.by_scenario_and_iteration(
    default=0.0,
    carbon_tax={
        1: 0.0,
        5: mobility.SensitivityValue.relative(
            carbon_tax()["walk/public_transport/walk"],
            changes=[-0.2, 0.2],
            name="pt_carbon_tax_cost",
            label="PT carbon tax",
        ),
    },
)

result = pop_group_day_trips.sensitivity(
    scenarios=["carbon_tax"],
).travel_distance(by_variable="mode")

fig = result.filter(pl.col("mode") == "public_transport").plot_tornado()
```

### Validation
- `mamba run -n mobility python -m py_compile ...` on the changed Python files.
- `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/runtime/test_001_parameter_values.py tests/back/unit/runtime/test_002_scenarios.py tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py tests/back/unit/domain/group_day_trips/test_005_public_api_forwarding.py tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py tests/back/unit/domain/group_day_trips/test_016_run_inputs.py`
- Result: 95 passed.
- `git diff --check`
- Import smoke test for the pushed-down sensitivity API.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

Scope of AI-assisted content: API design, implementation, tests, and PR text.

What was reviewed or changed: resolver behavior, run and result axis changes, metric gap logic, public API shape, and tests.

How it was validated: compile checks, focused unit tests, whitespace check, and an import smoke test.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior