### PR TITLE
Install the released package in the runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 .git
 .gitignore
 .gitattributes
+.codex/
+.agents/
+.worktrees/
+mobility.worktrees/
 
 
 # CI

--- a/.github/docker/runtime/Dockerfile
+++ b/.github/docker/runtime/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 ARG R_VERSION=4.4.1
 ARG UV_VERSION=0.10.9
+ARG MOBILITY_VERSION=0.2.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV R_VERSION=${R_VERSION}
@@ -41,10 +42,8 @@ COPY DESCRIPTION /tmp/mobility-r-deps/
 RUN Rscript -e "options(repos = c(CRAN = Sys.getenv('RSPM'))); install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform\$pkgType, R.Version()\$os, R.Version()\$arch)); pak::pkg_install(c('deps::/tmp/mobility-r-deps', 'any::sessioninfo'), dependencies = TRUE)" \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the Mobility package from the checked-out source for the image tag.
-COPY . /tmp/mobility-source/
-RUN uv pip install --python /opt/venv/bin/python /tmp/mobility-source \
-    && rm -rf /tmp/mobility-source
+# Install the released Mobility package from PyPI.
+RUN uv pip install --python /opt/venv/bin/python "mobility-tools==${MOBILITY_VERSION}"
 
 WORKDIR /app
 

--- a/.github/workflows/build-runtime-image.yml
+++ b/.github/workflows/build-runtime-image.yml
@@ -36,9 +36,27 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-24.04
+    outputs:
+      mobility_version: ${{ steps.package-version.outputs.mobility_version }}
+      mobility_minor_version: ${{ steps.package-version.outputs.mobility_minor_version }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Read package version
+        id: package-version
+        run: |
+          version="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          minor_version="${version%.*}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* && "${GITHUB_REF_NAME#v}" != "${version}" ]]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${version}."
+            exit 1
+          fi
+
+          echo "mobility_version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "mobility_minor_version=${minor_version}" >> "${GITHUB_OUTPUT}"
+        shell: bash
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -50,6 +68,8 @@ jobs:
           file: .github/docker/runtime/Dockerfile
           load: true
           tags: mobility-runtime:test
+          build-args: |
+            MOBILITY_VERSION=${{ steps.package-version.outputs.mobility_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -83,6 +103,13 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Check publish branch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "Manual image publishing must run from the main branch."
+          exit 1
+        shell: bash
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -93,21 +120,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
       - name: Prepare image tags
         id: image-tags
         run: |
-          version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
-          minor_version="${version%.*}"
-
           {
             echo "tags<<EOF"
-            echo "ghcr.io/mobility-team/mobility-runtime:${version}"
-            echo "ghcr.io/mobility-team/mobility-runtime:${minor_version}"
+            echo "ghcr.io/mobility-team/mobility-runtime:${{ needs.validate.outputs.mobility_version }}"
+            echo "ghcr.io/mobility-team/mobility-runtime:${{ needs.validate.outputs.mobility_minor_version }}"
             echo "ghcr.io/mobility-team/mobility-runtime:sha-${GITHUB_SHA}"
             if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
               echo "ghcr.io/mobility-team/mobility-runtime:latest"
@@ -123,5 +142,7 @@ jobs:
           file: .github/docker/runtime/Dockerfile
           push: true
           tags: ${{ steps.image-tags.outputs.tags }}
+          build-args: |
+            MOBILITY_VERSION=${{ needs.validate.outputs.mobility_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
### Motivation

The runtime Docker image should contain the latest released Mobility package, not the source code from the branch that built the image.

This keeps the image aligned with the package users install from PyPI and reduces what is copied into public image layers.

### Changes

The runtime Dockerfile now installs `mobility-tools==<version>` from PyPI. The workflow reads the package version from `pyproject.toml` and passes it to the Docker build.

The workflow also checks that release tags match the package version before publishing, and manual publishing is limited to the `main` branch.

The Docker ignore file now excludes local Codex and worktree folders from local build contexts.

### Example

The published image for version `0.2.0` installs:

```shell
mobility-tools==0.2.0
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: Dockerfile and GitHub workflow changes.
- What you reviewed or changed: The package installation source, publish guards, image tags, and Docker build context exclusions.
- How you validated it (tests, checks, manual verification): Ran `git diff --check`. Docker build validation will run in CI.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
