### PR TITLE
Check wheel resources without importing package

### DIFF
--- a/.github/scripts/check_runtime_resources.py
+++ b/.github/scripts/check_runtime_resources.py
@@ -1,26 +1,27 @@
-from importlib import metadata, resources
+from importlib import metadata
 
 
 def main():
-    resource_folder = resources.files("mobility.runtime.resources")
+    distribution = metadata.distribution("mobility-tools")
     expected_files = [
-        "osmdata_0.2.5.005.zip",
-        "gtfs/gtfs_route_types.csv",
-        "ademe/Base_Carbone_V22.0.csv",
-        "ademe/mapping.csv",
-        "surveys/entd_mode.xlsx",
+        "mobility/runtime/resources/osmdata_0.2.5.005.zip",
+        "mobility/runtime/resources/gtfs/gtfs_route_types.csv",
+        "mobility/runtime/resources/ademe/Base_Carbone_V22.0.csv",
+        "mobility/runtime/resources/ademe/mapping.csv",
+        "mobility/runtime/resources/surveys/entd_mode.xlsx",
     ]
 
+    installed_files = {str(file_path).replace("\\", "/") for file_path in distribution.files or []}
     missing_files = [
         file_path
         for file_path in expected_files
-        if not resource_folder.joinpath(file_path).is_file()
+        if file_path not in installed_files
     ]
 
     if missing_files:
         raise SystemExit(f"Missing files in wheel: {missing_files}")
 
-    print(f"Installed mobility-tools {metadata.version('mobility-tools')} from wheel.")
+    print(f"Installed mobility-tools {distribution.version} from wheel.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

The manual release workflow now builds the wheel successfully, but the packaged resource check fails after installing the wheel with `--no-deps`.

The check imported `mobility.runtime.resources`. Importing that package also imports `mobility/__init__.py`, which needs runtime dependencies such as `numpy`. The release check should only verify packaged files, so it should not import Mobility itself.

### Changes

- update `.github/scripts/check_runtime_resources.py` to inspect the installed `mobility-tools` distribution file list
- keep the wheel install step dependency-free while still checking that runtime resource files are present

### Example (if relevant)

Not relevant; this fixes a release workflow check.

### AI-assisted contribution

_Select one:_
- [ ] No AI assistance
- [x] AI used for minor help only (e.g. autocomplete, small refactors)
- [ ] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
- What you reviewed or changed:
- How you validated it (tests, checks, manual verification):

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior