### PR TITLE
Resolve public transport leg cost parameters by iteration

### DIFF
--- a/mobility/transport/costs/transport_costs.py
+++ b/mobility/transport/costs/transport_costs.py
@@ -6,8 +6,7 @@ import pathlib
 
 import polars as pl
 
-from mobility.runtime.assets.in_memory_asset import InMemoryAsset
-from mobility.runtime.parameter_values import SensitivityCase, resolve_parameter_values
+from mobility.runtime.parameter_values import SensitivityCase
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.costs.road_flow_manager import RoadFlowManager
@@ -66,9 +65,8 @@ class TransportCosts(FileAsset):
         """
 
         resolved_modes = [
-            self._resolve_mode_for_iteration(
-                mode,
-                iteration=iteration,
+            mode.for_iteration(
+                iteration,
                 scenario=scenario,
                 sensitivity_case=sensitivity_case,
             )
@@ -79,55 +77,6 @@ class TransportCosts(FileAsset):
             congestion=self.inputs["congestion"],
             road_flow_asset=self.inputs["road_flow_asset"],
         )
-
-    def _resolve_mode_for_iteration(
-        self,
-        mode,
-        *,
-        iteration: int,
-        scenario: str | None,
-        sensitivity_case: SensitivityCase | None,
-    ):
-        """Return one mode with iteration and scenario values resolved."""
-        for_iteration = getattr(mode, "for_iteration", None)
-        if callable(for_iteration):
-            return for_iteration(
-                iteration,
-                scenario=scenario,
-                sensitivity_case=sensitivity_case,
-            )
-
-        generalized_cost = mode.inputs.get("generalized_cost")
-        if not isinstance(generalized_cost, InMemoryAsset):
-            return mode
-
-        resolved_gc_inputs = resolve_parameter_values(
-            generalized_cost.inputs,
-            scenario=scenario,
-            iteration=iteration,
-            sensitivity_case=sensitivity_case,
-        )
-        if resolved_gc_inputs == generalized_cost.inputs:
-            return mode
-
-        resolved_generalized_cost = self._copy_in_memory_asset(
-            generalized_cost,
-            resolved_gc_inputs,
-        )
-        resolved_mode_inputs = dict(mode.inputs)
-        resolved_mode_inputs["generalized_cost"] = resolved_generalized_cost
-        return self._copy_in_memory_asset(mode, resolved_mode_inputs)
-
-    @staticmethod
-    def _copy_in_memory_asset(asset: InMemoryAsset, inputs: dict):
-        """Copy an in-memory asset with new inputs and a matching input hash."""
-        clone = asset.__class__.__new__(asset.__class__)
-        clone.__dict__ = dict(asset.__dict__)
-        clone.inputs = inputs
-        clone.inputs_hash = clone.compute_inputs_hash()
-        for name, value in inputs.items():
-            setattr(clone, name, value)
-        return clone
 
     def asset_for_congestion(self, congestion: bool) -> "TransportCosts":
         """Return the transport-cost variant for a congestion flag.

--- a/mobility/transport/modes/core/transport_mode.py
+++ b/mobility/transport/modes/core/transport_mode.py
@@ -1,6 +1,7 @@
 from typing import Annotated, List
 
 from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+from mobility.runtime.parameter_values import SensitivityCase, resolve_parameter_values
 from pydantic import BaseModel, ConfigDict, Field
 
 class TransportMode(InMemoryAsset):
@@ -85,6 +86,52 @@ class TransportMode(InMemoryAsset):
             ``None`` when this mode does not directly refresh congestion.
         """
         return None
+
+    def for_iteration(
+        self,
+        iteration: int,
+        scenario: str | None = None,
+        sensitivity_case: SensitivityCase | None = None,
+    ) -> "TransportMode":
+        """Return this mode with its own parameter values resolved.
+
+        This default implementation covers simple in-memory modes such as walk,
+        bicycle, and car generalized costs. More complex modes can override it
+        when they need to rebuild child modes or other derived assets.
+        """
+        generalized_cost = self.inputs.get("generalized_cost")
+        if not isinstance(generalized_cost, InMemoryAsset):
+            return self
+
+        # Keep routing assets untouched here. They often own derived table
+        # assets, so modes that vary routing should rebuild themselves.
+        resolved_gc_inputs = resolve_parameter_values(
+            generalized_cost.inputs,
+            scenario=scenario,
+            iteration=iteration,
+            sensitivity_case=sensitivity_case,
+        )
+        if resolved_gc_inputs == generalized_cost.inputs:
+            return self
+
+        resolved_generalized_cost = self._copy_in_memory_asset(
+            generalized_cost,
+            resolved_gc_inputs,
+        )
+        resolved_inputs = dict(self.inputs)
+        resolved_inputs["generalized_cost"] = resolved_generalized_cost
+        return self._copy_in_memory_asset(self, resolved_inputs)
+
+    @staticmethod
+    def _copy_in_memory_asset(asset: InMemoryAsset, inputs: dict):
+        """Copy an in-memory asset with new inputs and a matching input hash."""
+        clone = asset.__class__.__new__(asset.__class__)
+        clone.__dict__ = dict(asset.__dict__)
+        clone.inputs = inputs
+        clone.inputs_hash = clone.compute_inputs_hash()
+        for name, value in inputs.items():
+            setattr(clone, name, value)
+        return clone
 
 class TransportModeParameters(BaseModel):
     """Common parameters for transport mode definitions."""

--- a/mobility/transport/modes/public_transport/public_transport.py
+++ b/mobility/transport/modes/public_transport/public_transport.py
@@ -166,7 +166,7 @@ class PublicTransportMode(TransportMode):
         scenario: str | None = None,
         sensitivity_case: SensitivityCase | None = None,
     ) -> "PublicTransportMode":
-        """Return a PT mode with routing parameters resolved for one iteration."""
+        """Return a PT mode with all leg parameters resolved for one iteration."""
         
         routing_parameters = self.inputs["travel_costs"].inputs["parameters"]
         resolved_routing_parameters = resolve_parameter_values(
@@ -182,10 +182,22 @@ class PublicTransportMode(TransportMode):
             iteration=iteration,
             sensitivity_case=sensitivity_case,
         )
+        resolved_first_leg_mode = self.first_leg_mode.for_iteration(
+            iteration,
+            scenario=scenario,
+            sensitivity_case=sensitivity_case,
+        )
+        resolved_last_leg_mode = self.last_leg_mode.for_iteration(
+            iteration,
+            scenario=scenario,
+            sensitivity_case=sensitivity_case,
+        )
 
         if (
             resolved_routing_parameters == routing_parameters
             and resolved_mid_parameters == generalized_cost.inputs["mid_parameters"]
+            and resolved_first_leg_mode is self.first_leg_mode
+            and resolved_last_leg_mode is self.last_leg_mode
         ):
             return self
 
@@ -193,8 +205,8 @@ class PublicTransportMode(TransportMode):
 
         return PublicTransportMode(
             transport_zones=travel_costs.inputs["transport_zones"],
-            first_leg_mode=self.first_leg_mode,
-            last_leg_mode=self.last_leg_mode,
+            first_leg_mode=resolved_first_leg_mode,
+            last_leg_mode=resolved_last_leg_mode,
             first_intermodal_transfer=travel_costs.inputs["first_modal_transfer"],
             last_intermodal_transfer=travel_costs.inputs["last_modal_transfer"],
             routing_parameters=resolved_routing_parameters,

--- a/tests/back/unit/domain/transport_modes/test_003_public_transport_mode.py
+++ b/tests/back/unit/domain/transport_modes/test_003_public_transport_mode.py
@@ -1,0 +1,95 @@
+from mobility.runtime.assets.in_memory_asset import InMemoryAsset
+from mobility.runtime.parameter_values import ParameterValue
+from mobility.transport.costs.parameters.generalized_cost_parameters import (
+    GeneralizedCostParameters,
+)
+from mobility.transport.modes.core.transport_mode import TransportMode
+from mobility.transport.modes.public_transport import public_transport as pt_module
+
+
+def _fake_public_transport_travel_costs(**inputs):
+    """Return a small PT travel-cost asset for constructor-only tests."""
+    return InMemoryAsset(inputs)
+
+
+def _fake_public_transport_generalized_cost(
+    travel_costs,
+    first_leg_mode_name,
+    last_leg_mode_name,
+    start_parameters,
+    mid_parameters,
+    last_parameters,
+):
+    """Return a small PT generalized-cost asset with resolved leg parameters."""
+    return InMemoryAsset(
+        {
+            "travel_costs": travel_costs,
+            "first_leg_mode_name": first_leg_mode_name,
+            "last_leg_mode_name": last_leg_mode_name,
+            "start_parameters": start_parameters,
+            "mid_parameters": mid_parameters,
+            "last_parameters": last_parameters,
+        }
+    )
+
+
+def test_public_transport_for_iteration_resolves_walk_leg_parameters(monkeypatch):
+    """Check that PT resolves scenario values owned by access and egress modes."""
+    monkeypatch.setattr(
+        pt_module,
+        "PublicTransportTravelCosts",
+        _fake_public_transport_travel_costs,
+    )
+    monkeypatch.setattr(
+        pt_module,
+        "PublicTransportGeneralizedCost",
+        _fake_public_transport_generalized_cost,
+    )
+
+    walk_distance_cost = ParameterValue.by_scenario_and_iteration(
+        {
+            "default": {1: 0.0},
+            "paid_walk": {1: 0.0, 2: 0.25},
+        }
+    )
+    walk_parameters = GeneralizedCostParameters(
+        cost_of_distance=walk_distance_cost,
+    )
+    walk_travel_costs = InMemoryAsset({"parameters": {}})
+    walk_generalized_cost = InMemoryAsset(
+        {
+            "travel_costs": walk_travel_costs,
+            "parameters": walk_parameters,
+        }
+    )
+    walk_mode = TransportMode(
+        name="walk",
+        travel_costs=walk_travel_costs,
+        generalized_cost=walk_generalized_cost,
+        ghg_intensity=0.0,
+    )
+
+    public_transport = pt_module.PublicTransportMode(
+        transport_zones="test-zones",
+        first_leg_mode=walk_mode,
+        last_leg_mode=walk_mode,
+        routing_parameters=pt_module.PublicTransportRoutingParameters(
+            gtfs_reference_date="2026-01-01",
+            gtfs_sources_folder="inputs/gtfs_sources",
+        ),
+    )
+
+    resolved_public_transport = public_transport.for_iteration(
+        iteration=2,
+        scenario="paid_walk",
+    )
+    resolved_generalized_cost = resolved_public_transport.inputs["generalized_cost"]
+
+    assert (
+        resolved_generalized_cost.inputs["start_parameters"].cost_of_distance
+        == 0.25
+    )
+    assert (
+        resolved_generalized_cost.inputs["last_parameters"].cost_of_distance
+        == 0.25
+    )


### PR DESCRIPTION
### Motivation

I reproduced a bug locally on a case study where walk costs vary by scenario and iteration.

The case study defines `walk.cost_of_distance` with `ParameterValue.by_scenario_and_iteration()`. This value should be converted to a plain number before costs are computed for one scenario and one iteration.

This worked for the public transport middle leg, but not for the walk access and egress legs in modes such as `walk/public_transport/walk`. As a result, the public transport generalized cost tried to multiply a `ParameterValue` object by the walk distance columns, instead of multiplying a number by the walk distances. The run crashed before producing the transport costs.

This PR fixes that problem for the case study by resolving the access and egress modes before rebuilding the public transport mode for one scenario and iteration.

### Changes

- Added `TransportMode.for_iteration()` as the common way to resolve generalized cost parameters owned by a mode.
- Updated `PublicTransportMode.for_iteration()` so it resolves the first and last leg modes before rebuilding the public transport mode.
- Simplified `TransportCosts.for_iteration()` so it delegates parameter resolution to each mode.
- Added a regression test for `walk/public_transport/walk` with a scenario-and-iteration walk distance cost.

This keeps the fix small: routing assets are not changed by the generic mode resolver, because routing assets often own derived graph and table assets.

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: implementation, regression test, and local review of the refactor.
- What you reviewed or changed: mode-level parameter resolution, public transport leg rebuilding, and focused tests.
- How you validated it (tests, checks, manual verification): ran `py_compile` on changed Python files and ran focused unit tests.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
