### PR TITLE
Fix missing urban unit categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.pixi
 .env
 .venv
 env/

--- a/mobility/spatial/local_admin_units.py
+++ b/mobility/spatial/local_admin_units.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import warnings
 
 import geopandas as gpd
 import pandas as pd
@@ -44,7 +45,7 @@ class LocalAdminUnits(FileAsset):
             )
 
         inputs = {
-            "cache_version": 2,
+            "version": 2,
             "countries": countries,
             "local_admin_unit_ids": local_admin_unit_ids,
             "bounds": bounds,
@@ -106,8 +107,9 @@ class LocalAdminUnits(FileAsset):
             local_admin_units["urban_unit_category"].isna()
         ]["local_admin_unit_id"].tolist()
         if missing_categories:
-            raise ValueError(
-                "No urban unit category found for local admin units: "
+            local_admin_units["urban_unit_category"] = local_admin_units["urban_unit_category"].fillna("R")
+            warnings.warn(
+                "No urban unit category found for local admin units, setting them to rural: "
                 f"{sorted(missing_categories)}."
             )
 

--- a/mobility/spatial/switzerland.py
+++ b/mobility/spatial/switzerland.py
@@ -13,12 +13,17 @@ class SwissLocalAdminUnitsCategories(FileAsset):
     """Swiss municipality categories used by the shared local-admin-units file."""
 
     def __init__(self):
-        inputs = {"cache_version": 2}
+
         cache_path = (
             pathlib.Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"])
             / "bfs"
             / "local_admin_units_categories_ch.parquet"
         )
+    
+        inputs = {
+            "version": 2
+        }
+    
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pd.DataFrame:

--- a/tests/back/unit/domain/spatial/test_001_admin_units.py
+++ b/tests/back/unit/domain/spatial/test_001_admin_units.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 import geopandas as gpd
 import pandas as pd
@@ -334,7 +335,7 @@ def test_001_local_admin_units_fails_when_selected_admin_unit_is_missing(tmp_pat
     )
     monkeypatch.setattr(LocalAdminUnitsCategories, "get_by_ids", fake_categories_get_by_ids)
 
-    with pytest.raises(ValueError, match="No local admin unit found for: ['fr-75056']."):
+    with pytest.raises(ValueError, match=re.escape("No local admin unit found for: ['fr-75056'].")):
         LocalAdminUnits(local_admin_unit_ids=["fr-75056"]).create_and_get_asset()
 
 

--- a/tests/back/unit/domain/spatial/test_001_admin_units.py
+++ b/tests/back/unit/domain/spatial/test_001_admin_units.py
@@ -325,31 +325,6 @@ def test_001_local_admin_units_fails_when_selected_admin_unit_is_missing(tmp_pat
     with pytest.raises(ValueError, match="No local admin unit found"):
         LocalAdminUnits(local_admin_unit_ids=["fr-00000"]).create_and_get_asset()
 
-
-def test_001_local_admin_units_fails_when_category_is_missing(tmp_path, monkeypatch):
-    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
-
-    class FakeAdminUnits(Asset):
-        def __init__(self, level):
-            super().__init__({"level": level, "country": "fr"})
-
-        def get_cached_hash(self):
-            return self.inputs_hash
-
-        def get(self):
-            raise AssertionError("Explicit local admin unit lists should use get_by_ids.")
-
-        def get_by_ids(self, admin_ids):
-            return gpd.GeoDataFrame(
-                {
-                    "admin_id": ["fr-75056"],
-                    "admin_name": ["Paris"],
-                    "country": ["fr"],
-                },
-                geometry=[box(0, 0, 1, 1)],
-                crs=3035,
-            )
-
     def fake_categories_get_by_ids(self, local_admin_unit_ids):
         return pd.DataFrame(columns=["local_admin_unit_id", "urban_unit_category"])
 

--- a/tests/back/unit/domain/spatial/test_001_admin_units.py
+++ b/tests/back/unit/domain/spatial/test_001_admin_units.py
@@ -339,6 +339,47 @@ def test_001_local_admin_units_fails_when_selected_admin_unit_is_missing(tmp_pat
         LocalAdminUnits(local_admin_unit_ids=["fr-75056"]).create_and_get_asset()
 
 
+def test_001_local_admin_units_warns_and_defaults_to_rural_when_category_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
+
+    class FakeAdminUnits(Asset):
+        def __init__(self, level):
+            super().__init__({"level": level, "country": "fr"})
+
+        def get_cached_hash(self):
+            return self.inputs_hash
+
+        def get(self):
+            raise AssertionError("Explicit local admin unit lists should use get_by_ids.")
+
+        def get_by_ids(self, admin_ids):
+            return gpd.GeoDataFrame(
+                {
+                    "admin_id": ["fr-75056"],
+                    "admin_name": ["Paris"],
+                    "country": ["fr"],
+                },
+                geometry=[box(0, 0, 1, 1)],
+                crs=3035,
+            )
+
+    def fake_categories_get_by_ids(self, local_admin_unit_ids):
+        assert local_admin_unit_ids == ["fr-75056"]
+        return pd.DataFrame(columns=["local_admin_unit_id", "urban_unit_category"])
+
+    monkeypatch.setattr(
+        "mobility.spatial.local_admin_units.available_admin_units",
+        lambda: {"fr": (FakeAdminUnits, "commune")},
+    )
+    monkeypatch.setattr(LocalAdminUnitsCategories, "get_by_ids", fake_categories_get_by_ids)
+
+    with pytest.warns(UserWarning, match="setting them to rural"):
+        local_admin_units = LocalAdminUnits(local_admin_unit_ids=["fr-75056"]).create_and_get_asset()
+
+    assert local_admin_units["local_admin_unit_id"].tolist() == ["fr-75056"]
+    assert local_admin_units["urban_unit_category"].tolist() == ["R"]
+
+
 def test_001_local_admin_units_loads_admin_units_near_bounds(tmp_path, monkeypatch):
     monkeypatch.setenv("MOBILITY_PACKAGE_DATA_FOLDER", str(tmp_path))
 

--- a/tests/back/unit/domain/spatial/test_001_admin_units.py
+++ b/tests/back/unit/domain/spatial/test_001_admin_units.py
@@ -334,7 +334,7 @@ def test_001_local_admin_units_fails_when_selected_admin_unit_is_missing(tmp_pat
     )
     monkeypatch.setattr(LocalAdminUnitsCategories, "get_by_ids", fake_categories_get_by_ids)
 
-    with pytest.raises(ValueError, match="No urban unit category found"):
+    with pytest.raises(ValueError, match="No local admin unit found for: ['fr-75056']."):
         LocalAdminUnits(local_admin_unit_ids=["fr-75056"]).create_and_get_asset()
 
 


### PR DESCRIPTION
### Motivation
Some cities have no urban unit category after parsing the files from BFS and INSEE.
See https://github.com/mobility-team/mobility/issues/392 for more context and details.

### Changes
This PR makes a small modification to LocalAdminUnits: instead of raising an error when finding missing urban unit categories, it warns and gives the list of city ids which do not have the info, and then proceeds to set it to "R" (rural). 

### AI-assisted contribution
- [x] No AI assistance

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
