### PR TITLE
Add wheel to CI build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
   "pytest>=8,<10",
   "pytest-cov>=5,<8",
   "pytest-dependency>=0.6,<1",
+  "wheel>=0.45,<1",
 ]
 
 [project.urls]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -140,6 +140,7 @@ packaging==26.0
     #   plotly
     #   pyogrio
     #   pytest
+    #   wheel
 pandas==3.0.1
     # via
     #   mobility-tools (pyproject.toml)
@@ -273,6 +274,8 @@ werkzeug==3.1.8
     # via
     #   dash
     #   flask
+wheel==0.47.0
+    # via mobility-tools (pyproject.toml)
 xyzservices==2025.11.0
     # via folium
 zipp==4.1.0


### PR DESCRIPTION
### Motivation

The manual release workflow failed while building the wheel and source archive with `--no-isolation` because the CI Python environment had `build` installed but not `wheel`.

The package metadata already declares `wheel` as a build-system requirement. Because the release workflow intentionally disables build isolation, the CI image must also include `wheel` in its preinstalled Python dependencies.

### Changes

- add `wheel` to the `dev` optional dependency group used to generate the CI Python environment
- regenerate `requirements-ci.txt` so the next CI image includes `wheel`

### Example (if relevant)

Not relevant; this fixes the release build environment.

### AI-assisted contribution

_Select one:_
- [ ] No AI assistance
- [x] AI used for minor help only (e.g. autocomplete, small refactors)
- [ ] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
- What you reviewed or changed:
- How you validated it (tests, checks, manual verification):

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior