### PR TITLE
Speed up group day trip result metrics

### DIFF
--- a/mobility/trips/group_day_trips/results/assets/scoped_tables.py
+++ b/mobility/trips/group_day_trips/results/assets/scoped_tables.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import TYPE_CHECKING
+import hashlib
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
 from mobility.runtime.assets.file_asset import FileAsset
-from mobility.trips.group_day_trips.iterations import Iterations
 
 if TYPE_CHECKING:
     from mobility.trips.group_day_trips.results import (
@@ -27,6 +27,7 @@ class ScopedRunTable(FileAsset):
         results: "GroupDayTripsResults",
         table_name: str,
         iterations: IterationSelector = "last",
+        columns: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         run_contexts = results.run_contexts
         if not run_contexts:
@@ -35,6 +36,7 @@ class ScopedRunTable(FileAsset):
         self.results = results
         self.run_contexts = list(run_contexts)
         self.table_name = table_name
+        self.columns = None if columns is None else tuple(dict.fromkeys(columns))
         self.iterations = results._validate_iterations(iterations)
         self.selected_iterations = results.selected_iterations(iterations)
         self.uses_last_iteration = self.iterations == "last"
@@ -44,18 +46,31 @@ class ScopedRunTable(FileAsset):
             iteration_suffix = "last"
         else:
             iteration_suffix = "-".join(str(iteration) for iteration in self.selected_iterations)
+        if self.columns is None:
+            column_suffix = "all-columns"
+        else:
+            column_key = "|".join(self.columns).encode("utf-8")
+            column_suffix = f"cols-{hashlib.md5(column_key).hexdigest()[:8]}"
         cache_path = (
             project_folder
             / "group_day_trips"
             / "results"
-            / f"{table_name}_{iteration_suffix}.parquet"
+            / f"{table_name}_{iteration_suffix}_{column_suffix}.parquet"
         )
         inputs = {
-            "version": 3,
+            "version": 4,
             "table_name": table_name,
             "iterations": tuple(self.selected_iterations),
             "uses_last_iteration": self.uses_last_iteration,
-            "runs": tuple(run_context.run for run_context in self.run_contexts),
+            "columns": self.columns,
+            # Result tables only need to know which completed run outputs they
+            # summarize. Keeping the full Run assets out of the hash inputs
+            # avoids walking every simulation iteration asset before reading an
+            # already-finalized result table.
+            "run_outputs": tuple(
+                self._run_output_descriptor(run_context)
+                for run_context in self.run_contexts
+            ),
             "scope": tuple(
                 (
                     run_context.scenario,
@@ -68,6 +83,28 @@ class ScopedRunTable(FileAsset):
         }
         super().__init__(inputs, cache_path)
 
+    @staticmethod
+    def _run_output_descriptor(run_context: "ResultRun") -> dict[str, Any]:
+        """Return the compact run identity needed by result-table caches."""
+        run = run_context.run
+        cache_path = getattr(run, "cache_path", {})
+        if isinstance(cache_path, dict):
+            output_paths = {
+                name: str(path)
+                for name, path in sorted(cache_path.items())
+            }
+        else:
+            output_paths = {"default": str(cache_path)}
+
+        return {
+            "run_hash": str(getattr(run, "inputs_hash", "")),
+            "scenario": str(run_context.scenario),
+            "sensitivity_case": str(run_context.sensitivity_case_id),
+            "day_type": str(run_context.day_type),
+            "replication": str(run_context.replication),
+            "output_paths": output_paths,
+        }
+
     def get_cached_asset(self) -> pl.LazyFrame:
         """Return the cached scoped table as a lazy parquet scan."""
         return pl.scan_parquet(self.cache_path)
@@ -79,7 +116,7 @@ class ScopedRunTable(FileAsset):
 
         scoped_tables: list[pl.LazyFrame] = []
         for run_context in self.run_contexts:
-            run_context.run.get()
+            self._ensure_run_output_available(run_context, self.table_name)
             cached = run_context.run.get_cached_asset()
             if self.table_name not in cached:
                 raise KeyError(
@@ -96,12 +133,14 @@ class ScopedRunTable(FileAsset):
             else:
                 iteration_expr = pl.lit(self.results.last_iteration, dtype=pl.Int32)
             scoped_tables.append(
-                table.with_columns(
-                    scenario=pl.lit(run_context.scenario, dtype=pl.String),
-                    sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
-                    day_type=pl.lit(run_context.day_type, dtype=pl.String),
-                    iteration=iteration_expr,
-                    replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                self._select_columns(
+                    table.with_columns(
+                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
+                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                        iteration=iteration_expr,
+                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                    )
                 )
             )
 
@@ -115,6 +154,8 @@ class ScopedRunTable(FileAsset):
         """Build and cache a table for selected saved iterations."""
         if self.table_name == "plan_steps":
             scoped_tables = self._iteration_plan_steps()
+        elif self.table_name == "costs":
+            scoped_tables = self._iteration_costs()
         elif self.table_name == "demand_groups":
             scoped_tables = self._iteration_demand_groups()
         elif self.table_name == "iteration_metrics":
@@ -123,7 +164,7 @@ class ScopedRunTable(FileAsset):
             raise ValueError(
                 f'iterations={self.iterations!r} is not available for '
                 f"`{self.table_name}` yet. Saved iteration artifacts currently "
-                "support plan_steps, demand_groups, and iteration_metrics."
+                "support plan_steps, costs, demand_groups, and iteration_metrics."
             )
 
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -136,7 +177,6 @@ class ScopedRunTable(FileAsset):
         """Return selected saved current plan steps with result scope columns."""
         scoped_tables = []
         for run_context in self.run_contexts:
-            run_context.run.get()
             for iteration in self.selected_iterations:
                 current_plan_steps = self._iteration_table_for_run(
                     run_context,
@@ -144,12 +184,37 @@ class ScopedRunTable(FileAsset):
                     iteration=iteration,
                 )
                 scoped_tables.append(
-                    current_plan_steps.with_columns(
-                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
-                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
-                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
-                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
-                        iteration=pl.lit(iteration, dtype=pl.Int32),
+                    self._select_columns(
+                        current_plan_steps.with_columns(
+                            scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                            sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
+                            day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                            replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                            iteration=pl.lit(iteration, dtype=pl.Int32),
+                        )
+                    )
+                )
+        return scoped_tables
+
+    def _iteration_costs(self) -> list[pl.LazyFrame]:
+        """Return selected saved transport costs with result scope columns."""
+        scoped_tables = []
+        for run_context in self.run_contexts:
+            for iteration in self.selected_iterations:
+                costs = self._iteration_table_for_run(
+                    run_context,
+                    table_name="costs",
+                    iteration=iteration,
+                )
+                scoped_tables.append(
+                    self._select_columns(
+                        costs.with_columns(
+                            scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                            sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
+                            day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                            replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                            iteration=pl.lit(iteration, dtype=pl.Int32),
+                        )
                     )
                 )
         return scoped_tables
@@ -163,24 +228,22 @@ class ScopedRunTable(FileAsset):
     ) -> pl.LazyFrame:
         """Return one saved iteration table for a run."""
         run = run_context.run
-        if callable(getattr(run, "iteration_table", None)):
-            table = run.iteration_table(table_name, iteration)
-            if isinstance(table, pl.DataFrame):
-                return table.lazy()
-            return table
+        if not callable(getattr(run, "iteration_table", None)):
+            raise TypeError(
+                "Iteration-scoped result tables need runs exposing "
+                "`iteration_table(table_name, iteration)`."
+            )
 
-        if table_name == "plan_steps":
-            return self._iterations_for_run(run_context).iteration(iteration).load_state().current_plan_steps.lazy()
-
-        raise ValueError(
-            f"Saved iteration table `{table_name}` is not available for this run."
-        )
+        table = run.iteration_table(table_name, iteration)
+        if isinstance(table, pl.DataFrame):
+            return table.lazy()
+        return table
 
     def _iteration_demand_groups(self) -> list[pl.LazyFrame]:
         """Return demand groups repeated for each selected iteration."""
         scoped_tables = []
         for run_context in self.run_contexts:
-            run_context.run.get()
+            self._ensure_run_output_available(run_context, "demand_groups")
             cached = run_context.run.get_cached_asset()
             if "demand_groups" not in cached:
                 raise KeyError("Run output table `demand_groups` is not available.")
@@ -189,12 +252,14 @@ class ScopedRunTable(FileAsset):
                 table = table.lazy()
             for iteration in self.selected_iterations:
                 scoped_tables.append(
-                    table.with_columns(
-                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
-                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
-                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
-                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
-                        iteration=pl.lit(iteration, dtype=pl.Int32),
+                    self._select_columns(
+                        table.with_columns(
+                            scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                            sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
+                            day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                            replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                            iteration=pl.lit(iteration, dtype=pl.Int32),
+                        )
                     )
                 )
         return scoped_tables
@@ -203,7 +268,7 @@ class ScopedRunTable(FileAsset):
         """Return iteration diagnostics filtered to the selected iterations."""
         scoped_tables = []
         for run_context in self.run_contexts:
-            run_context.run.get()
+            self._ensure_run_output_available(run_context, "iteration_metrics")
             cached = run_context.run.get_cached_asset()
             if "iteration_metrics" not in cached:
                 raise KeyError("Run output table `iteration_metrics` is not available.")
@@ -211,32 +276,35 @@ class ScopedRunTable(FileAsset):
             if isinstance(table, pl.DataFrame):
                 table = table.lazy()
             scoped_tables.append(
-                table
-                .filter(pl.col("iteration").is_in(self.selected_iterations))
-                .with_columns(
-                    scenario=pl.lit(run_context.scenario, dtype=pl.String),
-                    sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
-                    day_type=pl.lit(run_context.day_type, dtype=pl.String),
-                    replication=pl.lit(run_context.replication, dtype=pl.Int32),
-                    iteration=pl.col("iteration").cast(pl.Int32),
+                self._select_columns(
+                    table
+                    .filter(pl.col("iteration").is_in(self.selected_iterations))
+                    .with_columns(
+                        scenario=pl.lit(run_context.scenario, dtype=pl.String),
+                        sensitivity_case=pl.lit(run_context.sensitivity_case_id, dtype=pl.String),
+                        day_type=pl.lit(run_context.day_type, dtype=pl.String),
+                        replication=pl.lit(run_context.replication, dtype=pl.Int32),
+                        iteration=pl.col("iteration").cast(pl.Int32),
+                    )
                 )
             )
         return scoped_tables
 
-    def _iterations_for_run(self, run_context: "ResultRun") -> Iterations:
-        """Return persisted iteration access for one run context."""
+    def _select_columns(self, table: pl.LazyFrame) -> pl.LazyFrame:
+        """Return only requested columns when this scoped table is projected."""
+        if self.columns is None:
+            return table
+        schema = table.collect_schema().names()
+        columns = [column for column in self.columns if column in schema]
+        return table.select(columns)
+
+    @staticmethod
+    def _ensure_run_output_available(run_context: "ResultRun", table_name: str) -> None:
+        """Materialize a run only when the requested final output is missing."""
         run = run_context.run
-        try:
-            base_folder = pathlib.Path(run.cache_path["plan_steps"]).parent
-            run_inputs_hash = run.inputs_hash
-            is_weekday = bool(run.is_weekday)
-        except (AttributeError, KeyError) as exc:
-            raise TypeError(
-                "Iteration-scoped results need runs with cache_path['plan_steps'], "
-                "inputs_hash, and is_weekday."
-            ) from exc
-        return Iterations(
-            run_inputs_hash=run_inputs_hash,
-            is_weekday=is_weekday,
-            base_folder=base_folder,
-        )
+        cache_path = getattr(run, "cache_path", {})
+        if isinstance(cache_path, dict) and table_name in cache_path:
+            if pathlib.Path(cache_path[table_name]).exists():
+                return
+        run.get()
+

--- a/mobility/trips/group_day_trips/results/metrics.py
+++ b/mobility/trips/group_day_trips/results/metrics.py
@@ -6,6 +6,10 @@ from typing import Literal
 import polars as pl
 
 from mobility.reports import TransportZoneMaps
+from mobility.runtime.assets.resolver import (
+    asset_resolution_context,
+    get_current_asset_resolver,
+)
 
 from .assets.final_state_metrics import Immobility, TripCountByDemandGroup
 from .assets.person_metrics import (
@@ -44,6 +48,7 @@ NormalizeScope = Literal["zone", "study_area"]
 IterationSelector = str | int | list[int] | range
 MetricReference = Literal["external"] | tuple[Literal["scenario"], str] | None
 ReferenceView = Literal["gap", "values"]
+DemandGroupSelector = str | int | list[str | int] | tuple[str | int, ...] | None
 
 REFERENCE_DIMENSIONS = {"mode", "activity", "distance_bin", "time_bin"}
 
@@ -93,12 +98,19 @@ class GroupDayTripsResultMetrics:
         self.results = results
         self._transport_zone_maps = None
 
-    def _table(self, table_name: str, *, iterations: IterationSelector = "last") -> ScopedRunTable:
+    def _table(
+        self,
+        table_name: str,
+        *,
+        iterations: IterationSelector = "last",
+        columns: list[str] | tuple[str, ...] | None = None,
+    ) -> ScopedRunTable:
         """Return one scoped run output table for this result set."""
         return ScopedRunTable(
             results=self.results,
             table_name=table_name,
             iterations=iterations,
+            columns=columns,
         )
 
     def metric(
@@ -113,6 +125,9 @@ class GroupDayTripsResultMetrics:
         reference_view: ReferenceView = "gap",
         inner_zone_residents_only: bool = False,
         iterations: IterationSelector = "last",
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
         output: MetricOutput = "table",
         scenarios: str | list[str] | tuple[str, ...] | None = None,
         width: int = 760,
@@ -125,6 +140,59 @@ class GroupDayTripsResultMetrics:
         min_line_width: float = 0.1,
     ) -> pl.DataFrame:
         """Return one simple trip metric, optionally split and normalized."""
+        with asset_resolution_context(get_current_asset_resolver()):
+            return self._metric(
+                name,
+                by_zone=by_zone,
+                by_variable=by_variable,
+                normalize_by=normalize_by,
+                normalize_scope=normalize_scope,
+                reference=reference,
+                reference_view=reference_view,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+                modes=modes,
+                output=output,
+                scenarios=scenarios,
+                width=width,
+                height=height,
+                labels=labels,
+                n_largest=n_largest,
+                min_value=min_value,
+                min_share=min_share,
+                max_line_width=max_line_width,
+                min_line_width=min_line_width,
+            )
+
+    def _metric(
+        self,
+        name: MetricName,
+        *,
+        by_zone: ZoneDimensions | None,
+        by_variable: VariableDimension | None,
+        normalize_by: NormalizeBy | None,
+        normalize_scope: NormalizeScope | None,
+        reference: MetricReference,
+        reference_view: ReferenceView,
+        inner_zone_residents_only: bool,
+        iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector,
+        csp: DemandGroupSelector,
+        modes: DemandGroupSelector,
+        output: MetricOutput,
+        scenarios: str | list[str] | tuple[str, ...] | None,
+        width: int,
+        height: int,
+        labels: bool,
+        n_largest: int | None,
+        min_value: float | None,
+        min_share: float | None,
+        max_line_width: float,
+        min_line_width: float,
+    ) -> pl.DataFrame:
+        """Compute one simple trip metric inside the caller's asset resolver."""
         if name not in METRIC_SPECS:
             raise ValueError(
                 "Unknown metric name. Expected one of: "
@@ -132,7 +200,7 @@ class GroupDayTripsResultMetrics:
                 + "."
             )
         spec = METRIC_SPECS[name]
-        return self._metric(
+        return self._metric_values(
             quantity=spec.quantity,
             quantity_column=spec.quantity_column,
             indicator=spec.indicator,
@@ -144,6 +212,9 @@ class GroupDayTripsResultMetrics:
             reference_view=reference_view,
             inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
             output=output,
             scenarios=scenarios,
             width=width,
@@ -335,7 +406,7 @@ class GroupDayTripsResultMetrics:
             )
         return values
 
-    def _metric(
+    def _metric_values(
         self,
         *,
         quantity: str,
@@ -349,6 +420,9 @@ class GroupDayTripsResultMetrics:
         reference_view: ReferenceView,
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector,
+        csp: DemandGroupSelector,
+        modes: DemandGroupSelector,
         output: MetricOutput,
         scenarios: str | list[str] | tuple[str, ...] | None,
         width: int,
@@ -369,8 +443,11 @@ class GroupDayTripsResultMetrics:
             by_zone=by_zone,
             by_variable=by_variable,
         )
+        self._validate_demand_group_filters(home_zone_ids=home_zone_ids, csp=csp, modes=modes)
         reference_kind = self._reference_kind(reference)
         self._validate_reference_view(reference_view, reference_kind=reference_kind)
+        if reference_kind == "external" and self._has_metric_filter(home_zone_ids=home_zone_ids, csp=csp, modes=modes):
+            raise ValueError("External references are not available with metric filters.")
         if reference_kind == "external" and indicator is None:
             raise ValueError(f"No reference is available for {quantity}.")
         if reference_kind == "external" and not self.results.uses_last_iteration(iterations):
@@ -388,7 +465,8 @@ class GroupDayTripsResultMetrics:
         variable_column = self._variable_column(by_variable) if by_variable is not None else None
         group_columns = zone_columns + ([variable_column] if variable_column is not None else [])
 
-        if quantity == "trip_count":
+        has_metric_filter = self._has_metric_filter(home_zone_ids=home_zone_ids, csp=csp, modes=modes)
+        if quantity == "trip_count" and not has_metric_filter:
             values = self._trip_count(
                 output_column=(
                     "trip_count"
@@ -405,11 +483,59 @@ class GroupDayTripsResultMetrics:
                     values,
                     normalize_scope=normalize_scope,
                     zone_column=zone_column,
+                group_columns=group_columns,
+                value_column="trip_count",
+                output_column=metric_column,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+            )
+            elif normalize_by == "metric_total":
+                values = self._with_metric_total_share(
+                    values,
+                    denominator_columns=self._denominator_columns(
+                        normalize_scope=normalize_scope,
+                        zone_column=zone_column,
+                    ),
+                    group_columns=group_columns,
+                    value_column="trip_count",
+                    output_column=metric_column,
+                )
+        elif quantity == "trip_count":
+            trip_count_by_replication = self._trip_count_by_replication(
+                group_columns=group_columns,
+                inner_zone_residents_only=inner_zone_residents_only,
+                iterations=iterations,
+                value_column="trip_count",
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+                modes=modes,
+            )
+            output_columns = RESULT_COLUMNS + group_columns
+            values = (
+                trip_count_by_replication
+                .group_by(output_columns)
+                .agg(
+                    pl.col("trip_count").mean().alias("trip_count"),
+                    pl.col("trip_count").std().alias("trip_count_std"),
+                    pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+                )
+                .sort(output_columns)
+            )
+            if normalize_by == "person_count":
+                values = self._with_person_count_normalization(
+                    values,
+                    normalize_scope=normalize_scope,
+                    zone_column=zone_column,
                     group_columns=group_columns,
                     value_column="trip_count",
                     output_column=metric_column,
                     inner_zone_residents_only=inner_zone_residents_only,
                     iterations=iterations,
+                    home_zone_ids=home_zone_ids,
+                    csp=csp,
+                    modes=modes,
                 )
             elif normalize_by == "metric_total":
                 values = self._with_metric_total_share(
@@ -429,6 +555,9 @@ class GroupDayTripsResultMetrics:
                 group_columns=group_columns,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+                modes=modes,
             )
             if normalize_by == "person_count":
                 values = self._with_person_count_normalization(
@@ -440,6 +569,8 @@ class GroupDayTripsResultMetrics:
                     output_column=metric_column,
                     inner_zone_residents_only=inner_zone_residents_only,
                     iterations=iterations,
+                    home_zone_ids=home_zone_ids,
+                    csp=csp,
                 )
             elif normalize_by == "metric_total":
                 values = self._with_metric_total_share(
@@ -466,6 +597,8 @@ class GroupDayTripsResultMetrics:
                     normalize_scope=normalize_scope,
                     inner_zone_residents_only=inner_zone_residents_only,
                     iterations=iterations,
+                    home_zone_ids=home_zone_ids,
+                    csp=csp,
                 )
                 values = self._with_scenario_reference(
                     values,
@@ -891,7 +1024,7 @@ class GroupDayTripsResultMetrics:
             for column in per_replication_values.columns
             if column not in SCOPE_COLUMNS + [metric_column]
         ]
-        pairing_columns = ["day_type", "iteration", "replication"] + dimension_columns
+        pairing_columns = ["sensitivity_case", "day_type", "iteration", "replication"] + dimension_columns
         paired_output_columns = RESULT_COLUMNS + dimension_columns
 
         reference_rows = (
@@ -903,6 +1036,28 @@ class GroupDayTripsResultMetrics:
             )
         )
         model_rows = values.filter(pl.col("scenario").is_in(model_scenarios))
+        scope_match_columns = [column for column in RESULT_COLUMNS if column != "scenario"]
+        model_keys = model_rows.select(["scenario"] + join_columns).unique()
+        reference_keys_for_models = (
+            model_rows
+            .select(RESULT_COLUMNS)
+            .unique()
+            .join(
+                reference_rows.select(join_columns).unique(),
+                on=scope_match_columns,
+                how="inner",
+            )
+            .select(["scenario"] + join_columns)
+        )
+        model_index = pl.concat(
+            [model_keys, reference_keys_for_models],
+            how="vertical_relaxed",
+        ).unique()
+        model_rows = (
+            model_index
+            .join(model_rows, on=["scenario"] + join_columns, how="left")
+            .with_columns(pl.col(metric_column).fill_null(0.0))
+        )
         output_columns = [
             column
             for column in model_rows.columns
@@ -922,9 +1077,36 @@ class GroupDayTripsResultMetrics:
         model_replications = per_replication_values.filter(
             pl.col("scenario").is_in(model_scenarios)
         )
+        replication_scope_match_columns = [column for column in SCOPE_COLUMNS if column != "scenario"]
+        model_replication_columns = SCOPE_COLUMNS + dimension_columns
+        model_replication_keys = model_replications.select(model_replication_columns).unique()
+        reference_replication_keys_for_models = (
+            model_replications
+            .select(SCOPE_COLUMNS)
+            .unique()
+            .join(
+                reference_replications.select(pairing_columns).unique(),
+                on=replication_scope_match_columns,
+                how="inner",
+            )
+            .select(model_replication_columns)
+        )
+        replication_index = pl.concat(
+            [model_replication_keys, reference_replication_keys_for_models],
+            how="vertical_relaxed",
+        ).unique()
+        model_replications = (
+            replication_index
+            .join(model_replications, on=model_replication_columns, how="left")
+            .with_columns(pl.col(metric_column).fill_null(0.0))
+        )
+        reference_replications = reference_replications.with_columns(
+            pl.col(reference_column).fill_null(0.0)
+        )
         paired_gaps = (
             model_replications
-            .join(reference_replications, on=pairing_columns, how="inner")
+            .join(reference_replications, on=pairing_columns, how="left")
+            .with_columns(pl.col(reference_column).fill_null(0.0))
             .with_columns(
                 paired_gap=pl.col(metric_column) - pl.col(reference_column),
             )
@@ -940,6 +1122,7 @@ class GroupDayTripsResultMetrics:
             .join(reference_rows, on=join_columns, how="left")
             .join(paired_gaps, on=paired_output_columns, how="left")
             .with_columns(
+                pl.col(reference_column).fill_null(0.0),
                 reference_source=pl.lit(f"scenario:{reference_scenario}"),
                 relative_gap=(
                     pl.col("gap") / pl.col(reference_column).abs().clip(1e-12)
@@ -1253,6 +1436,9 @@ class GroupDayTripsResultMetrics:
         group_columns: list[str],
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Return an absolute weighted quantity averaged over replications."""
         plan_steps = self._metric_plan_steps(
@@ -1260,7 +1446,20 @@ class GroupDayTripsResultMetrics:
             group_columns=group_columns,
             inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
+            attach_quantity=False,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
         )
+        if quantity_column not in plan_steps.collect_schema().names():
+            return self._weighted_quantity_from_costs(
+                plan_steps,
+                quantity_column=quantity_column,
+                output_column=output_column,
+                group_columns=group_columns,
+                iterations=iterations,
+            )
+
         required_columns = set(SCOPE_COLUMNS + group_columns + ["activity_seq_id", quantity_column, "n_persons"])
         missing_columns = required_columns.difference(plan_steps.collect_schema().names())
         if missing_columns:
@@ -1279,6 +1478,11 @@ class GroupDayTripsResultMetrics:
                     pl.col(quantity_column).cast(pl.Float64)
                     * pl.col("n_persons").cast(pl.Float64)
                 ).sum()
+            )
+            .pipe(
+                complete_missing_replication_groups,
+                group_columns=group_columns,
+                value_column="value",
             )
             .group_by(output_columns)
             .agg(
@@ -1302,6 +1506,9 @@ class GroupDayTripsResultMetrics:
         normalize_scope: NormalizeScope | None,
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Return metric values before averaging replications."""
         if quantity == "trip_count":
@@ -1311,6 +1518,9 @@ class GroupDayTripsResultMetrics:
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
                 value_column=value_column,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+                modes=modes,
             )
         else:
             value_column = quantity
@@ -1320,6 +1530,9 @@ class GroupDayTripsResultMetrics:
                 group_columns=group_columns,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
+                modes=modes,
             )
 
         if normalize_by == "person_count":
@@ -1332,6 +1545,8 @@ class GroupDayTripsResultMetrics:
                 output_column=metric_column,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
             )
         elif normalize_by == "metric_total":
             per_replication = self._with_metric_total_share_by_replication(
@@ -1356,12 +1571,18 @@ class GroupDayTripsResultMetrics:
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
         value_column: str,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Return weighted trip counts by replication."""
         plan_steps = self._metric_plan_steps(
             group_columns=group_columns,
             inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
         )
         return (
             plan_steps
@@ -1384,6 +1605,9 @@ class GroupDayTripsResultMetrics:
         group_columns: list[str],
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Return one weighted quantity by replication."""
         plan_steps = self._metric_plan_steps(
@@ -1391,7 +1615,20 @@ class GroupDayTripsResultMetrics:
             group_columns=group_columns,
             inner_zone_residents_only=inner_zone_residents_only,
             iterations=iterations,
+            attach_quantity=False,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
         )
+        if quantity_column not in plan_steps.collect_schema().names():
+            return self._weighted_quantity_from_costs_by_replication(
+                plan_steps,
+                quantity_column=quantity_column,
+                output_column=output_column,
+                group_columns=group_columns,
+                iterations=iterations,
+            )
+
         return (
             plan_steps
             .filter(pl.col("activity_seq_id") != 0)
@@ -1401,6 +1638,11 @@ class GroupDayTripsResultMetrics:
                     pl.col(quantity_column).cast(pl.Float64)
                     * pl.col("n_persons").cast(pl.Float64)
                 ).sum().alias(output_column)
+            )
+            .pipe(
+                complete_missing_replication_groups,
+                group_columns=group_columns,
+                value_column=output_column,
             )
             .collect(engine="streaming")
         )
@@ -1412,34 +1654,226 @@ class GroupDayTripsResultMetrics:
         group_columns: list[str],
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        attach_quantity: bool = True,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
     ) -> pl.LazyFrame:
         """Return plan steps with the columns needed by metric queries."""
-        if quantity_column is None:
-            plan_steps = self._table("plan_steps", iterations=iterations).get()
+        plan_columns = self._metric_plan_step_columns(
+            quantity_column=quantity_column,
+            group_columns=group_columns,
+            inner_zone_residents_only=inner_zone_residents_only,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
+        )
+        if quantity_column is None or not attach_quantity:
+            plan_steps = self._table(
+                "plan_steps",
+                iterations=iterations,
+                columns=plan_columns,
+            ).get()
         else:
             plan_steps = self._plan_steps_with_quantity(
                 quantity_column,
                 iterations=iterations,
+                plan_columns=plan_columns,
             )
         needed_demand_columns = [
             column
             for column in group_columns
             if column in DEMAND_GROUP_COLUMNS
         ]
+        if home_zone_ids is not None and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if csp is not None and "csp" not in needed_demand_columns:
+            needed_demand_columns.append("csp")
         if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
             needed_demand_columns.append("home_zone_id")
         if needed_demand_columns:
             plan_steps = add_demand_group_columns(
                 plan_steps,
-                self._table("demand_groups", iterations=iterations).get(),
+                self._table(
+                    "demand_groups",
+                    iterations=iterations,
+                    columns=self._demand_group_columns(needed_demand_columns),
+                ).get(),
                 needed_demand_columns,
             )
+        plan_steps = self._filter_demand_group_rows(
+            plan_steps,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+            modes=modes,
+        )
         if inner_zone_residents_only:
             plan_steps = filter_plan_steps_to_inner_zone_residents(
                 plan_steps,
                 self.results.transport_zones,
             )
         return with_analysis_dimensions(plan_steps, group_columns)
+
+    def _weighted_quantity_from_costs(
+        self,
+        plan_steps: pl.LazyFrame,
+        *,
+        quantity_column: str,
+        output_column: str,
+        group_columns: list[str],
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return a weighted quantity after joining route-level flows to costs."""
+        output_columns = RESULT_COLUMNS + group_columns
+        values = self._route_flows_with_cost_quantity(
+            plan_steps,
+            quantity_column=quantity_column,
+            group_columns=group_columns,
+            iterations=iterations,
+        )
+        return (
+            values
+            .group_by(SCOPE_COLUMNS + group_columns)
+            .agg(
+                value=(
+                    pl.col(quantity_column).cast(pl.Float64)
+                    * pl.col("n_persons").cast(pl.Float64)
+                ).sum()
+            )
+            .pipe(
+                complete_missing_replication_groups,
+                group_columns=group_columns,
+                value_column="value",
+            )
+            .group_by(output_columns)
+            .agg(
+                pl.col("value").mean().alias(output_column),
+                pl.col("value").std().alias(f"{output_column}_std"),
+                pl.col("replication").n_unique().cast(pl.UInt32).alias("n_replications"),
+            )
+            .sort(output_columns)
+            .collect(engine="streaming")
+        )
+
+    def _weighted_quantity_from_costs_by_replication(
+        self,
+        plan_steps: pl.LazyFrame,
+        *,
+        quantity_column: str,
+        output_column: str,
+        group_columns: list[str],
+        iterations: IterationSelector,
+    ) -> pl.DataFrame:
+        """Return a per-replication weighted quantity using route-level costs."""
+        values = self._route_flows_with_cost_quantity(
+            plan_steps,
+            quantity_column=quantity_column,
+            group_columns=group_columns,
+            iterations=iterations,
+        )
+        return (
+            values
+            .group_by(SCOPE_COLUMNS + group_columns)
+            .agg(
+                (
+                    pl.col(quantity_column).cast(pl.Float64)
+                    * pl.col("n_persons").cast(pl.Float64)
+                ).sum().alias(output_column)
+            )
+            .pipe(
+                complete_missing_replication_groups,
+                group_columns=group_columns,
+                value_column=output_column,
+            )
+            .collect(engine="streaming")
+        )
+
+    def _route_flows_with_cost_quantity(
+        self,
+        plan_steps: pl.LazyFrame,
+        *,
+        quantity_column: str,
+        group_columns: list[str],
+        iterations: IterationSelector,
+    ) -> pl.LazyFrame:
+        """Aggregate plan steps to OD-mode flows before joining transport costs."""
+        route_columns = ["from", "to", "mode"]
+        join_columns = SCOPE_COLUMNS + route_columns
+        flow_columns = list(dict.fromkeys(SCOPE_COLUMNS + group_columns + route_columns))
+        flows = (
+            plan_steps
+            .filter(pl.col("activity_seq_id") != 0)
+            .with_columns(pl.col(column).cast(pl.String) for column in route_columns)
+            .group_by(flow_columns)
+            .agg(pl.col("n_persons").cast(pl.Float64).sum().alias("n_persons"))
+        )
+        costs = (
+            self._table(
+                "costs",
+                iterations=iterations,
+                columns=join_columns + [quantity_column],
+            )
+            .get()
+            .with_columns(pl.col(column).cast(pl.String) for column in route_columns)
+            .select(join_columns + [quantity_column])
+        )
+        return flows.join(costs, on=join_columns, how="left")
+
+    @staticmethod
+    def _metric_plan_step_columns(
+        *,
+        quantity_column: str | None,
+        group_columns: list[str],
+        inner_zone_residents_only: bool,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
+        modes: DemandGroupSelector = None,
+    ) -> list[str]:
+        """Return raw plan-step columns needed for one metric query."""
+        columns = list(SCOPE_COLUMNS) + ["activity_seq_id", "n_persons"]
+        if quantity_column is not None:
+            columns.append(quantity_column)
+        if quantity_column not in {None, "distance", "time"}:
+            columns.extend(["from", "to", "mode"])
+        if modes is not None:
+            columns.append("mode")
+        needed_demand_columns = [
+            column
+            for column in group_columns
+            if column in DEMAND_GROUP_COLUMNS
+        ]
+        if home_zone_ids is not None and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if csp is not None and "csp" not in needed_demand_columns:
+            needed_demand_columns.append("csp")
+        if inner_zone_residents_only and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if home_zone_ids is not None and "home_zone_id" not in needed_demand_columns:
+            needed_demand_columns.append("home_zone_id")
+        if csp is not None and "csp" not in needed_demand_columns:
+            needed_demand_columns.append("csp")
+        if needed_demand_columns:
+            columns.extend(needed_demand_columns)
+            columns.append("demand_group_id")
+            columns.append("demand_subgroup_id")
+        raw_group_columns = {
+            "origin_zone_id": "from",
+            "destination_zone_id": "to",
+            "mode": "mode",
+            "activity": "activity",
+            "distance_bin": "distance",
+            "time_bin": "time",
+        }
+        for group_column in group_columns:
+            raw_column = raw_group_columns.get(group_column)
+            if raw_column is not None:
+                columns.append(raw_column)
+        return list(dict.fromkeys(columns))
+
+    @staticmethod
+    def _demand_group_columns(extra_columns: list[str]) -> list[str]:
+        """Return scoped demand-group columns needed for joins or population."""
+        return list(dict.fromkeys(SCOPE_COLUMNS + ["demand_group_id", "demand_subgroup_id", "n_persons"] + list(extra_columns)))
 
     def _with_person_count_normalization_by_replication(
         self,
@@ -1452,6 +1886,8 @@ class GroupDayTripsResultMetrics:
         output_column: str,
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Normalize one per-replication metric by population."""
         if normalize_scope == "zone":
@@ -1463,6 +1899,8 @@ class GroupDayTripsResultMetrics:
                 by_replication=True,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
             )
             join_columns = SCOPE_COLUMNS + [zone_column]
         else:
@@ -1470,6 +1908,8 @@ class GroupDayTripsResultMetrics:
                 by_replication=True,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
             )
             join_columns = SCOPE_COLUMNS
 
@@ -1513,6 +1953,8 @@ class GroupDayTripsResultMetrics:
         output_column: str,
         inner_zone_residents_only: bool,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Normalize a metric by population at the requested scope."""
         if normalize_scope == "zone":
@@ -1523,12 +1965,16 @@ class GroupDayTripsResultMetrics:
                 zone_column=zone_column,
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
             )
             join_columns = RESULT_COLUMNS + [zone_column]
         else:
             population = self._population(
                 inner_zone_residents_only=inner_zone_residents_only,
                 iterations=iterations,
+                home_zone_ids=home_zone_ids,
+                csp=csp,
             )
             join_columns = RESULT_COLUMNS
 
@@ -1574,14 +2020,32 @@ class GroupDayTripsResultMetrics:
         quantity_column: str,
         *,
         iterations: IterationSelector,
+        plan_columns: list[str] | None = None,
     ) -> pl.LazyFrame:
         """Return plan steps, joining costs when the requested quantity is absent."""
-        plan_steps = self._table("plan_steps", iterations=iterations).get()
+        plan_steps = self._table(
+            "plan_steps",
+            iterations=iterations,
+            columns=plan_columns,
+        ).get()
         if quantity_column in plan_steps.collect_schema().names():
             return plan_steps
 
-        costs = self._table("costs", iterations=iterations).get()
         join_columns = SCOPE_COLUMNS + ["from", "to", "mode"]
+        costs = self._table(
+            "costs",
+            iterations=iterations,
+            columns=join_columns + [quantity_column],
+        ).get()
+        route_join_columns = ["from", "to", "mode"]
+        plan_steps = plan_steps.with_columns(
+            pl.col(column).cast(pl.String)
+            for column in route_join_columns
+        )
+        costs = costs.with_columns(
+            pl.col(column).cast(pl.String)
+            for column in route_join_columns
+        )
         return plan_steps.join(
             costs.select(join_columns + [quantity_column]),
             on=join_columns,
@@ -1599,6 +2063,87 @@ class GroupDayTripsResultMetrics:
             return values
         selected_scenarios = select_scenarios(self.results, scenarios)
         return values.filter(pl.col("scenario").is_in(selected_scenarios))
+
+    @staticmethod
+    def _selector_values(
+        selector: DemandGroupSelector,
+        *,
+        name: str,
+        allow_int: bool = False,
+    ) -> list[str]:
+        """Return a demand-group selector as a non-empty string list."""
+        if selector is None:
+            return []
+        if isinstance(selector, (str, int)):
+            values = [selector]
+        elif isinstance(selector, (list, tuple)):
+            values = list(selector)
+        else:
+            raise TypeError(f"{name} should be one value or a list of values.")
+        if not values:
+            raise ValueError(f"{name} should not be an empty list.")
+        allowed_types = (str, int) if allow_int else (str,)
+        if not all(isinstance(value, allowed_types) for value in values):
+            expected = "strings or integers" if allow_int else "strings"
+            raise TypeError(f"{name} should only contain {expected}.")
+        return [str(value) for value in values]
+
+    @classmethod
+    def _validate_demand_group_filters(
+        cls,
+        *,
+        home_zone_ids: DemandGroupSelector,
+        csp: DemandGroupSelector,
+        modes: DemandGroupSelector = None,
+    ) -> None:
+        """Check metric filter selectors."""
+        cls._selector_values(home_zone_ids, name="home_zone_ids", allow_int=True)
+        cls._selector_values(csp, name="csp")
+        cls._selector_values(modes, name="modes")
+
+    @staticmethod
+    def _has_metric_filter(
+        *,
+        home_zone_ids: DemandGroupSelector,
+        csp: DemandGroupSelector,
+        modes: DemandGroupSelector = None,
+    ) -> bool:
+        """Return whether one metric row filter is active."""
+        return home_zone_ids is not None or csp is not None or modes is not None
+
+    @classmethod
+    def _filter_demand_group_rows(
+        cls,
+        frame: pl.LazyFrame,
+        *,
+        home_zone_ids: DemandGroupSelector,
+        csp: DemandGroupSelector,
+        modes: DemandGroupSelector = None,
+    ) -> pl.LazyFrame:
+        """Filter rows to selected resident groups and modes."""
+        home_zone_values = cls._selector_values(home_zone_ids, name="home_zone_ids", allow_int=True)
+        csp_values = cls._selector_values(csp, name="csp")
+        mode_values = cls._selector_values(modes, name="modes")
+        if not home_zone_values and not csp_values and not mode_values:
+            return frame
+        schema = frame.collect_schema().names()
+        filters = []
+        if home_zone_values:
+            if "home_zone_id" not in schema:
+                raise ValueError("Filtering by home_zone_ids needs `home_zone_id`.")
+            filters.append(pl.col("home_zone_id").cast(pl.String).is_in(home_zone_values))
+        if csp_values:
+            if "csp" not in schema:
+                raise ValueError("Filtering by csp needs `csp`.")
+            filters.append(pl.col("csp").cast(pl.String).is_in(csp_values))
+        if mode_values:
+            if "mode" not in schema:
+                raise ValueError("Filtering by modes needs `mode`.")
+            filters.append(pl.col("mode").cast(pl.String).is_in(mode_values))
+        predicate = filters[0]
+        for extra_filter in filters[1:]:
+            predicate = predicate & extra_filter
+        return frame.filter(predicate)
 
     def _survey_reference_marginal(self, marginal_columns: list[str]) -> SurveyReferenceMarginal:
         """Build one cached survey-reference marginal."""
@@ -1658,9 +2203,16 @@ class GroupDayTripsResultMetrics:
         by_replication: bool = False,
         inner_zone_residents_only: bool = False,
         iterations: IterationSelector,
+        home_zone_ids: DemandGroupSelector = None,
+        csp: DemandGroupSelector = None,
     ) -> pl.DataFrame:
         """Return resident population for the requested result scope."""
         demand_groups = self._table("demand_groups", iterations=iterations).get()
+        demand_groups = self._filter_demand_group_rows(
+            demand_groups,
+            home_zone_ids=home_zone_ids,
+            csp=csp,
+        )
         if inner_zone_residents_only:
             demand_groups = filter_demand_groups_to_inner_zone_residents(
                 demand_groups,

--- a/mobility/trips/group_day_trips/results/plots.py
+++ b/mobility/trips/group_day_trips/results/plots.py
@@ -291,10 +291,18 @@ def plot_metric_over_iterations(
     fig.update_layout(
         width=width,
         height=height,
+        title={
+            "text": title,
+            "x": 0.02,
+            "xanchor": "left",
+            "y": 0.98,
+            "yanchor": "top",
+            "pad": {"b": 6},
+        },
         xaxis_title="Iteration",
         yaxis_title=metric.replace("_", " "),
         showlegend=True,
-        margin={"l": 70, "r": 45, "t": 95, "b": 80},
+        margin={"l": 70, "r": 45, "t": 92, "b": 80},
         legend={
             "orientation": "h",
             "yanchor": "bottom",

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -13,8 +13,12 @@ from mobility.reports import TransportZoneMaps
 from mobility.runtime import Scenario, Scenarios
 from mobility.runtime.parameter_values import SensitivityCase, SensitivityValue
 from mobility.runtime.assets.file_asset import FileAsset
+from mobility.runtime.assets.graph import build_asset_graph
+from mobility.runtime.assets.resolver import AssetResolver
 from mobility.trips.group_day_trips.core.group_day_trips import PopulationGroupDayTrips
+from mobility.trips.group_day_trips.core.run import Run
 from mobility.trips.group_day_trips.results import GroupDayTripsResults
+from mobility.trips.group_day_trips.results.metrics import GroupDayTripsResultMetrics
 from mobility.trips.group_day_trips.sensitivity import GroupDayTripsSensitivityAnalysis
 from mobility.trips.group_day_trips.results.plots import (
     plot_metric_by_zone,
@@ -39,6 +43,7 @@ class _FakeRun(FileAsset):
         transport_zones: FileAsset | None = None,
         surveys: list | None = None,
         iteration_plan_steps: dict[int, pl.DataFrame] | None = None,
+        iteration_costs: dict[int, pl.DataFrame] | None = None,
     ) -> None:
         self.frames = {
             "plan_steps": plan_steps,
@@ -50,6 +55,7 @@ class _FakeRun(FileAsset):
         }
         self._reference_plan_steps = reference_plan_steps
         self._iteration_plan_steps = iteration_plan_steps or {}
+        self._iteration_costs = iteration_costs or {}
         self.parameters = SimpleNamespace(
             run=SimpleNamespace(n_iterations=max(self._iteration_plan_steps, default=1))
         )
@@ -82,9 +88,11 @@ class _FakeRun(FileAsset):
 
     def iteration_table(self, table_name: str, iteration: int):
         """Return one fake saved iteration table."""
-        if table_name != "plan_steps":
-            raise ValueError(f"Fake run has no saved iteration table `{table_name}`.")
-        return self._iteration_plan_steps[iteration].lazy()
+        if table_name == "plan_steps":
+            return self._iteration_plan_steps[iteration].lazy()
+        if table_name == "costs":
+            return self._iteration_costs[iteration].lazy()
+        raise ValueError(f"Fake run has no saved iteration table `{table_name}`.")
 
 
 class _FakeLazyFrameAsset(FileAsset):
@@ -205,6 +213,8 @@ def _run_factory(base_folder: Path):
                     5.0 + 2.0 * replication + scenario_distance_shift,
                 ],
                 "time": [1.0 + replication, 0.5 + 0.2 * replication],
+                "cost": [2.0 + 2.0 * replication, 1.0 + 2.0 * replication],
+                "ghg_emissions_per_trip": [1.0 + replication, 0.5 + 0.5 * replication],
                 "duration_per_pers": [8.5, 0.75],
                 "departure_time": [8.0, 10.0],
                 "arrival_time": [8.5, 10.25],
@@ -252,6 +262,7 @@ def _run_factory(base_folder: Path):
             transport_zones=transport_zones,
             surveys=[survey],
             iteration_plan_steps=iteration_plan_steps,
+            iteration_costs={1: costs, 2: costs},
         )
 
     return run
@@ -533,6 +544,39 @@ def test_iteration_travel_metrics_can_group_by_demand_group_columns(tmp_path, mo
     assert time["travel_time"].to_list() == pytest.approx([0.5, 2.0, 0.5, 2.0])
 
 
+def test_iteration_emissions_use_quantity_stored_on_plan_steps(tmp_path, monkeypatch):
+    """Check saved iteration emissions do not need iteration-scoped cost tables."""
+    results = _results(tmp_path, replication=0)
+
+    emissions = results.metrics.ghg_emissions(
+        by_variable="mode",
+        iterations=[1, 2],
+    ).sort(["iteration", "mode"])
+
+    assert emissions["iteration"].to_list() == [1, 1, 2, 2]
+    assert emissions["mode"].to_list() == ["car", "walk", "car", "walk"]
+    assert emissions["ghg_emissions"].to_list() == pytest.approx([2.0, 0.5, 2.0, 0.5])
+
+
+def test_iteration_emissions_can_join_saved_iteration_costs(tmp_path, monkeypatch):
+    """Check emissions can use saved iteration costs when plan steps are narrow."""
+    results = _results(tmp_path, replication=0)
+    for run_context in results.run_contexts:
+        run_context.run._iteration_plan_steps = {
+            iteration: plan_steps.drop("ghg_emissions_per_trip")
+            for iteration, plan_steps in run_context.run._iteration_plan_steps.items()
+        }
+
+    emissions = results.metrics.ghg_emissions(
+        by_variable="mode",
+        iterations=[1, 2],
+    ).sort(["iteration", "mode"])
+
+    assert emissions["iteration"].to_list() == [1, 1, 2, 2]
+    assert emissions["mode"].to_list() == ["car", "walk", "car", "walk"]
+    assert emissions["ghg_emissions"].to_list() == pytest.approx([2.0, 0.5, 2.0, 0.5])
+
+
 def test_iteration_final_state_metrics_use_demand_group_columns(tmp_path, monkeypatch):
     """Check saved iteration final-state metrics can join demand-group dimensions."""
     results = _results(tmp_path, replication=0)
@@ -789,6 +833,212 @@ def test_compact_time_cost_and_emissions_metrics(tmp_path, monkeypatch):
     assert emissions["ghg_emissions_per_person"].to_list() == pytest.approx([(2.5 / 3.0 + 5.0 / 3.0) / 2.0])
 
 
+def test_weighted_metrics_count_zero_trip_groups_in_each_replication(tmp_path, monkeypatch):
+    """Check weighted metrics treat missing replication/group rows as zero."""
+    base_factory = _run_factory(tmp_path)
+
+    def run(day_type: str, *, scenario=None, sensitivity_case=None, replication: int = 0):
+        run_asset = base_factory(
+            day_type,
+            scenario=scenario,
+            sensitivity_case=sensitivity_case,
+            replication=replication,
+        )
+        if replication == 1:
+            run_asset.frames["plan_steps"] = run_asset.frames["plan_steps"].with_columns(
+                pl.when(pl.col("home_zone_id") == "z2")
+                .then(pl.lit(0))
+                .otherwise(pl.col("activity_seq_id"))
+                .alias("activity_seq_id")
+            )
+        return run_asset
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios="default",
+        n_replications=2,
+    )
+
+    distance = results.metrics.travel_distance(by_zone="home_zone").sort("home_zone_id")
+
+    assert distance["home_zone_id"].to_list() == ["z1", "z2"]
+    assert distance["travel_distance"].to_list() == pytest.approx([30.0, 2.5])
+    assert distance["travel_distance_std"].to_list() == pytest.approx([14.1421356237, 3.5355339059])
+    assert distance["n_replications"].to_list() == [2, 2]
+
+
+def test_compact_metrics_can_filter_demand_groups(tmp_path, monkeypatch):
+    """Check metrics can focus on selected resident home zones or CSPs."""
+    results = _results(tmp_path)
+
+    z1_trips = results.metrics.trip_count(by_variable="mode", home_zone_ids="z1").sort("mode")
+    worker_distance = results.metrics.travel_distance(
+        by_variable="mode",
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        csp="worker",
+    ).sort("mode")
+    selected_emissions = results.metrics.ghg_emissions(
+        by_variable="mode",
+        home_zone_ids=["z1"],
+        csp=["worker"],
+    ).sort("mode")
+    walk_trips = results.metrics.trip_count(by_variable="mode", modes="walk").sort("mode")
+    selected_mode_distance = results.metrics.travel_distance(modes=["walk"]).sort("scenario")
+
+    assert z1_trips["mode"].to_list() == ["car"]
+    assert z1_trips["trip_count"].to_list() == pytest.approx([2.0])
+    assert worker_distance["mode"].to_list() == ["car"]
+    assert worker_distance["travel_distance_per_person"].to_list() == pytest.approx([15.0])
+    assert selected_emissions["mode"].to_list() == ["car"]
+    assert selected_emissions["ghg_emissions"].to_list() == pytest.approx([3.0])
+    assert walk_trips["mode"].to_list() == ["walk"]
+    assert walk_trips["trip_count"].to_list() == pytest.approx([1.0])
+    assert selected_mode_distance["travel_distance"].to_list() == pytest.approx([6.0])
+
+    integer_zone_frame = pl.DataFrame({"home_zone_id": [1, 2], "n_persons": [1.0, 2.0]}).lazy()
+    filtered_integer_zone = GroupDayTripsResultMetrics._filter_demand_group_rows(
+        integer_zone_frame,
+        home_zone_ids=1,
+        csp=None,
+    ).collect()
+    assert filtered_integer_zone["home_zone_id"].to_list() == [1]
+
+
+def test_compact_metric_filters_are_not_available_with_external_reference(tmp_path, monkeypatch):
+    """Check demand-group filters are not mixed with external survey references."""
+    results = _results(tmp_path)
+
+    with pytest.raises(ValueError, match="External references"):
+        results.metrics.trip_count(by_variable="mode", home_zone_ids="z1", reference="external")
+
+
+def test_compact_metric_call_reuses_one_asset_resolver(tmp_path, monkeypatch):
+    """Check one public metric query shares asset graph work across sibling assets."""
+    results = _results(tmp_path)
+    resolver_ids = []
+    original_get_dependency_graph = AssetResolver._get_dependency_graph
+
+    def record_resolver(self, *args, **kwargs):
+        resolver_ids.append(id(self))
+        return original_get_dependency_graph(self, *args, **kwargs)
+
+    monkeypatch.setattr(AssetResolver, "_get_dependency_graph", record_resolver)
+
+    results.metrics.trip_count(
+        by_variable="activity",
+        normalize_by="person_count",
+        normalize_scope="study_area",
+        output="plot",
+        inner_zone_residents_only=True,
+        iterations="last",
+        reference="external",
+        reference_view="values",
+    )
+
+    assert resolver_ids
+    assert len(set(resolver_ids)) == 1
+
+
+def test_scoped_run_table_does_not_depend_on_full_run_asset(tmp_path):
+    """Check result tables validate compact run outputs, not the full run DAG."""
+    results = _results(tmp_path)
+
+    graph = build_asset_graph(
+        results.metrics._table("plan_steps"),
+        include_root=True,
+        file_assets_only=True,
+        include_node_data=False,
+    )
+
+    assert not any(isinstance(asset, _FakeRun) for asset in graph.nodes)
+
+
+def test_run_iteration_table_scans_cached_plan_steps_without_state_load(tmp_path):
+    """Check all-iteration results do not load the full saved iteration state."""
+    plan_steps_path = tmp_path / "current_plan_steps.parquet"
+    pl.DataFrame({"activity_seq_id": [1], "n_persons": [2.0]}).write_parquet(plan_steps_path)
+
+    class CachedStateAsset:
+        cache_path = {"current_plan_steps": plan_steps_path}
+
+        def get(self):
+            raise AssertionError("Run.iteration_table should scan cached plan steps directly.")
+
+    run = object.__new__(Run)
+    run.iteration_state_assets = [CachedStateAsset()]
+
+    table = run.iteration_table("plan_steps", 1).collect()
+
+    assert table["n_persons"].to_list() == [2.0]
+
+
+def test_metric_projection_accepts_plan_steps_without_demand_group_id(tmp_path):
+    """Check projected final plan steps can use direct home-zone columns."""
+    transport_zones = _FakeTransportZones(base_folder=tmp_path)
+    reference_plan_steps = _FakeLazyFrameAsset(
+        base_folder=tmp_path,
+        name="reference_plan_steps_direct_home_zone",
+        frame=pl.DataFrame(
+            {
+                "home_zone_id": ["z1", "z2"],
+                "activity_seq_id": [1, 1],
+                "mode": ["car", "walk"],
+                "n_persons": [2.0, 1.0],
+            }
+        ),
+    )
+
+    def run(day_type: str, *, scenario=None, sensitivity_case=None, replication: int = 0):
+        plan_steps = pl.DataFrame(
+            {
+                "activity_seq_id": [1, 1],
+                "home_zone_id": ["z1", "z2"],
+                "from": ["z1", "z2"],
+                "to": ["z3", "z4"],
+                "mode": ["car", "walk"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        demand_groups = pl.DataFrame(
+            {
+                "demand_group_id": [1, 2],
+                "home_zone_id": ["z1", "z2"],
+                "n_persons": [2.0, 1.0],
+            }
+        )
+        return _FakeRun(
+            base_folder=tmp_path,
+            name=f"direct_home_zone_{scenario or 'default'}_{day_type}_{replication}",
+            plan_steps=plan_steps,
+            demand_groups=demand_groups,
+            costs=pl.DataFrame({"from": ["z1", "z2"], "to": ["z3", "z4"], "mode": ["car", "walk"]}),
+            opportunities=pl.DataFrame(),
+            iteration_metrics=pl.DataFrame(),
+            reference_plan_steps=reference_plan_steps,
+            transport_zones=transport_zones,
+        )
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios="default",
+        n_replications=1,
+    )
+
+    metric = results.metrics.trip_count(
+        by_variable="mode",
+        by_zone="home_zone",
+        normalize_by="metric_total",
+        normalize_scope="zone",
+        inner_zone_residents_only=True,
+    ).sort(["home_zone_id", "mode"])
+
+    assert metric["home_zone_id"].to_list() == ["z1", "z2"]
+    assert metric["trip_count_share"].to_list() == pytest.approx([1.0, 1.0])
+
+
 def test_metrics_can_include_survey_reference(tmp_path, monkeypatch):
     """Check supported quantities can opt into external references."""
     results = _results(tmp_path)
@@ -978,6 +1228,109 @@ def test_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
         "scenario:default",
     ]
     assert distance_values["travel_distance"].to_list() == pytest.approx([36.0, 9.0, 30.0, 6.0])
+
+    emissions_by_home_zone = results.metrics.ghg_emissions(
+        by_zone="home_zone",
+        inner_zone_residents_only=True,
+        reference=("scenario", "default"),
+    ).sort("home_zone_id")
+
+    assert emissions_by_home_zone["scenario"].to_list() == ["test", "test"]
+    assert emissions_by_home_zone["home_zone_id"].to_list() == ["z1", "z2"]
+    assert emissions_by_home_zone["ghg_emissions"].to_list() == pytest.approx([3.0, 0.75])
+    assert emissions_by_home_zone["ghg_emissions_reference"].to_list() == pytest.approx([3.0, 0.75])
+    assert emissions_by_home_zone["gap"].to_list() == pytest.approx([0.0, 0.0])
+
+
+def test_scenario_reference_pairs_replications_within_sensitivity_case(tmp_path, monkeypatch):
+    """Check scenario deltas do not mix reference runs from other sensitivity cases."""
+    base_factory = _run_factory(tmp_path)
+    sensitivity_case = SensitivityCase(
+        case_id="high_distance",
+        parameter_name="distance",
+        parameter_label="Distance",
+        variation_type="absolute",
+        variation_value=100.0,
+        variation_label="+100",
+    )
+
+    def run(day_type: str, *, scenario: str | None = None, sensitivity_case=None, replication: int = 0):
+        run_asset = base_factory(
+            day_type,
+            scenario=scenario,
+            sensitivity_case=sensitivity_case,
+            replication=replication,
+        )
+        if sensitivity_case is not None:
+            run_asset.frames["plan_steps"] = run_asset.frames["plan_steps"].with_columns(
+                pl.when(pl.col("mode") == "car")
+                .then(pl.col("distance") + 100.0)
+                .otherwise(pl.col("distance"))
+                .alias("distance")
+            )
+        return run_asset
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios=["default", "test"],
+        n_replications=2,
+        sensitivity_cases=[None, sensitivity_case],
+    )
+
+    distance = results.metrics.travel_distance(
+        by_variable="mode",
+        reference=("scenario", "default"),
+    ).sort(["sensitivity_case", "mode"])
+
+    assert distance["sensitivity_case"].to_list() == [
+        "base",
+        "base",
+        "high_distance",
+        "high_distance",
+    ]
+    assert distance["mode"].to_list() == ["car", "walk", "car", "walk"]
+    assert distance["gap"].to_list() == pytest.approx([6.0, 3.0, 6.0, 3.0])
+
+
+def test_scenario_reference_compares_missing_dimension_rows_to_zero(tmp_path, monkeypatch):
+    """Check scenario gaps keep modes that exist only on one side of the comparison."""
+    base_factory = _run_factory(tmp_path)
+
+    def run(day_type: str, *, scenario: str | None = None, sensitivity_case=None, replication: int = 0):
+        run_asset = base_factory(
+            day_type,
+            scenario=scenario,
+            sensitivity_case=sensitivity_case,
+            replication=replication,
+        )
+        if scenario == "test":
+            run_asset.frames["plan_steps"] = run_asset.frames["plan_steps"].with_columns(
+                pl.when(pl.col("home_zone_id") == "z1")
+                .then(pl.lit("walk/public_transport/walk"))
+                .otherwise(pl.col("mode"))
+                .alias("mode")
+            )
+        return run_asset
+
+    results = GroupDayTripsResults(
+        run=run,
+        day_type="weekday",
+        scenarios=["default", "test"],
+        n_replications=1,
+    )
+
+    trip_count = results.metrics.trip_count(
+        by_zone="home_zone",
+        by_variable="mode",
+        reference=("scenario", "default"),
+    ).sort(["home_zone_id", "mode"])
+
+    assert trip_count["home_zone_id"].to_list() == ["z1", "z1", "z2"]
+    assert trip_count["mode"].to_list() == ["car", "walk/public_transport/walk", "walk"]
+    assert trip_count["trip_count"].to_list() == pytest.approx([0.0, 2.0, 1.0])
+    assert trip_count["trip_count_reference"].to_list() == pytest.approx([2.0, 0.0, 1.0])
+    assert trip_count["gap"].to_list() == pytest.approx([-2.0, 2.0, 0.0])
 
 
 def test_iteration_metrics_can_use_scenario_reference(tmp_path, monkeypatch):
@@ -1218,6 +1571,9 @@ def test_metric_plot_uses_line_chart_for_multiple_iterations(tmp_path, monkeypat
 
     assert isinstance(fig, BaseFigure)
     assert fig.layout.title.text == "Travel distance by mode"
+    assert fig.layout.title.y == pytest.approx(0.98)
+    assert fig.layout.legend.y == pytest.approx(1.03)
+    assert 85 <= fig.layout.margin.t <= 100
     assert fig.layout.xaxis.title.text == "Iteration"
     assert all(trace.type == "scatter" for trace in fig.data)
     ribbon_traces = [trace for trace in fig.data if trace.fill == "toself"]
@@ -1333,6 +1689,7 @@ def test_reference_gap_map_uses_diverging_colors(tmp_path, monkeypatch):
     """Check map plots of reference gaps use a zero-centered diverging scale."""
     results = _results(tmp_path, scenarios=["default", "test"])
     calls = _record_metric_plot(monkeypatch, "plot_metric_grid_by_zone")
+    zone_calls = _record_metric_plot(monkeypatch, "plot_metric_by_zone")
 
     fig = results.metrics.trip_count(
         by_variable="mode",
@@ -1350,6 +1707,22 @@ def test_reference_gap_map_uses_diverging_colors(tmp_path, monkeypatch):
     assert calls[0]["kwargs"]["title"] == "Gap to reference: Trip count share by home zone and mode"
     assert calls[0]["kwargs"]["diverging_center"] == 0.0
     assert calls[0]["args"][1]["scenario"].unique(maintain_order=True).to_list() == ["test"]
+
+    emissions_fig = results.metrics.ghg_emissions(
+        by_zone="home_zone",
+        output="plot",
+        inner_zone_residents_only=True,
+        iterations="last",
+        reference=("scenario", "default"),
+    )
+
+    assert isinstance(emissions_fig, BaseFigure)
+    assert zone_calls[0]["kwargs"]["metric"] == "gap"
+    assert zone_calls[0]["kwargs"]["zone_column"] == "home_zone_id"
+    assert zone_calls[0]["kwargs"]["title"] == "Gap to reference: Ghg emissions by home zone"
+    assert zone_calls[0]["kwargs"]["diverging_center"] == 0.0
+    assert zone_calls[0]["args"][1]["home_zone_id"].to_list() == ["z1", "z2"]
+    assert zone_calls[0]["args"][1]["gap"].to_list() == pytest.approx([0.0, 0.0])
 
 
 def test_origin_destination_metric_plot_uses_flow_map_helper(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation

Some result metric calls are slow after the simulation has already finished because they prepare more saved data than they need.

### Changes

Reuses result-table preparation work inside one public metric call.

Reads only the columns needed by a metric when building saved result tables.

Lets metrics read saved iteration plan steps and saved iteration costs through `Run.iteration_table(...)`.

For cost-based metrics, groups plan steps by origin, destination, and mode before joining costs, so fewer rows are joined.

Adds simple metric filters for home zones, CSPs, and modes:

```python
results.metrics.trip_count(home_zone_ids=[1])
results.metrics.travel_distance(csp=["fr-3"])
results.metrics.trip_count(modes=["walk"])
```

Improves scenario comparisons so missing rows are treated as zero and sensitivity cases are compared separately.

### Example

```python
results.metrics.trip_count(
    by_variable="activity",
    reference="external",
    reference_view="values",
    output="plot",
)
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: result metric speedups, metric filters, and tests.
- What you reviewed or changed: columns read by metrics, saved iteration reads, filtered metrics, and scenario comparisons.
- How you validated it (tests, checks, manual verification): ran the targeted unit tests for the stacked changes.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior