### PR TITLE
Fix Swiss urban unit category mapping

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.12"
 

--- a/mobility/spatial/switzerland.py
+++ b/mobility/spatial/switzerland.py
@@ -13,7 +13,7 @@ class SwissLocalAdminUnitsCategories(FileAsset):
     """Swiss municipality categories used by the shared local-admin-units file."""
 
     def __init__(self):
-        inputs = {}
+        inputs = {"cache_version": 2}
         cache_path = (
             pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"])
             / "bfs"
@@ -44,19 +44,32 @@ class SwissLocalAdminUnitsCategories(FileAsset):
         categories = categories.iloc[:, [0, 2]]
         categories.columns = ["local_admin_unit_id", "urban_unit_category"]
         categories["local_admin_unit_id"] = "ch-" + categories["local_admin_unit_id"].astype(str)
-        categories["urban_unit_category"] = categories["urban_unit_category"].map(
+
+        # The stable part of the BFS typology is the numeric code in parentheses.
+        # The French wording can change slightly between source files.
+        type_codes = categories["urban_unit_category"].astype(str).str.extract(r"\((\d{2})\)", expand=False)
+        categories["urban_unit_category"] = type_codes.map(
             {
-                "Commune urbaine d’une grande agglomération (11)": "C",
-                "Commune urbaine d'une agglomération moyenne (12)": "C",
-                "Commune urbaine d’une petite ou hors agglomération (13)": "I",
-                "Commune périurbaine de forte densité (21)": "B",
-                "Commune périurbaine de moyenne densité (22)": "B",
-                "Commune périurbaine de faible densité (23)": "B",
-                "Commune d’un centre rural (31)": "R",
-                "Commune rurale en situation centrale (32)": "R",
-                "Commune rurale périphérique (33)": "R",
+                "11": "C",
+                "12": "C",
+                "13": "I",
+                "21": "B",
+                "22": "B",
+                "23": "B",
+                "31": "R",
+                "32": "R",
+                "33": "R",
             }
         )
+        unknown_categories = categories.loc[
+            categories["urban_unit_category"].isna(),
+            "local_admin_unit_id",
+        ].tolist()
+        if unknown_categories:
+            raise ValueError(
+                "No Swiss urban unit category could be read for local admin units: "
+                f"{sorted(unknown_categories)}."
+            )
 
         categories.to_parquet(self.cache_path)
         return categories

--- a/tests/back/unit/domain/spatial/test_001_admin_units.py
+++ b/tests/back/unit/domain/spatial/test_001_admin_units.py
@@ -11,6 +11,7 @@ from mobility.spatial.admin_units import FrenchAdminUnits
 from mobility.spatial.local_admin_units import LocalAdminUnits
 from mobility.spatial.local_admin_units_categories import LocalAdminUnitsCategories
 from mobility.spatial.study_area import StudyArea
+from mobility.spatial.switzerland import SwissLocalAdminUnitsCategories
 
 
 def test_001_admin_express_dataset_requires_expected_extracted_files(tmp_path, monkeypatch):
@@ -173,6 +174,49 @@ def test_001_local_admin_unit_categories_load_selected_ids(tmp_path, monkeypatch
     assert set(categories["local_admin_unit_id"]) == {"fr-75056", "ch-6621"}
     assert FakeFrenchCategories.requested_ids == [("ch-6621", "fr-75056")]
     assert FakeSwissCategories.requested_ids == [("ch-6621", "fr-75056")]
+
+
+def test_001_swiss_local_admin_unit_categories_use_bfs_type_codes(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
+
+    def fake_download_file(url, file_path):
+        return pathlib.Path(file_path)
+
+    def fake_read_excel(file_path, skiprows, skipfooter):
+        return pd.DataFrame(
+            {
+                "bfs_id": [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
+                "unused": [""] * 9,
+                "typology": [
+                    "Urban wording can vary (11)",
+                    "Urban wording with another apostrophe (12)",
+                    "Small urban area wording can vary (13)",
+                    "Periurban high density wording can vary (21)",
+                    "Periurban middle density wording can vary (22)",
+                    "Periurban low density wording can vary (23)",
+                    "Rural centre wording can vary (31)",
+                    "Central rural wording can vary (32)",
+                    "Peripheral rural wording can vary (33)",
+                ],
+            }
+        )
+
+    monkeypatch.setattr("mobility.spatial.switzerland.download_file", fake_download_file)
+    monkeypatch.setattr("mobility.spatial.switzerland.pd.read_excel", fake_read_excel)
+
+    categories = SwissLocalAdminUnitsCategories().create_and_get_asset()
+
+    assert categories["urban_unit_category"].tolist() == [
+        "C",
+        "C",
+        "I",
+        "B",
+        "B",
+        "B",
+        "R",
+        "R",
+        "R",
+    ]
 
 
 def test_001_local_admin_units_loads_selected_admin_units(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation

Swiss local admin unit categories were present in the prepared BFS table, but many urban and periurban rows were saved with a missing `urban_unit_category`.

This happened because the importer matched the full French text of each BFS typology label. Small wording or apostrophe differences in the source file made the match fail. For Grand Genève, this blocked study area preparation with an error saying that no urban unit category was found for several Swiss municipalities.

The Read the Docs build also used `ubuntu-20.04`, which is no longer accepted by the Read the Docs config validator.

### Changes

This PR changes `SwissLocalAdminUnitsCategories` to read the stable BFS typology code in parentheses instead of matching the full label text.

The mapping is now based on the numeric codes:

- `11`, `12` -> `C`
- `13` -> `I`
- `21`, `22`, `23` -> `B`
- `31`, `32`, `33` -> `R`

The Swiss category asset cache version is also bumped, so existing cached files with missing category values are rebuilt.

A unit test was added to check that all Swiss BFS typology codes are mapped correctly, even when the label wording changes.

The Read the Docs build image is updated from `ubuntu-20.04` to `ubuntu-24.04` so the docs config passes validation.

### Example (if relevant)

A Grand Genève study area including Swiss municipalities such as `ch-6621` now gets valid urban unit categories instead of failing during local admin unit preparation.

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:

- Scope of AI-assisted content: investigation of the Swiss category mismatch, code change, unit test, and docs CI config fix.
- What you reviewed or changed: the Swiss BFS typology mapping now uses numeric category codes instead of full text labels, and the Read the Docs build image now uses a supported Ubuntu version.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/domain/spatial/test_001_admin_units.py`; also checked the Grand Genève Swiss ids returned no missing categories after rebuild.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior