### PR TITLE
Add project cache cleanup registry

### DIFF
--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -20,6 +20,69 @@ Main arguments:
 
 See [installation](installation.md) for folder setup and common installation problems.
 
+### Project cache cleanup
+
+Mobility records cache files used by project scripts. This lets you preview and
+remove old tracked cache files later. In a normal Python script, tracking starts
+automatically when `mobility.set_params(...)` runs.
+
+In a notebook or interactive session, register a clear name before running the
+model:
+
+```python
+cache = mobility.ProjectCache()
+cache.register_cache_source("baseline notebook")
+```
+
+Preview cleanup:
+
+```python
+cache = mobility.ProjectCache()
+report = cache.unused_files_preview()
+print(report)
+```
+
+Delete the reported tracked cache files only when the report is clear:
+
+```python
+cache = mobility.ProjectCache()
+cache.remove_unused_files()
+```
+
+Untracked files are reported separately. In this context, untracked means not
+registered by Mobility. On older projects, this can include old Mobility cache
+files created before the registry existed, but also exports, reports, copied
+input data, or any other local file. Protect the folders you want to keep before
+using the dedicated untracked-file removal:
+
+```python
+cache = mobility.ProjectCache()
+report = cache.untracked_files_preview()
+print(report)
+cache.remove_untracked_files()
+```
+
+Useful methods:
+
+- `cache.cache_sources()`: list scripts and notebooks that keep cache files alive,
+- `cache.unused_files_preview()`: show unused tracked cache files,
+- `cache.remove_unused_files()`: remove unused tracked cache files,
+- `cache.untracked_files_preview()`: show untracked files,
+- `cache.remove_untracked_files()`: remove untracked files,
+- `cache.archive_cache_source(...)`: stop an old cache source from keeping cache files alive,
+- `cache.restore_cache_source(...)`: make an archived cache source active again,
+- `cache.protect(...)`: protect a file or folder from cleanup,
+- `cache.protected_paths()`: list protected paths,
+- `cache.unprotect(...)`: remove one protection.
+
+Removal only works inside the project data folder. Unused-file removal deletes
+registered cache files that no latest script or notebook run uses anymore.
+Untracked-file removal removes files that are not registered by Mobility and
+are not protected.
+
+Changed scripts block tracked cache cleanup until they are rerun. They do not
+block untracked-file removal.
+
 ## Study Area
 
 ### `mobility.TransportZones(...)`

--- a/docs/source/workflow.md
+++ b/docs/source/workflow.md
@@ -19,6 +19,60 @@ mobility.set_params(
 
 This tells Mobility where to store shared datasets and project cache files.
 
+### Project Cache
+
+Mobility keeps intermediate cache files in the project data folder. In a normal
+Python script, `mobility.set_params(...)` automatically records which cache
+files the script uses. You do not need to add anything else to the script.
+
+Later, you can preview a cleanup:
+
+```python
+cache = mobility.ProjectCache()
+print(cache.unused_files_preview())
+```
+
+`unused_files_preview()` never deletes files. It only shows what Mobility could remove.
+
+When the preview is clear, delete the listed tracked cache files:
+
+```python
+cache.remove_unused_files()
+```
+
+`unused_files_preview()` only looks at files registered by Mobility. An unused
+file is a registered cache file that no latest script or notebook run uses
+anymore. You can also explicitly protect folders that should never be removed:
+
+```python
+cache.protect("exports")
+cache.protect("reports")
+```
+
+In a notebook or interactive session, Mobility cannot reliably know which work
+should keep cache files alive. Give that work a clear name before running the
+model:
+
+```python
+cache = mobility.ProjectCache()
+cache.register_cache_source("baseline notebook")
+```
+
+Untracked files are handled separately. In this context, untracked means not
+registered by Mobility. On older projects, this can include old Mobility cache
+files created before the registry existed, but also exports, reports, copied
+input data, or any other local file. Protect the folders you want to keep, then
+use the dedicated untracked-file removal:
+
+```python
+print(cache.untracked_files_preview())
+cache.remove_untracked_files()
+```
+
+If a script changed since its last registered run, Mobility will not delete
+unused tracked cache files for that script. Untracked-file removal can still
+run, because those files are not linked to a registered cache source.
+
 ## 2. Define The Study Area
 
 ```python

--- a/mobility/__init__.py
+++ b/mobility/__init__.py
@@ -75,6 +75,7 @@ from .transport.modes.public_transport import (
 )
 from .transport.modes.core import IntermodalTransfer, ModeRegistry
 from .runtime.parameter_values import DEFAULT_SCENARIO, ParameterValue, SensitivityValue
+from .runtime.project_cache import ProjectCache
 from .runtime.scenarios import Scenario, Scenarios
 
 from .transport.graphs.modified.modifiers import (

--- a/mobility/config.py
+++ b/mobility/config.py
@@ -8,6 +8,7 @@ import warnings
 
 from importlib import resources
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
+from mobility.runtime.project_cache import register_current_script_if_available
 
 # This is a workaround for retained native memory after heavy Polars workloads.
 # Keep the references below so we can revisit this if upstream behavior improves:
@@ -39,6 +40,7 @@ def set_params(
     r_idle_cpu_percent=1.0,
     r_idle_memory_change_mb=1.0,
     r_cpu_check_interval_seconds=5,
+    track_project_cache=True,
 ):
     """
     Sets up the necessary environment for the Mobility package.
@@ -72,6 +74,8 @@ def set_params(
     r_idle_cpu_percent (float, optional): CPU threshold used by the R idle monitor.
     r_idle_memory_change_mb (float, optional): RAM-change threshold used by the R idle monitor.
     r_cpu_check_interval_seconds (int, optional): frequency of the R idle monitor checks.
+    track_project_cache (bool, optional): Whether Mobility should track cache
+        files used by the running script for later project-data cleanup.
     """
 
     feedback = _normalize_feedback_setting(
@@ -106,6 +110,8 @@ def set_params(
 
     setup_package_data_folder_path(package_data_folder_path)
     setup_project_data_folder_path(project_data_folder_path)
+    if track_project_cache:
+        register_current_script_if_available()
 
     install_r_packages(r_packages, r_packages_force_reinstall, r_packages_download_method)
 

--- a/mobility/runtime/assets/resolver.py
+++ b/mobility/runtime/assets/resolver.py
@@ -9,6 +9,7 @@ import networkx as nx
 
 from mobility.runtime.assets.asset import Asset
 from mobility.runtime.assets.graph import asset_graph_key, build_asset_graph
+from mobility.runtime.project_cache import record_file_asset_use
 
 
 _current_asset_resolver: ContextVar["AssetResolver | None"] = ContextVar(
@@ -165,6 +166,7 @@ class AssetResolver:
             # Mark the asset as prepared whether it was rebuilt or already
             # valid. Later reads in the same execution can skip it.
             self.prepared_asset_keys.add(dependency_asset_key)
+            record_file_asset_use(dependency_asset)
 
         return rebuilt_requested_asset_value
 

--- a/mobility/runtime/project_cache.py
+++ b/mobility/runtime/project_cache.py
@@ -1,0 +1,1037 @@
+import hashlib
+import logging
+import os
+import pathlib
+import sqlite3
+import sys
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+_active_project_ref_version: ContextVar[str | None] = ContextVar(
+    "active_project_ref_version",
+    default=None,
+)
+_active_project_ref_folder: ContextVar[str | None] = ContextVar(
+    "active_project_ref_folder",
+    default=None,
+)
+_registries_by_project_folder: dict[str, "ProjectCacheRegistry"] = {}
+_UNTRACKED_SCAN_BATCH_SIZE = 1000
+
+
+@dataclass(frozen=True)
+class ProjectCacheReport:
+    """Cleanup summary.
+
+    Modellers usually only need to print this object. The path lists are kept
+    available for notebooks that need to inspect the files before deleting them.
+    """
+
+    preview: bool
+    deleted_files: list[pathlib.Path]
+    files_to_delete: list[pathlib.Path]
+    kept_files_count: int
+    protected_files_count: int
+    protected_paths: list[pathlib.Path]
+    untracked_files_count: int
+    untracked_size_bytes: int
+    include_untracked_files: bool
+    tracked_files_to_delete_count: int
+    tracked_bytes_to_delete: int
+    untracked_files_to_delete_count: int
+    untracked_bytes_to_delete: int
+    bytes_to_delete: int
+    blockers: list[str]
+
+    def __str__(self) -> str:
+        """Return a plain-language cleanup summary."""
+        lines = []
+        if self.blockers:
+            if self.preview:
+                lines.append("Preview: no files were deleted.")
+            else:
+                lines.append("Cleanup is blocked.")
+            lines.append("Tracked cache cleanup is blocked.")
+        elif self.preview:
+            lines.append("Preview: no files were deleted.")
+        elif self.include_untracked_files:
+            lines.append(
+                f"Deleted {len(self.deleted_files)} files not registered by Mobility."
+            )
+        else:
+            lines.append(f"Deleted {len(self.deleted_files)} Mobility cache files.")
+
+        if self.blockers:
+            lines.append("")
+            lines.append(
+                "These cache sources need your attention before tracked cache "
+                "files can be deleted:"
+            )
+            lines.extend(f"- {blocker}" for blocker in self.blockers)
+            lines.append("")
+            lines.append(
+                "Run changed scripts again, or archive cache sources you no longer need."
+            )
+
+        lines.append("")
+        lines.append("Cleanup candidates:")
+        if self.include_untracked_files:
+            lines.append(
+                f"- {self.untracked_files_to_delete_count} files not registered "
+                f"by Mobility "
+                f"({format_bytes(self.untracked_bytes_to_delete)})"
+            )
+            lines.append(
+                f"Mobility will keep {self.kept_files_count} registered cache files."
+            )
+            if self.untracked_files_to_delete_count:
+                lines.append(
+                    "These files are inside the project data folder but not in "
+                    "Mobility's cache registry. On older projects, this can include "
+                    "old Mobility cache files and user files."
+                )
+                lines.append(
+                    "Review the list and protect input or output folders before "
+                    "removing them."
+                )
+        else:
+            lines.append(
+                f"- {self.tracked_files_to_delete_count} unused registered cache files "
+                f"({format_bytes(self.tracked_bytes_to_delete)})"
+            )
+            lines.append(
+                f"Mobility will keep {self.kept_files_count} registered cache files."
+            )
+
+        if self.protected_files_count:
+            lines.append(f"Skipped {self.protected_files_count} protected files.")
+        if self.protected_paths:
+            lines.append("")
+            lines.append("Protected project data:")
+            lines.extend(f"- {path}" for path in self.protected_paths)
+        if self.untracked_files_count and not self.include_untracked_files:
+            lines.append("")
+            lines.append("Files not registered by Mobility:")
+            lines.append(
+                f"- {self.untracked_files_count} files "
+                f"({format_bytes(self.untracked_size_bytes)})"
+            )
+            lines.append(
+                "These files are not in Mobility's cache registry. "
+                "They are not removed by normal cache cleanup."
+            )
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        """Show the readable report in notebooks instead of a huge path dump."""
+        return str(self)
+
+
+class ProjectCache:
+    """User-facing project-data cache tools."""
+
+    def __init__(self, project_folder: str | pathlib.Path | None = None) -> None:
+        if project_folder is None:
+            project_folder = _project_folder()
+        self._registry = _registry_for_project_folder(pathlib.Path(project_folder))
+
+    def register_cache_source(self, name: str) -> None:
+        """Register a notebook or named cache source."""
+        self._register_cache_source(name, ref_type="manual")
+
+    def _register_cache_source(self, name: str, *, ref_type: str) -> str:
+        version_id = self._registry.register_cache_source(
+            name,
+            source_type=ref_type,
+        )
+        _active_project_ref_version.set(version_id)
+        _active_project_ref_folder.set(str(self._registry.project_folder))
+        return version_id
+
+    def unused_files_preview(
+        self,
+    ) -> ProjectCacheReport:
+        """Show tracked cache files that no latest cache source uses."""
+        return self._registry.clean_project_data(
+            dry_run=True,
+            include_untracked_files=False,
+        )
+
+    def remove_unused_files(
+        self,
+    ) -> ProjectCacheReport:
+        """Delete cache files that no active cache source uses."""
+        return self._registry.clean_project_data(
+            dry_run=False,
+            include_untracked_files=False,
+        )
+
+    def untracked_files_preview(self) -> ProjectCacheReport:
+        """Show untracked project files that cleanup would delete."""
+        return self._registry.clean_project_data(
+            dry_run=True,
+            include_untracked_files=True,
+        )
+
+    def remove_untracked_files(self) -> ProjectCacheReport:
+        """Delete untracked project files."""
+        return self._registry.clean_project_data(
+            dry_run=False,
+            include_untracked_files=True,
+        )
+
+    def cache_sources(self) -> list[dict[str, Any]]:
+        """List scripts and notebooks that keep cache files alive."""
+        return self._registry.list_cache_sources()
+
+    def archive_cache_source(self, name: str) -> None:
+        """Stop one cache source from keeping cache files alive."""
+        self._registry.set_cache_source_status(name, "archived")
+
+    def restore_cache_source(self, name: str) -> None:
+        """Make one archived cache source active again."""
+        self._registry.set_cache_source_status(name, "active")
+
+    def protect(self, path: str | pathlib.Path) -> None:
+        """Protect a project-data file or folder from cleanup."""
+        self._registry.add_protected_path(path)
+
+    def unprotect(self, path: str | pathlib.Path) -> None:
+        """Remove one protected project-data path."""
+        self._registry.remove_protected_path(path)
+
+    def protected_paths(self) -> list[pathlib.Path]:
+        """Return project-data files or folders protected from cleanup."""
+        return self._registry.list_protected_paths()
+
+
+def register_current_script_if_available() -> str | None:
+    """Register the running Python script when Mobility can detect one."""
+    main_module = sys.modules.get("__main__")
+    script_path = getattr(main_module, "__file__", None)
+    if not script_path:
+        return None
+
+    path = pathlib.Path(script_path)
+    if not path.exists() or path.suffix.lower() != ".py":
+        return None
+
+    cache = ProjectCache()
+    return cache._register_cache_source(
+        str(path),
+        ref_type="script",
+    )
+
+
+def active_project_ref_version() -> str | None:
+    """Return the cache-source version currently linked to asset reads."""
+    project_folder = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+    if project_folder is None:
+        return None
+    if _active_project_ref_folder.get() != str(pathlib.Path(project_folder).resolve()):
+        return None
+    return _active_project_ref_version.get()
+
+
+def record_file_asset_use(asset: Any) -> None:
+    """Record one FileAsset in the project cache registry."""
+    project_folder = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+    if not project_folder:
+        return
+
+    registry = _registry_for_project_folder(pathlib.Path(project_folder))
+    registry.record_asset(asset, version_id=active_project_ref_version())
+
+
+def format_bytes(size_bytes: int) -> str:
+    """Format a byte count for modeller-facing reports."""
+    size = float(size_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size = size / 1024
+    return f"{size_bytes} B"
+
+
+class ProjectCacheRegistry:
+    """SQLite registry for Mobility project cache files."""
+
+    def __init__(self, project_folder: pathlib.Path) -> None:
+        self.project_folder = pathlib.Path(project_folder).resolve()
+        self.registry_folder = self.project_folder / ".mobility"
+        self.database_path = self.registry_folder / "cache.sqlite"
+        self.registry_folder.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def register_cache_source(self, name: str, *, source_type: str) -> str:
+        """Register one cache source version and return its version id."""
+        now = _now()
+        ref_type = str(source_type)
+        source_path = None
+        source_hash = None
+        ref_name = str(name)
+
+        if ref_type == "script":
+            source_path = str(pathlib.Path(name).resolve())
+            ref_name = _display_path(pathlib.Path(source_path), self.project_folder)
+            source_hash = _hash_file(pathlib.Path(source_path))
+        else:
+            source_hash = _hash_text(f"{ref_type}:{ref_name}:{now}")
+
+        ref_id = _hash_text(f"{ref_type}:{source_path or ref_name}")
+        version_id = _hash_text(f"{ref_id}:{source_hash}")
+
+        with self._connect() as con:
+            con.execute(
+                """
+                INSERT INTO project_refs (
+                    ref_id, ref_type, name, source_path, status, created_at, last_seen_at
+                )
+                VALUES (?, ?, ?, ?, 'active', ?, ?)
+                ON CONFLICT(ref_id) DO UPDATE SET
+                    name=excluded.name,
+                    source_path=excluded.source_path,
+                    last_seen_at=excluded.last_seen_at
+                """,
+                (ref_id, ref_type, ref_name, source_path, now, now),
+            )
+            con.execute(
+                """
+                INSERT INTO project_ref_versions (
+                    version_id, ref_id, source_hash, created_at, is_latest
+                )
+                VALUES (?, ?, ?, ?, 0)
+                ON CONFLICT(version_id) DO NOTHING
+                """,
+                (version_id, ref_id, source_hash, now),
+            )
+        return version_id
+
+    def record_asset(self, asset: Any, *, version_id: str | None) -> None:
+        """Record one file-backed asset and link it to the active ref version."""
+        now = _now()
+        asset_type = asset.__class__.__name__
+        inputs_hash = str(getattr(asset, "inputs_hash", ""))
+        paths = _asset_paths(asset)
+        with self._connect() as con:
+            version_marked_latest = False
+            for role, path in paths:
+                resolved = pathlib.Path(path).resolve()
+                if not _is_inside(resolved, self.project_folder):
+                    continue
+                if not resolved.is_file():
+                    continue
+                size = resolved.stat().st_size
+                asset_key = _hash_text(f"{asset_type}:{inputs_hash}:{resolved}")
+                con.execute(
+                    """
+                    INSERT INTO asset_cache_entries (
+                        path, asset_key, asset_type, inputs_hash, path_role,
+                        project_data_folder, size_bytes, first_seen_at, last_seen_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(path) DO UPDATE SET
+                        asset_key=excluded.asset_key,
+                        asset_type=excluded.asset_type,
+                        inputs_hash=excluded.inputs_hash,
+                        path_role=excluded.path_role,
+                        size_bytes=excluded.size_bytes,
+                        last_seen_at=excluded.last_seen_at
+                    """,
+                    (
+                        str(resolved),
+                        asset_key,
+                        asset_type,
+                        inputs_hash,
+                        role,
+                        str(self.project_folder),
+                        size,
+                        now,
+                        now,
+                    ),
+                )
+                if version_id is not None:
+                    if not version_marked_latest:
+                        self._mark_version_latest(con, version_id)
+                        version_marked_latest = True
+                    con.execute(
+                        """
+                        INSERT OR IGNORE INTO ref_assets (version_id, path)
+                        VALUES (?, ?)
+                        """,
+                        (version_id, str(resolved)),
+                    )
+                con.execute(
+                    "DELETE FROM untracked_project_files WHERE path=?",
+                    (str(resolved),),
+                )
+
+    def _mark_version_latest(self, con: sqlite3.Connection, version_id: str) -> None:
+        row = con.execute(
+            "SELECT ref_id FROM project_ref_versions WHERE version_id=?",
+            (version_id,),
+        ).fetchone()
+        if row is None:
+            return
+        con.execute(
+            """
+            UPDATE project_ref_versions
+            SET is_latest=0
+            WHERE ref_id=? AND version_id<>?
+            """,
+            (row["ref_id"], version_id),
+        )
+        con.execute(
+            """
+            UPDATE project_ref_versions
+            SET is_latest=1
+            WHERE version_id=?
+            """,
+            (version_id,),
+        )
+
+    def clean_project_data(
+        self,
+        *,
+        dry_run: bool,
+        include_untracked_files: bool,
+    ) -> ProjectCacheReport:
+        """Return a cleanup report and optionally delete unreferenced files."""
+        started_at = time.perf_counter()
+        logger.debug(
+            "Project cache cleanup started: project_folder=%s dry_run=%s "
+            "include_untracked_files=%s",
+            self.project_folder,
+            dry_run,
+            include_untracked_files,
+        )
+
+        # Untracked-file previews update Mobility's internal index, but never
+        # delete project files.
+        if include_untracked_files:
+            self.scan_untracked_files()
+        blockers = [] if include_untracked_files else self._cleanup_blockers()
+        protected_paths = self.list_protected_paths()
+        keep_paths = self._latest_active_ref_paths()
+        source_paths = self._cache_source_paths()
+        asset_rows = [] if include_untracked_files else self._asset_rows()
+        untracked_rows = (
+            self._untracked_file_rows()
+            if include_untracked_files
+            else []
+        )
+        project_folder_key = _resolved_path_key(self.project_folder)
+        protected_path_keys = [_resolved_path_key(path) for path in protected_paths]
+        keep_path_keys = {_stored_path_key(path) for path in keep_paths | source_paths}
+        logger.debug(
+            "Project cache cleanup loaded registry state: tracked_files=%d "
+            "kept_files=%d untracked_files=%d protected_paths=%d blockers=%d",
+            len(asset_rows),
+            len(keep_paths),
+            len(untracked_rows),
+            len(protected_paths),
+            len(blockers),
+        )
+
+        if blockers and not dry_run:
+            blocker_text = "\n".join(f"- {blocker}" for blocker in blockers)
+            raise RuntimeError(
+                "Cleanup stopped because some cache sources need attention:\n"
+                f"{blocker_text}"
+            )
+
+        files_to_delete = []
+        tracked_files_to_delete = []
+        untracked_files_to_delete = []
+        protected_files_count = 0
+        tracked_bytes_to_delete = 0
+        untracked_bytes_to_delete = 0
+        if not include_untracked_files and not blockers:
+            for path, size_bytes in asset_rows:
+                path_key = _stored_path_key(path)
+                if path_key in keep_path_keys:
+                    continue
+                if _is_protected_key(path_key, protected_path_keys):
+                    protected_files_count += 1
+                    continue
+                if not _is_inside_key(path_key, project_folder_key):
+                    continue
+                files_to_delete.append(path)
+                tracked_files_to_delete.append(path)
+                tracked_bytes_to_delete += size_bytes
+
+        if include_untracked_files:
+            filter_started_at = time.perf_counter()
+            for path, size_bytes in untracked_rows:
+                path_key = _stored_path_key(path)
+                if path_key in keep_path_keys:
+                    continue
+                if _is_protected_key(path_key, protected_path_keys):
+                    protected_files_count += 1
+                    continue
+                files_to_delete.append(path)
+                untracked_files_to_delete.append(path)
+                untracked_bytes_to_delete += size_bytes
+            logger.debug(
+                "Project cache cleanup filtered untracked files in %.2fs: "
+                "untracked_to_delete=%d protected_skipped=%d",
+                time.perf_counter() - filter_started_at,
+                len(untracked_files_to_delete),
+                protected_files_count,
+            )
+
+        deleted_files = []
+        deleted_tracked_files = []
+        deleted_untracked_files = []
+        if not dry_run:
+            tracked_delete_set = set(tracked_files_to_delete)
+            untracked_delete_set = set(untracked_files_to_delete)
+            for path in files_to_delete:
+                if path.exists() and path.is_file():
+                    path.unlink()
+                    deleted_files.append(path)
+                    if path in tracked_delete_set:
+                        deleted_tracked_files.append(path)
+                    if path in untracked_delete_set:
+                        deleted_untracked_files.append(path)
+            self._remove_tracked_files(deleted_tracked_files)
+            self._remove_untracked_files(deleted_untracked_files)
+
+        untracked_size = sum(size for _, size in untracked_rows)
+        report = ProjectCacheReport(
+            preview=dry_run,
+            deleted_files=deleted_files,
+            files_to_delete=files_to_delete,
+            kept_files_count=len(keep_paths),
+            protected_files_count=protected_files_count,
+            protected_paths=protected_paths,
+            untracked_files_count=len(untracked_rows),
+            untracked_size_bytes=untracked_size,
+            include_untracked_files=include_untracked_files,
+            tracked_files_to_delete_count=len(tracked_files_to_delete),
+            tracked_bytes_to_delete=tracked_bytes_to_delete,
+            untracked_files_to_delete_count=len(untracked_files_to_delete),
+            untracked_bytes_to_delete=untracked_bytes_to_delete,
+            bytes_to_delete=tracked_bytes_to_delete + untracked_bytes_to_delete,
+            blockers=blockers,
+        )
+        logger.debug(
+            "Project cache cleanup finished in %.2fs: tracked_to_delete=%d "
+            "untracked_to_delete=%d protected_skipped=%d deleted=%d",
+            time.perf_counter() - started_at,
+            len(tracked_files_to_delete),
+            len(untracked_files_to_delete),
+            protected_files_count,
+            len(deleted_files),
+        )
+        return report
+
+    def list_cache_sources(self) -> list[dict[str, Any]]:
+        """Return one row per cache source with computed file status."""
+        rows = []
+        with self._connect() as con:
+            for row in con.execute(
+                """
+                SELECT r.ref_id, r.ref_type, r.name, r.source_path, r.status,
+                       r.created_at AS ref_created_at,
+                       r.last_seen_at,
+                       v.source_hash,
+                       v.created_at AS version_created_at
+                FROM project_refs r
+                LEFT JOIN project_ref_versions v
+                    ON r.ref_id = v.ref_id AND v.is_latest = 1
+                ORDER BY r.name
+                """
+            ):
+                status = row["status"]
+                if status == "active" and row["ref_type"] == "script":
+                    status = self._script_status(row["source_path"], row["source_hash"])
+                rows.append(
+                    {
+                        "name": row["name"],
+                        "source_type": row["ref_type"],
+                        "source_path": row["source_path"],
+                        "status": status,
+                        "created_at": row["ref_created_at"],
+                        "last_seen_at": row["last_seen_at"],
+                        "latest_registered_at": row["version_created_at"],
+                    }
+                )
+        return rows
+
+    def set_cache_source_status(self, name: str, status: str) -> None:
+        """Set one cache source status by display name or source path."""
+        if status not in {"active", "archived"}:
+            raise ValueError("Cache source status should be 'active' or 'archived'.")
+
+        source_id = self._find_cache_source_id(name)
+        if source_id is None:
+            raise ValueError(f"Unknown cache source: {name}")
+
+        with self._connect() as con:
+            con.execute(
+                "UPDATE project_refs SET status=? WHERE ref_id=?",
+                (status, source_id),
+            )
+
+    def add_protected_path(self, path: str | pathlib.Path) -> None:
+        """Store one protected project-data path."""
+        resolved = self._resolve_project_path(path)
+        if not _is_inside(resolved, self.project_folder):
+            raise ValueError(
+                "Protected paths must be inside MOBILITY_PROJECT_DATA_FOLDER."
+            )
+        with self._connect() as con:
+            con.execute(
+                """
+                INSERT OR IGNORE INTO protected_paths (path, created_at)
+                VALUES (?, ?)
+                """,
+                (str(resolved), _now()),
+            )
+
+    def remove_protected_path(self, path: str | pathlib.Path) -> None:
+        """Remove one protected project-data path."""
+        resolved = self._resolve_project_path(path)
+        with self._connect() as con:
+            con.execute("DELETE FROM protected_paths WHERE path=?", (str(resolved),))
+
+    def list_protected_paths(self) -> list[pathlib.Path]:
+        """Return protected project-data paths."""
+        with self._connect() as con:
+            return [
+                pathlib.Path(row["path"])
+                for row in con.execute("SELECT path FROM protected_paths ORDER BY path")
+            ]
+
+    def scan_untracked_files(self) -> None:
+        """Index untracked project files without making them deletable by default."""
+        started_at = time.perf_counter()
+        scanned_files_count = 0
+        registry_files_count = 0
+        tracked_files_count = 0
+        untracked_files_count = 0
+        rows_to_upsert = []
+        now = _now()
+        registry_folder_key = _resolved_path_key(self.registry_folder)
+        logger.debug(
+            "Project cache untracked-file scan started: project_folder=%s",
+            self.project_folder,
+        )
+        with self._connect() as con:
+            self._forget_missing_untracked_files(con)
+            indexed_paths = {
+                _stored_path_key(pathlib.Path(row["path"]))
+                for row in con.execute("SELECT path FROM asset_cache_entries")
+            }
+            for file_path, size_bytes in _walk_project_files(self.project_folder):
+                scanned_files_count += 1
+                file_key = os.path.normcase(file_path)
+                if _is_inside_key(file_key, registry_folder_key):
+                    registry_files_count += 1
+                    continue
+                if file_key in indexed_paths:
+                    tracked_files_count += 1
+                    continue
+                untracked_files_count += 1
+                rows_to_upsert.append((file_path, size_bytes, now, now))
+                if len(rows_to_upsert) >= _UNTRACKED_SCAN_BATCH_SIZE:
+                    self._upsert_untracked_file_rows(con, rows_to_upsert)
+                    rows_to_upsert.clear()
+                if (
+                    logger.isEnabledFor(logging.DEBUG)
+                    and scanned_files_count % 10000 == 0
+                ):
+                    logger.debug(
+                        "Project cache untracked-file scan progress: scanned=%d "
+                        "untracked=%d tracked=%d registry=%d elapsed=%.2fs",
+                        scanned_files_count,
+                        untracked_files_count,
+                        tracked_files_count,
+                        registry_files_count,
+                        time.perf_counter() - started_at,
+                    )
+            if rows_to_upsert:
+                self._upsert_untracked_file_rows(con, rows_to_upsert)
+        logger.debug(
+            "Project cache untracked-file scan finished in %.2fs: scanned=%d "
+            "untracked=%d tracked=%d registry=%d",
+            time.perf_counter() - started_at,
+            scanned_files_count,
+            untracked_files_count,
+            tracked_files_count,
+            registry_files_count,
+        )
+
+    def _upsert_untracked_file_rows(
+        self,
+        con: sqlite3.Connection,
+        rows: list[tuple[str, int, str, str]],
+    ) -> None:
+        con.executemany(
+            """
+            INSERT INTO untracked_project_files (
+                path, size_bytes, first_seen_at, last_seen_at
+            )
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(path) DO UPDATE SET
+                size_bytes=excluded.size_bytes,
+                last_seen_at=excluded.last_seen_at
+            """,
+            rows,
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self.database_path)
+        con.row_factory = sqlite3.Row
+        return con
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as con:
+            con.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS project_refs (
+                    ref_id TEXT PRIMARY KEY,
+                    ref_type TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    source_path TEXT,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS project_ref_versions (
+                    version_id TEXT PRIMARY KEY,
+                    ref_id TEXT NOT NULL,
+                    source_hash TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    is_latest INTEGER NOT NULL,
+                    FOREIGN KEY(ref_id) REFERENCES project_refs(ref_id)
+                );
+
+                CREATE TABLE IF NOT EXISTS asset_cache_entries (
+                    path TEXT PRIMARY KEY,
+                    asset_key TEXT NOT NULL,
+                    asset_type TEXT NOT NULL,
+                    inputs_hash TEXT NOT NULL,
+                    path_role TEXT NOT NULL,
+                    project_data_folder TEXT NOT NULL,
+                    size_bytes INTEGER NOT NULL,
+                    first_seen_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS ref_assets (
+                    version_id TEXT NOT NULL,
+                    path TEXT NOT NULL,
+                    PRIMARY KEY(version_id, path),
+                    FOREIGN KEY(version_id) REFERENCES project_ref_versions(version_id)
+                );
+
+                CREATE TABLE IF NOT EXISTS untracked_project_files (
+                    path TEXT PRIMARY KEY,
+                    size_bytes INTEGER NOT NULL,
+                    first_seen_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS protected_paths (
+                    path TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL
+                );
+                """
+            )
+            self._remove_exists_on_disk_column(con)
+
+    def _remove_exists_on_disk_column(self, con: sqlite3.Connection) -> None:
+        columns = [
+            row["name"]
+            for row in con.execute("PRAGMA table_info(asset_cache_entries)")
+        ]
+        if "exists_on_disk" not in columns:
+            return
+        con.executescript(
+            """
+            CREATE TABLE asset_cache_entries_new (
+                path TEXT PRIMARY KEY,
+                asset_key TEXT NOT NULL,
+                asset_type TEXT NOT NULL,
+                inputs_hash TEXT NOT NULL,
+                path_role TEXT NOT NULL,
+                project_data_folder TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            );
+
+            INSERT INTO asset_cache_entries_new (
+                path, asset_key, asset_type, inputs_hash, path_role,
+                project_data_folder, size_bytes, first_seen_at, last_seen_at
+            )
+            SELECT
+                path, asset_key, asset_type, inputs_hash, path_role,
+                project_data_folder, size_bytes, first_seen_at, last_seen_at
+            FROM asset_cache_entries
+            WHERE exists_on_disk = 1;
+
+            DROP TABLE asset_cache_entries;
+            ALTER TABLE asset_cache_entries_new RENAME TO asset_cache_entries;
+            """
+        )
+
+    def _cleanup_blockers(self) -> list[str]:
+        blockers = []
+        with self._connect() as con:
+            rows = con.execute(
+                """
+                SELECT r.ref_type, r.name, r.source_path, v.source_hash
+                FROM project_refs r
+                JOIN project_ref_versions v
+                    ON r.ref_id = v.ref_id AND v.is_latest = 1
+                WHERE r.status = 'active'
+                ORDER BY r.name
+                """
+            )
+            for row in rows:
+                if row["ref_type"] != "script":
+                    continue
+                status = self._script_status(row["source_path"], row["source_hash"])
+                if status == "missing":
+                    blockers.append(
+                        f"{row['name']} is missing. "
+                        "Archive this cache source before removing cache files."
+                    )
+                elif status == "modified":
+                    blockers.append(
+                        f"{row['name']} changed since its last registered run. "
+                        "Rerun it before removing cache files."
+                    )
+        return blockers
+
+    def _script_status(self, source_path: str | None, source_hash: str | None) -> str:
+        if not source_path:
+            return "active"
+        path = pathlib.Path(source_path)
+        if not path.exists():
+            return "missing"
+        if source_hash and _hash_file(path) != source_hash:
+            return "modified"
+        return "active"
+
+    def _latest_active_ref_paths(self) -> set[pathlib.Path]:
+        with self._connect() as con:
+            return {
+                pathlib.Path(row["path"])
+                for row in con.execute(
+                    """
+                    SELECT DISTINCT a.path
+                    FROM ref_assets a
+                    JOIN project_ref_versions v ON a.version_id = v.version_id
+                    JOIN project_refs r ON v.ref_id = r.ref_id
+                    WHERE r.status = 'active' AND v.is_latest = 1
+                    """
+                )
+            }
+
+    def _cache_source_paths(self) -> set[pathlib.Path]:
+        with self._connect() as con:
+            return {
+                pathlib.Path(row["source_path"])
+                for row in con.execute(
+                    """
+                    SELECT source_path
+                    FROM project_refs
+                    WHERE source_path IS NOT NULL
+                    """
+                )
+            }
+
+    def _asset_rows(self) -> list[tuple[pathlib.Path, int]]:
+        with self._connect() as con:
+            return [
+                (pathlib.Path(row["path"]), int(row["size_bytes"]))
+                for row in con.execute(
+                    """
+                    SELECT path, size_bytes
+                    FROM asset_cache_entries
+                    ORDER BY path
+                    """
+                )
+            ]
+
+    def _untracked_file_rows(self) -> list[tuple[pathlib.Path, int]]:
+        with self._connect() as con:
+            return [
+                (pathlib.Path(row["path"]), int(row["size_bytes"]))
+                for row in con.execute(
+                    "SELECT path, size_bytes FROM untracked_project_files ORDER BY path"
+                )
+            ]
+
+    def _forget_missing_untracked_files(self, con: sqlite3.Connection) -> None:
+        rows = list(con.execute("SELECT path FROM untracked_project_files"))
+        for row in rows:
+            if not pathlib.Path(row["path"]).exists():
+                con.execute(
+                    "DELETE FROM untracked_project_files WHERE path=?",
+                    (row["path"],),
+                )
+
+    def _remove_tracked_files(self, paths: list[pathlib.Path]) -> None:
+        if not paths:
+            return
+        rows = [(str(path.resolve()),) for path in paths]
+        with self._connect() as con:
+            con.executemany("DELETE FROM ref_assets WHERE path=?", rows)
+            con.executemany("DELETE FROM asset_cache_entries WHERE path=?", rows)
+
+    def _remove_untracked_files(self, paths: list[pathlib.Path]) -> None:
+        if not paths:
+            return
+        rows = [(str(path.resolve()),) for path in paths]
+        with self._connect() as con:
+            con.executemany("DELETE FROM untracked_project_files WHERE path=?", rows)
+
+    def _resolve_project_path(self, path: str | pathlib.Path) -> pathlib.Path:
+        candidate = pathlib.Path(path)
+        if not candidate.is_absolute():
+            candidate = self.project_folder / candidate
+        return candidate.resolve()
+
+    def _find_cache_source_id(self, name: str) -> str | None:
+        target = str(name)
+        target_path = (
+            pathlib.Path(target).resolve()
+            if pathlib.Path(target).exists()
+            else None
+        )
+        with self._connect() as con:
+            for row in con.execute("SELECT ref_id, name, source_path FROM project_refs"):
+                if row["name"] == target or row["source_path"] == target:
+                    return row["ref_id"]
+                if target_path is not None and row["source_path"] == str(target_path):
+                    return row["ref_id"]
+        return None
+
+
+def _asset_paths(asset: Any) -> list[tuple[str, pathlib.Path]]:
+    paths = []
+    cache_path = getattr(asset, "cache_path", None)
+    if isinstance(cache_path, dict):
+        for role, path in sorted(cache_path.items()):
+            paths.append((str(role), pathlib.Path(path)))
+    elif cache_path is not None:
+        paths.append(("output", pathlib.Path(cache_path)))
+
+    hash_path = getattr(asset, "hash_path", None)
+    if hash_path is not None:
+        paths.append(("inputs_hash", pathlib.Path(hash_path)))
+    return paths
+
+
+def _project_folder() -> pathlib.Path:
+    value = os.environ.get("MOBILITY_PROJECT_DATA_FOLDER")
+    if not value:
+        raise RuntimeError(
+            "MOBILITY_PROJECT_DATA_FOLDER is not set. "
+            "Call mobility.set_params(...) before using project cache tools."
+        )
+    return pathlib.Path(value)
+
+
+def _walk_project_files(project_folder: pathlib.Path):
+    """Yield project files with sizes using a fast directory scanner."""
+    folders = [str(project_folder)]
+    while folders:
+        folder = folders.pop()
+        try:
+            entries = list(os.scandir(folder))
+        except OSError as error:
+            logger.debug(
+                "Skipping unreadable project-cache folder %s: %s",
+                folder,
+                error,
+            )
+            continue
+
+        for entry in entries:
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    folders.append(entry.path)
+                elif entry.is_file(follow_symlinks=False):
+                    yield entry.path, entry.stat(follow_symlinks=False).st_size
+            except OSError as error:
+                logger.debug(
+                    "Skipping unreadable project-cache path %s: %s",
+                    entry.path,
+                    error,
+                )
+
+
+def _registry_for_project_folder(project_folder: pathlib.Path) -> ProjectCacheRegistry:
+    resolved = str(pathlib.Path(project_folder).resolve())
+    if resolved not in _registries_by_project_folder:
+        _registries_by_project_folder[resolved] = ProjectCacheRegistry(
+            pathlib.Path(resolved)
+        )
+    return _registries_by_project_folder[resolved]
+
+
+def _hash_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _is_inside(path: pathlib.Path, folder: pathlib.Path) -> bool:
+    try:
+        path.resolve().relative_to(folder.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _resolved_path_key(path: pathlib.Path) -> str:
+    """Return a normalized absolute path string for fast path comparisons."""
+    return os.path.normcase(str(path.resolve()))
+
+
+def _stored_path_key(path: pathlib.Path) -> str:
+    """Return a normalized path string for paths already resolved in the registry."""
+    return os.path.normcase(str(path))
+
+
+def _is_inside_key(path_key: str, folder_key: str) -> bool:
+    return path_key == folder_key or path_key.startswith(folder_key + os.sep)
+
+
+def _is_protected_key(path_key: str, protected_path_keys: list[str]) -> bool:
+    return any(
+        _is_inside_key(path_key, protected_key)
+        for protected_key in protected_path_keys
+    )
+
+
+def _display_path(path: pathlib.Path, project_folder: pathlib.Path) -> str:
+    try:
+        return str(path.relative_to(project_folder))
+    except ValueError:
+        return str(path)

--- a/mobility/trips/group_day_trips/iterations/iteration_assets.py
+++ b/mobility/trips/group_day_trips/iterations/iteration_assets.py
@@ -689,6 +689,8 @@ class IterationStateAsset(FileAsset):
             iteration=iteration,
             base_folder=pathlib.Path(base_folder) / "transition-events",
         )
+        if cache_iteration_events:
+            self.cache_path["transition_events"] = self.transition_events_asset.cache_path
 
     def get_cached_asset(self) -> RunState:
         """Return the cached state after this iteration."""
@@ -757,13 +759,8 @@ class IterationStateAsset(FileAsset):
         _write_run_state(self.cache_path, state, seeds["rng_state_after_sampling"])
 
         if transition_events is not None and self.cache_iteration_events:
-            TransitionEventsAsset(
-                run_key=self.inputs_hash,
-                is_weekday=self.inputs["is_weekday"],
-                iteration=self.iteration,
-                base_folder=self.transition_events_asset.cache_path.parent,
-                transition_events=transition_events,
-            ).create_and_get_asset()
+            self.transition_events_asset.transition_events = transition_events
+            self.transition_events_asset.get()
 
         logging.debug("Group-day-trips iteration %s is ready.", str(self.iteration))
         get_group_day_trips_progress().finish_iteration(self.iteration)

--- a/tests/back/integration/test_012_project_cache_cleanup_workflow.py
+++ b/tests/back/integration/test_012_project_cache_cleanup_workflow.py
@@ -1,0 +1,215 @@
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import mobility
+import pytest
+
+
+@pytest.mark.dependency(
+    depends=[
+        "tests/back/integration/test_008_group_day_trips_can_be_computed.py::test_008_group_day_trips_can_be_computed"
+    ],
+    scope="session",
+)
+def test_project_cache_cleanup_after_real_group_day_trips_run(tmp_path):
+    """Cleanup removes stale files after a real model script changed and reran."""
+    package_folder = Path(os.environ["MOBILITY_PACKAGE_DATA_FOLDER"])
+    project_folder = Path(os.environ["MOBILITY_PROJECT_DATA_FOLDER"])
+    script = tmp_path / "scripts" / "run_model.py"
+    result_file = tmp_path / "run-result.txt"
+    script.parent.mkdir()
+    existing_files = {
+        path.resolve()
+        for path in project_folder.rglob("*")
+        if path.is_file()
+    }
+
+    def write_model_script(sample_size):
+        scenario_name = f"project_cache_cleanup_{sample_size}"
+        script.write_text(
+            f"""
+import mobility
+
+SAMPLE_SIZE = {sample_size}
+SCENARIO_NAME = {scenario_name!r}
+PACKAGE_FOLDER = {str(package_folder)!r}
+PROJECT_FOLDER = {str(project_folder)!r}
+RESULT_FILE = {str(result_file)!r}
+
+mobility.set_params(
+    package_data_folder_path=PACKAGE_FOLDER,
+    project_data_folder_path=PROJECT_FOLDER,
+    r_packages=False,
+)
+
+transport_zones = mobility.TransportZones("fr-87085", radius=10.0)
+survey = mobility.EMPMobilitySurvey()
+population = mobility.Population(transport_zones, sample_size=SAMPLE_SIZE)
+
+population_trips = mobility.PopulationGroupDayTrips(
+    population=population,
+    modes=[mobility.CarMode(transport_zones)],
+    activities=[
+        mobility.HomeActivity(),
+        mobility.WorkActivity(),
+        mobility.OtherActivity(population=population),
+    ],
+    surveys=[survey],
+    scenarios=mobility.Scenarios(
+        [
+            mobility.Scenario(name=SCENARIO_NAME),
+        ]
+    ),
+    parameters=mobility.GroupDayTripsParameters(
+        run=mobility.GroupDayTripsRunParameters(
+            n_iterations=1,
+            n_iter_per_cost_update=0,
+            seed=0,
+        ),
+        outputs=mobility.GroupDayTripsOutputParameters(
+            cache_iteration_events=True,
+        ),
+        periods=mobility.GroupDayTripsPeriodParameters(simulate_weekend=False),
+        destination_sequences=mobility.GroupDayTripsDestinationSequenceParameters(
+            dest_prob_cutoff=0.9,
+            cost_uncertainty_sd=1.0,
+        ),
+        mode_sequences=mobility.GroupDayTripsModeSequenceParameters(
+            k_mode_sequences=3,
+            mode_sequence_search_parallel=False,
+        ),
+    ),
+)
+
+plan_steps = population_trips.run("weekday", scenario=SCENARIO_NAME).get()["plan_steps"].collect()
+with open(RESULT_FILE, "w", encoding="utf-8") as file:
+    file.write(str(plan_steps.height))
+""",
+            encoding="utf-8",
+        )
+
+    def run_model_script():
+        subprocess.run(
+            [sys.executable, str(script)],
+            check=True,
+        )
+        assert int(result_file.read_text(encoding="utf-8")) > 0
+
+    # Run a real model script, then change its source and rerun it. The first
+    # run's registered cache files are now stale if the second run no longer
+    # uses them.
+    write_model_script(sample_size=5)
+    run_model_script()
+    write_model_script(sample_size=6)
+    run_model_script()
+
+    mobility.set_params(
+        package_data_folder_path=package_folder,
+        project_data_folder_path=project_folder,
+        r_packages=False,
+        track_project_cache=False,
+    )
+    registry_path = project_folder / ".mobility" / "cache.sqlite"
+    with sqlite3.connect(registry_path) as con:
+        latest_transition_event_paths = {
+            Path(row[0])
+            for row in con.execute(
+                """
+                SELECT a.path
+                FROM ref_assets a
+                JOIN project_ref_versions v ON a.version_id = v.version_id
+                JOIN project_refs r ON v.ref_id = r.ref_id
+                WHERE r.source_path = ? AND v.is_latest = 1
+                    AND a.path LIKE ?
+                """,
+                (
+                    str(script.resolve()),
+                    f"%{os.sep}transition_events_%.parquet",
+                ),
+            )
+        }
+    assert latest_transition_event_paths
+
+    # Older projects can contain Mobility-looking files that were never
+    # registered, plus user files. These must stay out of unused-cache removal.
+    legacy_cache_file = (
+        project_folder / "group_day_trips" / "project-cache-cleanup-legacy.parquet"
+    )
+    legacy_cache_file.parent.mkdir(exist_ok=True)
+    legacy_cache_file.write_text("old mobility cache", encoding="utf-8")
+    user_report = project_folder / "reports" / "project-cache-cleanup-note.txt"
+    user_report.parent.mkdir(exist_ok=True)
+    user_report.write_text("hand-written output", encoding="utf-8")
+    protected_input = project_folder / "manual_inputs" / "project-cache-survey.csv"
+    protected_input.parent.mkdir(exist_ok=True)
+    protected_input.write_text("do not remove", encoding="utf-8")
+
+    cache = mobility.ProjectCache()
+    protected_by_test = []
+    archived_by_test = []
+    for source in cache.cache_sources():
+        if source["status"] in {"missing", "modified"}:
+            source_name = source["source_path"] or source["name"]
+            cache.archive_cache_source(source_name)
+            archived_by_test.append(source_name)
+
+    cache.protect("manual_inputs")
+    protected_by_test.append(project_folder / "manual_inputs")
+
+    unused_report = cache.unused_files_preview()
+    for path in unused_report.files_to_delete:
+        if path.resolve() in existing_files:
+            cache.protect(path)
+            protected_by_test.append(path)
+    unused_report = cache.unused_files_preview()
+
+    unregistered_report = cache.untracked_files_preview()
+    expected_unregistered = {legacy_cache_file.resolve(), user_report.resolve()}
+    for path in unregistered_report.files_to_delete:
+        if path.resolve() not in expected_unregistered:
+            cache.protect(path)
+            protected_by_test.append(path)
+    unregistered_report = cache.untracked_files_preview()
+
+    assert unused_report.files_to_delete
+    assert latest_transition_event_paths.isdisjoint(unused_report.files_to_delete)
+    assert legacy_cache_file not in unused_report.files_to_delete
+    assert user_report not in unused_report.files_to_delete
+    assert "unused registered cache files" in str(unused_report)
+
+    assert latest_transition_event_paths.isdisjoint(
+        unregistered_report.files_to_delete
+    )
+    assert legacy_cache_file in unregistered_report.files_to_delete
+    assert user_report in unregistered_report.files_to_delete
+    assert protected_input not in unregistered_report.files_to_delete
+    assert "files not registered by Mobility" in str(unregistered_report)
+    assert "old Mobility cache files and user files" in str(unregistered_report)
+
+    removed_unused_report = cache.remove_unused_files()
+
+    assert removed_unused_report.deleted_files
+    assert set(removed_unused_report.deleted_files).issubset(
+        set(unused_report.files_to_delete)
+    )
+    assert not any(path.exists() for path in removed_unused_report.deleted_files)
+    assert legacy_cache_file.exists()
+    assert user_report.exists()
+    assert protected_input.exists()
+
+    removed_unregistered_report = cache.remove_untracked_files()
+
+    assert legacy_cache_file in removed_unregistered_report.deleted_files
+    assert user_report in removed_unregistered_report.deleted_files
+    assert protected_input not in removed_unregistered_report.deleted_files
+    assert not legacy_cache_file.exists()
+    assert not user_report.exists()
+    assert protected_input.exists()
+
+    for path in protected_by_test:
+        cache.unprotect(path)
+    for source_name in archived_by_test:
+        cache.restore_cache_source(source_name)

--- a/tests/back/unit/runtime/test_005_project_cache.py
+++ b/tests/back/unit/runtime/test_005_project_cache.py
@@ -1,0 +1,372 @@
+import logging
+import sqlite3
+import sys
+
+import pytest
+
+from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.project_cache import (
+    ProjectCache,
+    register_current_script_if_available,
+)
+
+
+class _TextFileAsset(FileAsset):
+    """Tiny file asset used to test project-cache registration."""
+
+    def __init__(self, *, name, cache_folder):
+        self.name = name
+        super().__init__({"name": name}, cache_folder / f"{name}.txt")
+
+    def get_cached_asset(self):
+        return self.cache_path.read_text(encoding="utf-8")
+
+    def create_and_get_asset(self):
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_path.write_text(self.name, encoding="utf-8")
+        return self.name
+
+
+class _ParentWritingChildAsset(FileAsset):
+    """Asset that writes a child file while it is being rebuilt."""
+
+    def __init__(self, *, child, cache_folder):
+        self.child = child
+        super().__init__({"child": child}, cache_folder / "parent.txt")
+
+    def get_cached_asset(self):
+        return self.cache_path.read_text(encoding="utf-8")
+
+    def create_and_get_asset(self):
+        self.child.get()
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_path.write_text("parent", encoding="utf-8")
+        return "parent"
+
+
+def _asset_paths(project_folder):
+    with sqlite3.connect(project_folder / ".mobility" / "cache.sqlite") as con:
+        return {
+            row[0]
+            for row in con.execute("SELECT path FROM asset_cache_entries")
+        }
+
+
+def test_register_cache_source_links_file_asset_to_current_source(
+    tmp_path,
+    monkeypatch,
+):
+    """A file asset read under a cache source is kept by cleanup."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    assert cache.register_cache_source("baseline notebook") is None
+    asset = _TextFileAsset(name="kept", cache_folder=tmp_path / "cache")
+
+    asset.get()
+
+    assert str(asset.cache_path.resolve()) in _asset_paths(tmp_path)
+    report = cache.unused_files_preview()
+
+    assert report.files_to_delete == []
+    assert report.kept_files_count == 2
+
+
+def test_old_script_version_assets_become_deletable(tmp_path, monkeypatch):
+    """Cleanup keeps only the latest active version of one script source."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    script = tmp_path / "run_scenarios.py"
+    script.write_text("version = 1\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    old_asset = _TextFileAsset(name="old", cache_folder=tmp_path / "cache")
+    old_asset.get()
+
+    script.write_text("version = 2\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    new_asset = _TextFileAsset(name="new", cache_folder=tmp_path / "cache")
+    new_asset.get()
+
+    report = cache.unused_files_preview()
+
+    paths_to_delete = {path.name for path in report.files_to_delete}
+    assert old_asset.cache_path.name in paths_to_delete
+    assert new_asset.cache_path.name not in paths_to_delete
+
+
+def test_modified_script_blocks_real_cleanup(tmp_path, monkeypatch):
+    """A changed active script must be rerun before deleting cache files."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    script = tmp_path / "run_scenarios.py"
+    script.write_text("version = 1\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    _TextFileAsset(name="kept", cache_folder=tmp_path / "cache").get()
+
+    script.write_text("version = 2\n", encoding="utf-8")
+
+    report = cache.unused_files_preview()
+    assert "changed since its last registered run" in report.blockers[0]
+    with pytest.raises(RuntimeError, match="cache sources need attention"):
+        cache.remove_unused_files()
+
+
+def test_modified_script_still_allows_untracked_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    """A changed script blocks tracked files, not untracked cleanup."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    script = tmp_path / "run_scenarios.py"
+    script.write_text("version = 1\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    asset = _TextFileAsset(name="kept", cache_folder=tmp_path / "cache")
+    asset.get()
+
+    untracked_file = tmp_path / "exports" / "old-export.txt"
+    untracked_file.parent.mkdir()
+    untracked_file.write_text("delete me", encoding="utf-8")
+    script.write_text("version = 2\n", encoding="utf-8")
+
+    report = cache.remove_untracked_files()
+
+    assert untracked_file in report.deleted_files
+    assert not untracked_file.exists()
+    assert asset.cache_path.exists()
+    assert report.tracked_files_to_delete_count == 0
+    assert report.untracked_files_to_delete_count == 1
+    assert report.blockers == []
+
+
+def test_modified_script_registration_does_not_make_previous_assets_unused(
+    tmp_path,
+    monkeypatch,
+):
+    """A cleanup-only script edit must not make previous assets unused."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    script = tmp_path / "run_scenarios.py"
+    script.write_text("version = 1\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    asset = _TextFileAsset(name="kept", cache_folder=tmp_path / "cache")
+    asset.get()
+
+    script.write_text("version = 2\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+
+    report = cache.unused_files_preview()
+
+    assert report.blockers
+    assert asset.cache_path not in report.files_to_delete
+    assert report.tracked_files_to_delete_count == 0
+    with pytest.raises(RuntimeError, match="cache sources need attention"):
+        cache.remove_unused_files()
+
+
+def test_missing_script_blocks_real_cleanup(tmp_path, monkeypatch):
+    """A removed active script must be archived before deleting cache files."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    script = tmp_path / "old_scenarios.py"
+    script.write_text("version = 1\n", encoding="utf-8")
+    cache._register_cache_source(str(script), ref_type="script")
+    _TextFileAsset(name="kept", cache_folder=tmp_path / "cache").get()
+
+    script.unlink()
+
+    report = cache.unused_files_preview()
+    assert "is missing" in report.blockers[0]
+    with pytest.raises(RuntimeError, match="cache sources need attention"):
+        cache.remove_unused_files()
+
+
+def test_archived_cache_source_stops_protecting_assets(tmp_path, monkeypatch):
+    """Archiving a cache source makes its indexed assets cleanup candidates."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    cache.register_cache_source("temporary notebook")
+    asset = _TextFileAsset(name="temporary", cache_folder=tmp_path / "cache")
+    asset.get()
+
+    cache.archive_cache_source("temporary notebook")
+    report = cache.remove_unused_files()
+
+    assert asset.cache_path in report.deleted_files
+    assert not asset.cache_path.exists()
+    assert str(asset.cache_path.resolve()) not in _asset_paths(tmp_path)
+
+
+def test_protected_project_data_is_never_deleted(tmp_path, monkeypatch):
+    """Protected paths override normal cleanup candidates."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    cache.register_cache_source("temporary notebook")
+    asset = _TextFileAsset(name="temporary", cache_folder=tmp_path / "cache")
+    asset.get()
+    cache.archive_cache_source("temporary notebook")
+
+    cache.protect("cache")
+    report = cache.remove_unused_files()
+
+    assert asset.cache_path.exists()
+    assert asset.cache_path not in report.deleted_files
+    assert cache.protected_paths() == [(tmp_path / "cache").resolve()]
+    assert "Protected project data:" in str(report)
+    assert str((tmp_path / "cache").resolve()) in str(report)
+
+
+def test_untracked_files_are_reported_but_not_deleted_by_default(
+    tmp_path, monkeypatch
+):
+    """Untracked files are reported only by untracked-file preview."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    untracked_file = tmp_path / "reports" / "manual-note.txt"
+    untracked_file.parent.mkdir(parents=True)
+    untracked_file.write_text("keep this by default", encoding="utf-8")
+
+    report = cache.remove_unused_files()
+
+    assert untracked_file.exists()
+    assert report.untracked_files_count == 0
+    assert report.deleted_files == []
+
+    untracked_report = cache.untracked_files_preview()
+    assert untracked_report.untracked_files_count == 1
+    assert "Cleanup candidates:" in str(untracked_report)
+
+
+def test_auto_register_current_script_uses_main_file(tmp_path, monkeypatch):
+    """set_params can register a normal Python entry script automatically."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    script = tmp_path / "scripts" / "run.py"
+    script.parent.mkdir()
+    script.write_text("print('run')\n", encoding="utf-8")
+    main_module = type("MainModule", (), {"__file__": str(script)})()
+    monkeypatch.setitem(sys.modules, "__main__", main_module)
+
+    version_id = register_current_script_if_available()
+
+    assert version_id is not None
+    sources = ProjectCache().cache_sources()
+    assert sources[0]["name"] == str(script.relative_to(tmp_path))
+    assert sources[0]["source_type"] == "script"
+    assert sources[0]["status"] == "active"
+
+
+def test_remove_untracked_files_can_delete_untracked_project_files(tmp_path, monkeypatch):
+    """Untracked project file removal uses a dedicated method."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    untracked_file = tmp_path / "reports" / "manual-note.txt"
+    untracked_file.parent.mkdir(parents=True)
+    untracked_file.write_text(
+        "delete this only when explicitly requested",
+        encoding="utf-8",
+    )
+
+    report = ProjectCache(tmp_path).remove_untracked_files()
+
+    assert untracked_file in report.deleted_files
+    assert not untracked_file.exists()
+    assert report.untracked_files_to_delete_count == 1
+
+    follow_up = ProjectCache(tmp_path).untracked_files_preview()
+    assert follow_up.untracked_files_count == 0
+
+
+def test_missing_untracked_rows_are_removed_from_reports(tmp_path, monkeypatch):
+    """Untracked files deleted outside Mobility disappear from later reports."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    untracked_file = tmp_path / "reports" / "manual-note.txt"
+    untracked_file.parent.mkdir(parents=True)
+    untracked_file.write_text("old file", encoding="utf-8")
+
+    first_report = cache.untracked_files_preview()
+    assert first_report.untracked_files_count == 1
+
+    untracked_file.unlink()
+    second_report = cache.untracked_files_preview()
+
+    assert second_report.untracked_files_count == 0
+
+
+def test_seen_untracked_file_becomes_tracked_cache_file(tmp_path, monkeypatch):
+    """An untracked file reused by a cache source is no longer a cleanup candidate."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    asset = _TextFileAsset(name="old", cache_folder=tmp_path / "group_day_trips")
+    asset.create_and_get_asset()
+
+    first_report = cache.untracked_files_preview()
+    assert first_report.untracked_files_count == 2
+
+    cache.register_cache_source("kept notebook")
+    asset.get()
+
+    second_report = cache.remove_untracked_files()
+    assert second_report.untracked_files_count == 0
+    assert second_report.deleted_files == []
+    assert asset.cache_path.exists()
+
+
+def test_child_asset_written_during_rebuild_is_registered(tmp_path, monkeypatch):
+    """Files written by nested assets are not treated as unregistered files."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    cache.register_cache_source("model script")
+    child = _TextFileAsset(name="child", cache_folder=tmp_path / "cache")
+    parent = _ParentWritingChildAsset(child=child, cache_folder=tmp_path / "cache")
+
+    parent.get()
+
+    untracked_report = cache.untracked_files_preview()
+
+    assert child.cache_path not in untracked_report.files_to_delete
+    assert child.hash_path not in untracked_report.files_to_delete
+    assert parent.cache_path not in untracked_report.files_to_delete
+    assert parent.hash_path not in untracked_report.files_to_delete
+
+
+def test_unused_files_preview_never_deletes_files(tmp_path, monkeypatch):
+    """ProjectCache.unused_files_preview returns the report without deleting files."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    cache = ProjectCache()
+    cache.register_cache_source("temporary notebook")
+    asset = _TextFileAsset(name="temporary", cache_folder=tmp_path / "cache")
+    asset.get()
+    cache.archive_cache_source("temporary notebook")
+
+    report = cache.unused_files_preview()
+
+    assert report.preview is True
+    assert asset.cache_path in report.files_to_delete
+    assert asset.cache_path.exists()
+    assert "Preview: no files were deleted." in str(report)
+    assert repr(report) == str(report)
+    assert "ProjectCacheReport(" not in repr(report)
+
+
+def test_untracked_files_preview_logs_debug_scan_details(tmp_path, monkeypatch, caplog):
+    """Debug logs show where project-cache cleanup spends time."""
+    monkeypatch.setenv("MOBILITY_PROJECT_DATA_FOLDER", str(tmp_path))
+    untracked_file = tmp_path / "reports" / "manual-note.txt"
+    untracked_file.parent.mkdir()
+    untracked_file.write_text("inspect me", encoding="utf-8")
+
+    cache = ProjectCache()
+    with caplog.at_level(logging.DEBUG, logger="mobility.runtime.project_cache"):
+        report = cache.untracked_files_preview()
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert report.untracked_files_count == 1
+    assert any("Project cache cleanup started" in message for message in messages)
+    assert any(
+        "Project cache untracked-file scan started" in message for message in messages
+    )
+    assert any(
+        "Project cache untracked-file scan finished" in message for message in messages
+    )
+    assert any("Project cache cleanup finished" in message for message in messages)
+
+


### PR DESCRIPTION
### Motivation

Project data folders can become very large over time because Mobility keeps many intermediate cache files. Until now, modellers had no clear way to see which cache files were still used by the latest project scripts, which files were old, and which local folders should never be removed.

This PR adds a small project-cache registry and a simple cleanup API so a modeller can safely preview and remove project-data files.

In this PR:

- **unused files** are Mobility cache files that are tracked in the registry, but are no longer used by any active script or notebook in its latest registered run;
- **untracked files** are files inside the project data folder that Mobility does not know as cache files. On existing projects, this can include old cache files created before the registry existed, but also user exports, reports, copied input data, or any other local file.

Because untracked files may include user data, Mobility never removes them through normal unused-cache cleanup. They have their own preview and removal methods.

### Changes

- Add `mobility.ProjectCache`.
- Automatically register the current Python script when `mobility.set_params(...)` runs.
- Record file-backed assets when Mobility reads or rebuilds cached assets.
- Store the project-cache registry in SQLite under `MOBILITY_PROJECT_DATA_FOLDER/.mobility/cache.sqlite`.
- Add cleanup methods with separate responsibilities:
  - `cache.unused_files_preview()`
  - `cache.remove_unused_files()`
  - `cache.untracked_files_preview()`
  - `cache.remove_untracked_files()`
- Add cache-source management:
  - `cache.cache_sources()`
  - `cache.register_cache_source(...)`
  - `cache.archive_cache_source(...)`
  - `cache.restore_cache_source(...)`
- Add protected project-data paths:
  - `cache.protect(...)`
  - `cache.protected_paths()`
  - `cache.unprotect(...)`
- Keep changed or missing scripts from allowing tracked cache-file removal until the modeller reruns or archives the source.
- Keep untracked-file removal separate, so old exports, reports, copied inputs, and legacy files are only removed when explicitly requested.
- Add debug logs around untracked-file scans to make large cleanup previews understandable.
- Document the workflow in `workflow.md` and the API reference.

### Example

```python
import mobility

mobility.set_params(
    project_data_folder_path=path/to/project-data,
)

cache = mobility.ProjectCache()

# Protect local folders that contain project inputs or hand-written outputs.
cache.protect(census)
cache.protect(reports)
cache.protect(manual_inputs)

print(cache.unused_files_preview())
cache.remove_unused_files()

print(cache.untracked_files_preview())
cache.remove_untracked_files()
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: implementation, tests, API naming, cleanup report wording, and documentation draft.
- What you reviewed or changed: reviewed the public API, cleanup behavior, performance of large untracked-file scans, report wording, and test coverage.
- How you validated it (tests, checks, manual verification):
  - `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/runtime/test_005_project_cache.py`
  - `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/runtime/test_005_project_cache.py tests/back/unit/runtime/test_004_asset_resolver.py tests/back/unit/runtime/test_003_asset_graph.py tests/back/unit/test_901_quickstart_drift_guard.py`
  - `mamba run -n mobility python -m py_compile mobility/runtime/project_cache.py mobility/config.py mobility/__init__.py tests/back/unit/runtime/test_005_project_cache.py`

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior