### PR TITLE
Limit runtime image validation on pull requests

### DIFF
--- a/.github/workflows/build-runtime-image.yml
+++ b/.github/workflows/build-runtime-image.yml
@@ -13,7 +13,6 @@ on:
     branches: [ "main" ]
     paths:
       - "DESCRIPTION"
-      - "pyproject.toml"
       - ".github/docker/runtime/Dockerfile"
       - ".github/workflows/build-runtime-image.yml"
   workflow_dispatch:


### PR DESCRIPTION
### Motivation

The runtime image check is useful when the Docker image changes, but it is expensive and depends on external package downloads.

Most pull requests that change `pyproject.toml` do not need to rebuild the runtime image. The image is still checked when the Dockerfile, the R dependency list, or the workflow itself changes.

### Changes

Removes `pyproject.toml` from the pull request path trigger of the runtime image workflow.

The workflow still reads `pyproject.toml` when it runs, and tag builds still include `pyproject.toml` in their path trigger.

### Example

A pull request that only changes Python package metadata no longer rebuilds the runtime Docker image.

### AI-assisted contribution

- [ ] No AI assistance
- [x] AI used for minor help only (e.g. autocomplete, small refactors)
- [ ] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content:
- What you reviewed or changed:
- How you validated it (tests, checks, manual verification):

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
