### PR TITLE
Simplify release artifact build

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ git ls-remote https://github.com/codecov/codecov-action.git refs/tags/v5
 git ls-remote https://github.com/docker/setup-buildx-action.git refs/tags/v3
 git ls-remote https://github.com/docker/login-action.git refs/tags/v3
 git ls-remote https://github.com/docker/build-push-action.git refs/tags/v6
-git ls-remote https://github.com/actions/setup-python.git refs/tags/v3
+git ls-remote https://github.com/actions/setup-python.git refs/tags/v5
 git ls-remote https://github.com/mamba-org/setup-micromamba.git refs/tags/v1
 git ls-remote https://github.com/r-lib/actions.git refs/tags/v2
 ```
@@ -52,12 +52,5 @@ then write this in the workflow:
 
 The long value after `@` is the exact code version that GitHub Actions will run.
 The short `# v4` comment is only there to help humans know which release tag it came from.
-
-The release workflow also pins the CI container image by digest. To update it,
-inspect the manifest for the source tag and use the Linux amd64 digest:
-
-```shell
-docker manifest inspect ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12
-```
 
 Only update these pins in a reviewed pull request.

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -12,19 +12,20 @@ permissions:
 jobs:
   build-artifacts:
     runs-on: ubuntu-24.04
-    container:
-      # docker manifest inspect ghcr.io/mobility-team/mobility-ci:ubuntu-24.04-r-4.4.1-py3.12 --verbose
-      image: ghcr.io/mobility-team/mobility-ci@sha256:4a177dced973d756b16df25fac6a50f2e42be671fe278efaa5b5fbed9c288fc2
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Select Python dependencies
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tool
         run: |
-          echo "VIRTUAL_ENV=/opt/venv-ci" >> "${GITHUB_ENV}"
-          echo "/opt/venv-ci/bin" >> "${GITHUB_PATH}"
+          python -m pip install "build>=1.5,<2"
         shell: bash
 
       - name: Check tag matches package version
@@ -49,7 +50,7 @@ jobs:
 
       - name: Build wheel and source archive
         run: |
-          python -m build --wheel --sdist --outdir dist --no-isolation
+          python -m build --wheel --sdist --outdir dist
         shell: bash
 
       - name: Copy install environment files

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,15 +5,14 @@ Use this checklist when publishing a new Mobility version.
 ## Before tagging
 
 1. Merge the release pull request into `main`.
-2. Wait for the CI image workflow to publish a new image.
-3. Update the pinned CI image digest in `.github/workflows/publish-github-release.yml`.
-4. Check that `pyproject.toml` has the version you want to release.
-5. Check that PyPI Trusted Publishing is configured for:
+2. Wait for the main CI workflows to pass.
+3. Check that `pyproject.toml` has the version you want to release.
+4. Check that PyPI Trusted Publishing is configured for:
    - project: `mobility-tools`,
    - repository: `mobility-team/mobility`,
    - workflow: `publish-github-release.yml`,
    - environment: `pypi`.
-6. Check that the GitHub `pypi` environment requires reviewer approval.
+5. Check that the GitHub `pypi` environment requires reviewer approval.
 
 ## Tag the release
 


### PR DESCRIPTION
### Motivation

The release workflow used the large CI image to build package artifacts. Because that image is pinned by digest, every CI image dependency change forced a follow-up PR just to update the release workflow digest.

This made the release path harder to operate than needed. Package artifact builds only need Python and the standard Python build tool, so the release workflow can be simpler while keeping PyPI publishing protected by trusted publishing and the `pypi` environment approval.

### Changes

- remove the custom CI container from the release artifact build job
- use `actions/setup-python` with Python 3.12 for release artifact builds
- install the Python `build` tool directly in the release workflow
- build the wheel and source archive with normal build isolation
- remove release checklist steps about updating the CI image digest
- update workflow pin documentation to match the new release workflow

### Example (if relevant)

Not relevant; this changes the release workflow internals.

### AI-assisted contribution

_Select one:_
- [ ] No AI assistance
- [x] AI used for minor help only (e.g. autocomplete, small refactors)
- [ ] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
- What you reviewed or changed:
- How you validated it (tests, checks, manual verification):

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior