### PR TITLE
Update release CI image digest

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -13,8 +13,8 @@ jobs:
   build-artifacts:
     runs-on: ubuntu-24.04
     container:
-      # ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12
-      image: ghcr.io/mobility-team/mobility-ci@sha256:24831213265cf0bfbbabbc9a01b83b7eb6c04d6f1af5a890f3e611d6c731e22e
+      # docker manifest inspect ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12 --verbose
+      image: ghcr.io/mobility-team/mobility-ci@sha256:4a177dced973d756b16df25fac6a50f2e42be671fe278efaa5b5fbed9c288fc2
     permissions:
       contents: read
 


### PR DESCRIPTION
### Motivation

The release workflow uses a pinned CI image digest. After the package release setup was merged, the CI image was rebuilt on `main`, so the release workflow must point to the new immutable image digest before the first release.

### Changes

- update the pinned release CI image digest to the image built from current `main`
- replace the old image tag comment with the command used to check the digest

### Example (if relevant)

Not relevant; this is a release workflow maintenance change.

### AI-assisted contribution

_Select one:_
- [ ] No AI assistance
- [x] AI used for minor help only (e.g. autocomplete, small refactors)
- [ ] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
- What you reviewed or changed:
- How you validated it (tests, checks, manual verification):

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior