### PR TITLE
Add follow-up coverage tests for country-neutral helpers

### DIFF
--- a/tests/back/unit/domain/activities/test_001_country_filtered_opportunities.py
+++ b/tests/back/unit/domain/activities/test_001_country_filtered_opportunities.py
@@ -1,8 +1,12 @@
 import pandas as pd
 import pytest
+import geopandas as gpd
+from shapely.geometry import Point
 
 from mobility.activities.leisure.leisure import LeisureActivity
+from mobility.activities.shopping.shop import ShopActivity
 from mobility.activities.shopping.shopping_opportunities import ShoppingOpportunities
+from mobility.activities.studies.study import StudyActivity
 from mobility.activities.studies.study_flows import StudyFlows
 from mobility.activities.studies.study_opportunities import StudyOpportunities
 from mobility.activities.work.countries.switzerland import SwissWorkFlows
@@ -71,6 +75,119 @@ def test_001_work_activity_uses_transport_zone_countries_and_admin_units(monkeyp
 
     assert calls == [(["zz"], ["zz-1"])]
     assert opportunities.to_pandas().to_dict("records") == [{"to": 1, "n_opp": 10.0}]
+
+
+def test_001_shopping_activity_uses_transport_zone_countries_and_admin_units(monkeypatch):
+    calls = []
+
+    class FakeShoppingOpportunities:
+        def __init__(self, countries=None, local_admin_unit_ids=None):
+            calls.append((countries, local_admin_unit_ids))
+
+        def get(self):
+            return pd.DataFrame(
+                {
+                    "local_admin_unit_id": ["zz-1", "zz-1"],
+                    "turnover": [2.0, 3.0],
+                }
+            )
+
+    monkeypatch.setattr(
+        "mobility.activities.shopping.shop.ShoppingOpportunities",
+        FakeShoppingOpportunities,
+    )
+
+    opportunities = ShopActivity().get_opportunities(FakeTransportZones())
+
+    assert calls == [(["zz"], ["zz-1"])]
+    assert opportunities.to_pandas().to_dict("records") == [{"to": 1, "n_opp": 5.0}]
+
+
+def test_001_study_activity_uses_transport_zone_countries_and_admin_units(monkeypatch):
+    calls = []
+
+    class FakeStudyOpportunities:
+        def __init__(self, countries=None, local_admin_unit_ids=None):
+            calls.append((countries, local_admin_unit_ids))
+
+        def get(self):
+            return gpd.GeoDataFrame(
+                {
+                    "local_admin_unit_id": ["zz-1", "zz-1"],
+                    "school_type": ["3", "3"],
+                    "n_students": [2.0, 4.0],
+                    "geometry": [Point(0, 0), Point(0, 0)],
+                },
+                geometry="geometry",
+                crs="EPSG:3035",
+            )
+
+    monkeypatch.setattr(
+        "mobility.activities.studies.study.StudyOpportunities",
+        FakeStudyOpportunities,
+    )
+    monkeypatch.setattr(
+        "mobility.activities.studies.study.gpd.sjoin",
+        lambda left, right, how, predicate: pd.DataFrame(
+            {
+                "school_type": ["3", "3"],
+                "n_students": [2.0, 4.0],
+                "transport_zone_id": [1, 1],
+                "local_admin_unit_id": ["zz-1", "zz-1"],
+                "country": ["zz", "zz"],
+                "weight": [0.5, 0.5],
+                "index_right": [0, 0],
+            }
+        ),
+    )
+
+    opportunities = StudyActivity().get_opportunities(FakeTransportZones())
+
+    assert calls == [(["zz"], ["zz-1"])]
+    assert opportunities.to_pandas().to_dict("records") == [{"to": 1, "n_opp": 3.0}]
+
+
+def test_001_study_activity_can_use_explicit_opportunities_and_plot_with_log_scale(monkeypatch):
+    plot_calls = []
+
+    class FakeAxes:
+        def set_axis_off(self):
+            plot_calls.append("axis-off")
+
+    def fake_plot(self, column, legend, cmap, linewidth, edgecolor, aspect):
+        plot_calls.append(
+            {
+                "column": column,
+                "values": self[column].tolist(),
+                "legend": legend,
+                "cmap": cmap,
+            }
+        )
+        return FakeAxes()
+
+    monkeypatch.setattr(gpd.GeoDataFrame, "plot", fake_plot, raising=False)
+
+    explicit_opportunities = pd.DataFrame({"to": [1], "n_opp": [3.0]})
+    opportunities = StudyActivity(opportunities=explicit_opportunities).get_opportunities(FakeTransportZones())
+
+    assert opportunities.to_pandas().to_dict("records") == [{"to": 1, "n_opp": 3.0}]
+
+    study_activity = StudyActivity()
+    transport_zones = pd.DataFrame(
+        {
+            "transport_zone_id": [1],
+            "geometry": [Point(0, 0)],
+        }
+    )
+    study_activity.plot_opportunities_map(
+        transport_zones=transport_zones,
+        opportunities=opportunities,
+        use_log=True,
+    )
+
+    assert plot_calls[0]["column"] == "log_n_opp"
+    assert plot_calls[0]["values"] == [pytest.approx(1.3862943611)]
+    assert plot_calls[1] == "axis-off"
 
 
 def test_001_leisure_activity_uses_the_transport_zone_study_area(monkeypatch):
@@ -239,3 +356,135 @@ def test_001_study_flows_use_country_priority_order_for_duplicates(tmp_path, mon
             "n_students": 20.0,
         }
     ]
+
+
+class FakeCountryOpportunities:
+    def __init__(self, payload):
+        self.payload = payload
+        self.selected_local_admin_unit_ids = None
+
+    def filter_by_local_admin_unit_id(self, local_admin_unit_ids):
+        self.selected_local_admin_unit_ids = local_admin_unit_ids
+        return self.payload
+
+
+class FakeCountryOpportunitiesData:
+    def __init__(self, payload):
+        self.opportunities = FakeCountryOpportunities(payload)
+
+
+def test_001_work_opportunities_create_and_get_asset_keeps_requested_units(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
+
+    jobs = pd.DataFrame(
+        {"n_jobs_total": [10.0]},
+        index=pd.Index(["fr-1"], name="local_admin_unit_id"),
+    )
+    active_population = pd.DataFrame(
+        {"active_pop": [4.0]},
+        index=pd.Index(["fr-1"], name="local_admin_unit_id"),
+    )
+    french_data = FakeCountryOpportunitiesData((jobs, active_population))
+    monkeypatch.setattr(
+        "mobility.activities.work.work_opportunities.available_work_data",
+        lambda: {"fr": french_data},
+    )
+
+    selected_jobs, selected_active_population = WorkOpportunities(
+        countries=["fr"],
+        local_admin_unit_ids=["fr-1"],
+    ).create_and_get_asset()
+
+    assert french_data.opportunities.selected_local_admin_unit_ids == ["fr-1"]
+    assert selected_jobs.index.tolist() == ["fr-1"]
+    assert selected_active_population.index.tolist() == ["fr-1"]
+
+
+def test_001_work_opportunities_validate_structure_reports_all_missing_parts():
+    jobs = pd.DataFrame({"wrong_column": [10.0]}, index=pd.Index(["fr-1"], name="wrong_index"))
+    active_population = pd.DataFrame({"wrong_column": [4.0]}, index=pd.Index(["fr-1"], name="wrong_index"))
+
+    with pytest.raises(ValueError, match="jobs index must be named local_admin_unit_id"):
+        WorkOpportunities.validate_opportunities("fr", jobs, active_population)
+
+
+def test_001_shopping_opportunities_create_and_get_asset_filters_invalid_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
+
+    french_data = FakeCountryOpportunitiesData(
+        pd.DataFrame(
+            {
+                "local_admin_unit_id": [None, "fr-1", "fr-2"],
+                "lon": [1.0, 2.0, 3.0],
+                "lat": [4.0, 5.0, 6.0],
+                "turnover": [100.0, 200.0, 300.0],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "mobility.activities.shopping.shopping_opportunities.available_shopping_data",
+        lambda: {"fr": french_data},
+    )
+
+    shopping = ShoppingOpportunities(
+        countries=["fr"],
+        local_admin_unit_ids=["fr-1"],
+    ).create_and_get_asset()
+
+    assert french_data.opportunities.selected_local_admin_unit_ids == ["fr-1"]
+    assert shopping["local_admin_unit_id"].tolist() == ["fr-1"]
+
+
+def test_001_shopping_opportunities_validate_structure_requires_expected_columns():
+    with pytest.raises(ValueError, match="Missing columns"):
+        ShoppingOpportunities.validate_opportunities(
+            "fr",
+            pd.DataFrame({"local_admin_unit_id": ["fr-1"], "lon": [1.0]}),
+        )
+
+
+def test_001_study_opportunities_create_and_get_asset_coerces_expected_columns(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
+
+    french_data = FakeCountryOpportunitiesData(
+        gpd.GeoDataFrame(
+            {
+                "local_admin_unit_id": [1],
+                "school_type": [3],
+                "n_students": ["12"],
+                "geometry": [Point(0, 0)],
+            },
+            geometry="geometry",
+            crs="EPSG:3035",
+        )
+    )
+    monkeypatch.setattr(
+        "mobility.activities.studies.study_opportunities.available_study_data",
+        lambda: {"fr": french_data},
+    )
+
+    schools = StudyOpportunities(
+        countries=["fr"],
+        local_admin_unit_ids=["1"],
+    ).create_and_get_asset()
+
+    assert french_data.opportunities.selected_local_admin_unit_ids == ["1"]
+    assert schools["local_admin_unit_id"].tolist() == ["1"]
+    assert schools["school_type"].tolist() == ["3"]
+    assert schools["n_students"].tolist() == [12]
+    assert schools.crs.to_epsg() == 3035
+
+
+def test_001_study_opportunities_validate_structure_requires_crs():
+    schools = gpd.GeoDataFrame(
+        {
+            "local_admin_unit_id": ["fr-1"],
+            "school_type": ["3"],
+            "n_students": [12.0],
+            "geometry": [Point(0, 0)],
+        },
+        geometry="geometry",
+    )
+
+    with pytest.raises(ValueError, match="geometry CRS is missing"):
+        StudyOpportunities.validate_opportunities("fr", schools)

--- a/tests/back/unit/domain/population/test_037_country_registry_helpers.py
+++ b/tests/back/unit/domain/population/test_037_country_registry_helpers.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from mobility.population.countries import available_legal_population, available_population_groups
+
+
+def test_population_country_registries_expose_built_in_countries(monkeypatch):
+    french_calls = []
+    swiss_calls = []
+
+    class FakeFrenchPopulationGroups:
+        def __init__(self, census_localized_individuals):
+            french_calls.append(census_localized_individuals)
+
+    class FakeSwissPopulationGroups:
+        def __init__(self, switzerland_census):
+            swiss_calls.append(switzerland_census)
+
+    monkeypatch.setattr(
+        "mobility.population.countries.FrenchPopulationGroups",
+        FakeFrenchPopulationGroups,
+    )
+    monkeypatch.setattr(
+        "mobility.population.countries.SwissPopulationGroups",
+        FakeSwissPopulationGroups,
+    )
+
+    population = SimpleNamespace(inputs={"switzerland_census": "swiss-census"})
+    registries = available_population_groups(population, "census-localized-individuals")
+
+    assert set(available_legal_population()) == {"fr", "ch"}
+    assert set(registries) == {"fr", "ch"}
+    assert french_calls == ["census-localized-individuals"]
+    assert swiss_calls == ["swiss-census"]

--- a/tests/back/unit/domain/spatial/test_002_selected_rows.py
+++ b/tests/back/unit/domain/spatial/test_002_selected_rows.py
@@ -1,0 +1,66 @@
+import pandas as pd
+
+from mobility.spatial.selected_rows import read_selected_rows
+
+
+class FakeAsset:
+    def __init__(self, rows, update_needed, cache_path="cache.parquet"):
+        self._rows = rows
+        self._update_needed = update_needed
+        self.cache_path = cache_path
+
+    def is_update_needed(self):
+        return self._update_needed
+
+    def get(self):
+        return self._rows.copy()
+
+
+def test_read_selected_rows_returns_empty_table_for_no_ids():
+    rows = pd.DataFrame({"local_admin_unit_id": ["fr-1"], "value": [1]})
+
+    selected = read_selected_rows(
+        FakeAsset(rows, update_needed=True),
+        id_column="local_admin_unit_id",
+        ids=[],
+        empty_columns=["local_admin_unit_id", "value"],
+    )
+
+    assert list(selected.columns) == ["local_admin_unit_id", "value"]
+    assert selected.empty
+
+
+def test_read_selected_rows_uses_asset_rows_when_update_is_needed():
+    rows = pd.DataFrame({"local_admin_unit_id": ["fr-1", "fr-2"], "value": [1, 2]})
+
+    selected = read_selected_rows(
+        FakeAsset(rows, update_needed=True),
+        id_column="local_admin_unit_id",
+        ids=["fr-2", "fr-2"],
+        empty_columns=["local_admin_unit_id", "value"],
+    )
+
+    assert selected.to_dict("records") == [{"local_admin_unit_id": "fr-2", "value": 2}]
+
+
+def test_read_selected_rows_falls_back_when_filtered_parquet_read_is_not_supported(monkeypatch):
+    rows = pd.DataFrame({"local_admin_unit_id": ["fr-1", "fr-2"], "value": [1, 2]})
+    read_calls = []
+
+    def fake_read_parquet(path, filters=None):
+        read_calls.append(filters)
+        if filters is not None:
+            raise TypeError("filters not supported")
+        return rows
+
+    monkeypatch.setattr("mobility.spatial.selected_rows.pd.read_parquet", fake_read_parquet)
+
+    selected = read_selected_rows(
+        FakeAsset(rows, update_needed=False),
+        id_column="local_admin_unit_id",
+        ids=["fr-2"],
+        empty_columns=["local_admin_unit_id", "value"],
+    )
+
+    assert read_calls == [[("local_admin_unit_id", "in", ["fr-2"])], None]
+    assert selected.to_dict("records") == [{"local_admin_unit_id": "fr-2", "value": 2}]


### PR DESCRIPTION
### Motivation
PR 383 introduced new country-neutral activity and population helper paths, but some of those new branches were still not covered by direct unit tests. This follow-up PR adds focused tests for the helper code that now drives shopping, study, work, population, and selected-row loading.

### Changes
This PR adds direct tests for the new country-neutral helper behavior.
It checks that work, shopping, and study activities forward country and local admin unit filters correctly.
It checks that shopping, study, and work opportunity assets validate their inputs and keep only the requested rows.
It adds tests for the population country registry helpers and the selected-row parquet fallback.
It also covers the explicit opportunities and plotting path in StudyActivity.

### Example (if relevant)
A modeller can now change or extend these helper classes with clearer test coverage on the expected inputs, filters, and validation errors.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Added focused unit tests for the country-neutral helper paths introduced earlier.
- What you reviewed or changed: Reviewed the affected activity, population, and spatial helper modules and adjusted the generated tests to keep only the relevant cases.
- How you validated it (tests, checks, manual verification): Ran the new test files directly, then reran the broader PR 383-related pytest slice and checked the targeted coverage report.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior