### PR TITLE
Fix CI download progress display

### DIFF
--- a/mobility/runtime/io/download_file.py
+++ b/mobility/runtime/io/download_file.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pathlib
 import re
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
@@ -78,12 +79,33 @@ def download_file(url, path, max_retries=3, timeout=(10, 120), raise_on_error=Tr
 
             total_size = int(response.headers.get("content-length", 0))
 
-            with Progress() as progress:
-                task = progress.add_task("[green]Downloading...", total=total_size)
-                with open(temp_path, "wb") as file:
+            # Rich progress uses a live console display. Avoid it in CI and in
+            # log mode because parallel downloads can already have a live display.
+            feedback = os.environ.get("MOBILITY_FEEDBACK")
+            feedback = feedback.lower() if feedback is not None else None
+            progress_setting = os.environ.get("MOBILITY_PROGRESS")
+            progress_setting = progress_setting.lower() if progress_setting is not None else None
+            use_rich_progress = (
+                feedback == "progress"
+                or (feedback is None and progress_setting in {"auto", "rich"})
+                or (
+                    feedback is None
+                    and progress_setting is None
+                    and not os.environ.get("CI")
+                    and sys.stderr.isatty()
+                )
+            )
+
+            with open(temp_path, "wb") as file:
+                if use_rich_progress:
+                    with Progress() as progress:
+                        task = progress.add_task("[green]Downloading...", total=total_size)
+                        for data in response.iter_content(chunk_size=chunk_size):
+                            file.write(data)
+                            progress.update(task, advance=len(data))
+                else:
                     for data in response.iter_content(chunk_size=chunk_size):
                         file.write(data)
-                        progress.update(task, advance=len(data))
 
             os.replace(temp_path, path)
             logging.info("Downloaded file to " + str(path))

--- a/tests/back/unit/test_014_download_file.py
+++ b/tests/back/unit/test_014_download_file.py
@@ -12,7 +12,10 @@ download_file_module = import_module("mobility.runtime.io.download_file")
 
 
 class _FakeProgress:
+    started_count = 0
+
     def __enter__(self):
+        type(self).started_count += 1
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -154,6 +157,46 @@ def test_download_file_uses_large_default_chunk_size(monkeypatch, tmp_path):
     assert path.read_bytes() == b"data"
     assert response.chunk_sizes == [1024 * 1024]
     assert response.closed is True
+
+
+def test_download_file_does_not_start_rich_progress_in_ci(monkeypatch, tmp_path):
+    response = _FakeResponse(
+        status_code=200,
+        chunks=[b"data"],
+        headers={"content-length": "4"},
+    )
+    _FakeProgress.started_count = 0
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("MOBILITY_FEEDBACK", raising=False)
+    monkeypatch.delenv("MOBILITY_PROGRESS", raising=False)
+    monkeypatch.setattr(download_file_module, "Progress", _FakeProgress)
+    monkeypatch.setattr(download_file_module, "request_url", lambda *args, **kwargs: response)
+
+    path = tmp_path / "file.txt"
+    result = download_file("https://example.com/file.txt", path, max_retries=0)
+
+    assert result == path
+    assert path.read_bytes() == b"data"
+    assert _FakeProgress.started_count == 0
+
+
+def test_download_file_starts_rich_progress_when_feedback_asks_for_it(monkeypatch, tmp_path):
+    response = _FakeResponse(
+        status_code=200,
+        chunks=[b"data"],
+        headers={"content-length": "4"},
+    )
+    _FakeProgress.started_count = 0
+    monkeypatch.setenv("MOBILITY_FEEDBACK", "progress")
+    monkeypatch.setattr(download_file_module, "Progress", _FakeProgress)
+    monkeypatch.setattr(download_file_module, "request_url", lambda *args, **kwargs: response)
+
+    path = tmp_path / "file.txt"
+    result = download_file("https://example.com/file.txt", path, max_retries=0)
+
+    assert result == path
+    assert path.read_bytes() == b"data"
+    assert _FakeProgress.started_count == 1
 
 
 def test_download_files_returns_paths_in_input_order(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
Main CI was failing in the minimum dependency workflow when public transport tests downloaded several GTFS files. Each download opened a Rich live progress display, and parallel downloads could overlap with another live display. Rich then raised `LiveError: Only one live display may be active at once`.

This made the test suite fail even though the download itself was valid.

### Changes
`download_file()` now only uses a Rich progress bar when Mobility is configured for progress feedback, or when it runs in an interactive non-CI console.

In CI and log mode, downloads still stream the file in chunks, but they do not start a Rich live display. This keeps CI output stable and avoids failures when several files are downloaded in parallel.

Unit tests now cover both behaviours:
- CI mode writes the downloaded file without starting Rich progress.
- Explicit progress feedback still starts Rich progress.

### Example (if relevant)
No user-facing API change.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

Scope of AI-assisted content: investigated the CI failure, changed the download progress behaviour, and added tests.

What you reviewed or changed: reviewed the CI logs, `download_file()`, and the related download tests.

How you validated it (tests, checks, manual verification):
- `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/test_014_download_file.py tests/back/integration/test_004_public_transport_costs_can_be_computed.py`
- `mamba run -n mobility python -m py_compile mobility/runtime/io/download_file.py tests/back/unit/test_014_download_file.py`

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior