### PR TITLE
Make runtime image publishing manual

### DIFF
--- a/.github/docker/runtime/Dockerfile
+++ b/.github/docker/runtime/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 ARG R_VERSION=4.4.1
 ARG UV_VERSION=0.10.9
-ARG MOBILITY_VERSION=0.2.0
+ARG MOBILITY_PACKAGE=mobility-tools
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV R_VERSION=${R_VERSION}
@@ -42,8 +42,8 @@ COPY DESCRIPTION /tmp/mobility-r-deps/
 RUN Rscript -e "options(repos = c(CRAN = Sys.getenv('RSPM'))); install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform\$pkgType, R.Version()\$os, R.Version()\$arch)); pak::pkg_install(c('deps::/tmp/mobility-r-deps', 'any::sessioninfo'), dependencies = TRUE)" \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the released Mobility package from PyPI.
-RUN uv pip install --python /opt/venv/bin/python "mobility-tools==${MOBILITY_VERSION}"
+# Install Mobility from PyPI. Release publishing passes an exact package version.
+RUN uv pip install --python /opt/venv/bin/python "${MOBILITY_PACKAGE}"
 
 WORKDIR /app
 

--- a/.github/workflows/build-runtime-image.yml
+++ b/.github/workflows/build-runtime-image.yml
@@ -1,14 +1,6 @@
 name: Build runtime image
 
 on:
-  push:
-    tags:
-      - "v*"
-    paths:
-      - "DESCRIPTION"
-      - "pyproject.toml"
-      - ".github/docker/runtime/Dockerfile"
-      - ".github/workflows/build-runtime-image.yml"
   pull_request:
     branches: [ "main" ]
     paths:
@@ -38,6 +30,7 @@ jobs:
     outputs:
       mobility_version: ${{ steps.package-version.outputs.mobility_version }}
       mobility_minor_version: ${{ steps.package-version.outputs.mobility_minor_version }}
+      mobility_package: ${{ steps.package-version.outputs.mobility_package }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -47,14 +40,15 @@ jobs:
         run: |
           version="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
           minor_version="${version%.*}"
+          package="mobility-tools==${version}"
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* && "${GITHUB_REF_NAME#v}" != "${version}" ]]; then
-            echo "Release tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${version}."
-            exit 1
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            package="mobility-tools"
           fi
 
           echo "mobility_version=${version}" >> "${GITHUB_OUTPUT}"
           echo "mobility_minor_version=${minor_version}" >> "${GITHUB_OUTPUT}"
+          echo "mobility_package=${package}" >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Set up Docker Buildx
@@ -68,7 +62,7 @@ jobs:
           load: true
           tags: mobility-runtime:test
           build-args: |
-            MOBILITY_VERSION=${{ steps.package-version.outputs.mobility_version }}
+            MOBILITY_PACKAGE=${{ steps.package-version.outputs.mobility_package }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -83,7 +77,7 @@ jobs:
         shell: bash
 
       - name: Run quickstart
-        if: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.run_quickstart) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.run_quickstart) }}
         run: |
           docker run --rm \
             -e MOBILITY_PACKAGE_DATA_FOLDER=/tmp/mobility-data \
@@ -96,7 +90,7 @@ jobs:
 
   publish:
     needs: validate
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
     runs-on: ubuntu-24.04
 
     steps:
@@ -127,9 +121,7 @@ jobs:
             echo "ghcr.io/mobility-team/mobility-runtime:${{ needs.validate.outputs.mobility_version }}"
             echo "ghcr.io/mobility-team/mobility-runtime:${{ needs.validate.outputs.mobility_minor_version }}"
             echo "ghcr.io/mobility-team/mobility-runtime:sha-${GITHUB_SHA}"
-            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-              echo "ghcr.io/mobility-team/mobility-runtime:latest"
-            fi
+            echo "ghcr.io/mobility-team/mobility-runtime:latest"
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
         shell: bash
@@ -142,6 +134,6 @@ jobs:
           push: true
           tags: ${{ steps.image-tags.outputs.tags }}
           build-args: |
-            MOBILITY_VERSION=${{ needs.validate.outputs.mobility_version }}
+            MOBILITY_PACKAGE=${{ needs.validate.outputs.mobility_package }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,8 +34,12 @@ Use the same version as `pyproject.toml`. For example, `version = "0.2.1"` uses 
    - `pixi.toml`,
    - `environment.yml`.
 3. Check that PyPI has the new `mobility-tools` version.
-4. Publish the draft GitHub release.
-5. Test the user Pixi install command from a temporary project folder:
+4. Run the `Build runtime image` workflow manually from `main`:
+   - set `publish` to `true`,
+   - set `run_quickstart` to `true`.
+5. Check that the GitHub container registry has the new `mobility-runtime` version.
+6. Publish the draft GitHub release.
+7. Test the user Pixi install command from a temporary project folder:
 
 ```shell
 version="v0.2.1"
@@ -45,9 +49,15 @@ pixi install
 pixi run python -c "import mobility; print(mobility.__file__)"
 ```
 
-6. Test the direct PyPI install command:
+8. Test the direct PyPI install command:
 
 ```shell
 pip install mobility-tools==0.2.1
 python -c "import mobility; print(mobility.__file__)"
+```
+
+9. Test the Docker image:
+
+```shell
+docker run --rm ghcr.io/mobility-team/mobility-runtime:0.2.1 python -c "import mobility; print(mobility.__file__)"
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -140,7 +140,7 @@ On macOS, Linux, WSL, or Git Bash:
 docker run --rm -it \
   -v "$PWD:/app" \
   -w /app \
-  ghcr.io/mobility-team/mobility-runtime:0.2.0 \
+  ghcr.io/mobility-team/mobility-runtime:0.2.1 \
   python your_script.py
 ```
 
@@ -150,7 +150,7 @@ On Windows PowerShell:
 docker run --rm -it `
   -v "${PWD}:/app" `
   -w /app `
-  ghcr.io/mobility-team/mobility-runtime:0.2.0 `
+  ghcr.io/mobility-team/mobility-runtime:0.2.1 `
   python your_script.py
 ```
 
@@ -160,7 +160,7 @@ If you cloned the Mobility repository and want to run the French quickstart, rep
 docker run --rm -it \
   -v "$PWD:/app" \
   -w /app \
-  ghcr.io/mobility-team/mobility-runtime:0.2.0 \
+  ghcr.io/mobility-team/mobility-runtime:0.2.1 \
   python examples/quickstart-fr.py
 ```
 


### PR DESCRIPTION
### Motivation
The `v0.2.1` package release and the runtime Docker image should not publish at the same time. The Docker image installs `mobility-tools` from PyPI, so the package must exist on PyPI before the image can be built and pushed reliably.

This PR makes that order explicit: first publish the Python package, then manually publish the runtime image.

### Changes
- Stop the runtime image workflow from running automatically when a release tag is pushed.
- Keep the runtime image workflow available as a manual workflow from `main`.
- Publish the manual runtime image with the version tag, minor version tag, commit SHA tag, and `latest`.
- Update the Docker examples in the installation docs to use `mobility-runtime:0.2.1`.
- Update the release checklist with the two-stage flow: publish PyPI first, then run the runtime image workflow manually.

### Example (if relevant)
After `mobility-tools==0.2.1` is available on PyPI, run the `Build runtime image` workflow manually from `main` with:

```text
publish = true
run_quickstart = true
```

Then the documented Docker command uses:

```shell
docker run --rm ghcr.io/mobility-team/mobility-runtime:0.2.1 python -c "import mobility; print(mobility.__file__)"
```

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: workflow trigger cleanup and release documentation updates.
- What you reviewed or changed: checked the runtime image workflow, removed automatic tag publishing, kept manual publishing, and updated Docker release instructions.
- How you validated it (tests, checks, manual verification): ran `git diff --check` and reviewed the final diff.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
