### PR TITLE
Add a Mobility runtime Docker image

### DIFF
--- a/.github/docker/runtime/Dockerfile
+++ b/.github/docker/runtime/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ARG R_VERSION=4.4.1
+ARG UV_VERSION=0.10.9
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV R_VERSION=${R_VERSION}
+ENV RSPM=https://packagemanager.posit.co/cran/__linux__/noble/latest
+ENV RENV_CONFIG_REPOS_OVERRIDE=${RSPM}
+ENV R_LIBS_SITE=/opt/R/${R_VERSION}/lib/R/site-library
+ENV R_LIB_FOR_PAK=${R_LIBS_SITE}
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH=/opt/venv/bin:/opt/uv/bin:/opt/R/${R_VERSION}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Install the operating system tools, Python, and R with one Ubuntu toolchain.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    gdebi-core \
+    git \
+    gnupg \
+    osmium-tool \
+    python3.12 \
+    python3.12-venv \
+    sudo \
+    && curl -fsSL -o /tmp/r.deb "https://cdn.posit.co/r/ubuntu-2404/pkgs/r-${R_VERSION}_1_$(dpkg --print-architecture).deb" \
+    && gdebi --non-interactive /tmp/r.deb \
+    && ln -sf "/opt/R/${R_VERSION}/bin/R" /usr/local/bin/R \
+    && ln -sf "/opt/R/${R_VERSION}/bin/Rscript" /usr/local/bin/Rscript \
+    && python3.12 -m venv /opt/uv \
+    && /opt/uv/bin/pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && python3.12 -m venv /opt/venv \
+    && rm -rf /var/lib/apt/lists/* /tmp/r.deb
+
+# Copy dependency metadata first so Docker can reuse these layers.
+COPY DESCRIPTION /tmp/mobility-r-deps/
+
+# Install the R packages used by Mobility. pak also installs the matching
+# Ubuntu system libraries, which avoids mixing conda and system compilers.
+RUN Rscript -e "options(repos = c(CRAN = Sys.getenv('RSPM'))); install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform\$pkgType, R.Version()\$os, R.Version()\$arch)); pak::pkg_install(c('deps::/tmp/mobility-r-deps', 'any::sessioninfo'), dependencies = TRUE)" \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the Mobility package from the checked-out source for the image tag.
+COPY . /tmp/mobility-source/
+RUN uv pip install --python /opt/venv/bin/python /tmp/mobility-source \
+    && rm -rf /tmp/mobility-source
+
+WORKDIR /app
+
+CMD ["python"]

--- a/.github/workflows/build-runtime-image.yml
+++ b/.github/workflows/build-runtime-image.yml
@@ -1,0 +1,127 @@
+name: Build runtime image
+
+on:
+  push:
+    tags:
+      - "v*"
+    paths:
+      - "DESCRIPTION"
+      - "pyproject.toml"
+      - ".github/docker/runtime/Dockerfile"
+      - ".github/workflows/build-runtime-image.yml"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "DESCRIPTION"
+      - "pyproject.toml"
+      - ".github/docker/runtime/Dockerfile"
+      - ".github/workflows/build-runtime-image.yml"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish the image to GHCR"
+        required: true
+        default: false
+        type: boolean
+      run_quickstart:
+        description: "Run the full CI quickstart inside the image"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build runtime image for checks
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: .github/docker/runtime/Dockerfile
+          load: true
+          tags: mobility-runtime:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Check Python import
+        run: |
+          docker run --rm mobility-runtime:test python -c "import mobility; print(mobility.__file__)"
+        shell: bash
+
+      - name: Check Mobility setup
+        run: |
+          docker run --rm mobility-runtime:test python -c "import mobility; mobility.set_params(package_data_folder_path='/tmp/mobility-data', project_data_folder_path='/tmp/mobility-project', debug=True)"
+        shell: bash
+
+      - name: Run quickstart
+        if: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.run_quickstart) }}
+        run: |
+          docker run --rm \
+            -e MOBILITY_PACKAGE_DATA_FOLDER=/tmp/mobility-data \
+            -e MOBILITY_PROJECT_DATA_FOLDER=/tmp/mobility-project \
+            -v "${GITHUB_WORKSPACE}/examples:/app/examples:ro" \
+            -w /app \
+            mobility-runtime:test \
+            bash -lc "mkdir -p /tmp/mobility-data /tmp/mobility-project && python examples/quickstart-fr-ci.py"
+        shell: bash
+
+  publish:
+    needs: validate
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Prepare image tags
+        id: image-tags
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          minor_version="${version%.*}"
+
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/mobility-team/mobility-runtime:${version}"
+            echo "ghcr.io/mobility-team/mobility-runtime:${minor_version}"
+            echo "ghcr.io/mobility-team/mobility-runtime:sha-${GITHUB_SHA}"
+            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+              echo "ghcr.io/mobility-team/mobility-runtime:latest"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+        shell: bash
+
+      - name: Publish runtime image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: .github/docker/runtime/Dockerfile
+          push: true
+          tags: ${{ steps.image-tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -65,6 +65,45 @@ Then check that Python can import it:
 python -c "import mobility; print(mobility.__file__)"
 ```
 
+## Docker
+
+If you use Docker, you can use the Mobility runtime image instead of creating the mamba environment yourself.
+The container includes Python, R, `osmium-tool`, and the system libraries needed by Mobility.
+
+From a folder that contains your script, run one of the commands below.
+
+On macOS, Linux, WSL, or Git Bash:
+
+```shell
+docker run --rm -it \
+  -v "$PWD:/app" \
+  -w /app \
+  ghcr.io/mobility-team/mobility-runtime:0.2.0 \
+  python your_script.py
+```
+
+On Windows PowerShell:
+
+```powershell
+docker run --rm -it `
+  -v "${PWD}:/app" `
+  -w /app `
+  ghcr.io/mobility-team/mobility-runtime:0.2.0 `
+  python your_script.py
+```
+
+If you cloned the Mobility repository and want to run the French quickstart, replace `your_script.py` with `examples/quickstart-fr.py`:
+
+```shell
+docker run --rm -it \
+  -v "$PWD:/app" \
+  -w /app \
+  ghcr.io/mobility-team/mobility-runtime:0.2.0 \
+  python examples/quickstart-fr.py
+```
+
+Use Docker when you want one prepared environment and do not want to manage R packages and system libraries by hand.
+
 ## 4. Choose data folders
 
 Mobility stores downloaded and prepared data on disk. Use two folders:


### PR DESCRIPTION
### Motivation

Fixes #293.

Mobility needs a simpler Docker installation path for users who do not want to manage Python, R, and system libraries themselves.

In #293, an R package fails to compile in a Docker environment because the setup mixes conda tools with Linux system headers. A prepared Mobility image avoids this by using one consistent Linux environment.

### Changes

Adds a Mobility runtime Docker image.

The image:

- uses Ubuntu 24.04,
- installs Python, R, `osmium-tool`, and `uv`,
- installs the R packages used by Mobility with `pak`,
- installs Mobility from the checked-out package source,
- avoids conda, so the image uses one consistent Linux toolchain.

Adds a GitHub workflow to build and validate the image. The workflow checks that Mobility imports, that `mobility.set_params(...)` works, and can run the CI quickstart before publishing the image.

Updates the installation documentation with Docker commands for macOS, Linux, WSL, Git Bash, and Windows PowerShell.

### Example

```shell
docker run --rm -it \
  -v "$PWD:/app" \
  -w /app \
  ghcr.io/mobility-team/mobility-runtime:0.2.0 \
  python examples/quickstart-fr.py
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Dockerfile, GitHub workflow, and installation documentation.
- What you reviewed or changed: The Docker setup, image validation steps, publishing tags, and user-facing documentation wording.
- How you validated it (tests, checks, manual verification): Ran the quickstart drift guard and the Sphinx documentation build. Local Docker build could not run because Docker Desktop was not running.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
