### PR TITLE
Move detailed diagnostics to trace logging

### DIFF
--- a/mobility/config.py
+++ b/mobility/config.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 
 from importlib import resources
+from mobility.runtime.logging_levels import TRACE_LEVEL, register_trace_level
 from mobility.runtime.r_integration.r_script_runner import RScriptRunner
 from mobility.runtime.project_cache import register_current_script_if_available
 
@@ -140,7 +141,7 @@ def _normalize_feedback_setting(feedback, *, progress=None, debug=False, logging
 def _is_debug_logging_level(logging_level) -> bool:
     """Return True when the old logging_level argument asks for DEBUG logs."""
     if isinstance(logging_level, str):
-        return logging_level.upper() == "DEBUG"
+        return logging_level.upper() in {"DEBUG", "TRACE"}
     return int(logging_level) <= logging.DEBUG
 
 
@@ -298,8 +299,9 @@ def setup_logging(logging_level="INFO"):
 
     This function sets up basic logging configuration including format, level, and date format.
     """
+    register_trace_level()
     if isinstance(logging_level, str):
-        level = getattr(logging, logging_level.upper(), None)
+        level = TRACE_LEVEL if logging_level.upper() == "TRACE" else getattr(logging, logging_level.upper(), None)
         if not isinstance(level, int):
             raise ValueError(f"Unknown logging level: {logging_level}")
     else:

--- a/mobility/runtime/logging_levels.py
+++ b/mobility/runtime/logging_levels.py
@@ -1,0 +1,15 @@
+import logging
+
+
+TRACE_LEVEL = 5
+
+
+def register_trace_level() -> None:
+    """Register the TRACE logging level used for expensive diagnostics."""
+    logging.addLevelName(TRACE_LEVEL, "TRACE")
+
+
+def is_trace_enabled() -> bool:
+    """Return True when very detailed diagnostics should be computed."""
+    register_trace_level()
+    return logging.root.isEnabledFor(TRACE_LEVEL)

--- a/mobility/trips/group_day_trips/plans/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/debug_logs.py
@@ -3,6 +3,10 @@ from typing import Any
 
 import polars as pl
 
+from mobility.runtime.logging_levels import TRACE_LEVEL, is_trace_enabled
+
+from .demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+
 
 def log_destination_sequence_diagnostics(
     *,
@@ -10,12 +14,15 @@ def log_destination_sequence_diagnostics(
     source_activity_sequences: pl.DataFrame,
     destination_sequences: pl.DataFrame,
 ) -> None:
-    """Log destination-chain diagnostics only when debug logging is enabled."""
-    if not logging.root.isEnabledFor(logging.DEBUG):
+    """Log destination-chain diagnostics only when trace logging is enabled."""
+    if not is_trace_enabled():
         return
 
+    source_activity_sequences = with_demand_subgroup_id(source_activity_sequences)
+    destination_sequences = with_demand_subgroup_id(destination_sequences)
     chain_lengths = _destination_chain_lengths(destination_sequences)
-    logging.debug(
+    logging.log(
+        TRACE_LEVEL,
         "Destination sequence step counts at iteration %s | grouped=%s",
         iteration,
         _distribution_by_count(chain_lengths, "step_count"),
@@ -25,9 +32,7 @@ def log_destination_sequence_diagnostics(
     if one_step_chains.height == 0:
         return
 
-    one_step_keys = one_step_chains.select(
-        ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"]
-    )
+    one_step_keys = one_step_chains.select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
     logging.warning(
         "Destination sequences contain %s one-step chains at iteration %s. "
         "Sample grouped chains: %s | Sample raw rows: %s",
@@ -53,13 +58,13 @@ def _destination_chain_lengths(destination_sequences: pl.DataFrame) -> pl.DataFr
     """Build one row per destination chain with ordered locations."""
     return (
         destination_sequences
-        .group_by(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"])
+        .group_by(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
         .agg(
             step_count=pl.len(),
             from_locations=pl.col("from").sort_by("seq_step_index"),
             to_locations=pl.col("to").sort_by("seq_step_index"),
         )
-        .sort(["step_count", "dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id"])
+        .sort(["step_count", "dest_seq_id"] + DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"])
     )
 
 
@@ -84,10 +89,10 @@ def _one_step_chain_rows(
         destination_sequences
         .join(
             one_step_keys,
-            on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"],
+            on=DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"],
             how="inner",
         )
-        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+        .sort(["dest_seq_id"] + DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "seq_step_index"])
     )
 
 
@@ -100,11 +105,11 @@ def _source_rows_for_chain_keys(
     return (
         source_activity_sequences
         .join(
-            one_step_keys.select(["demand_group_id", "activity_seq_id", "time_seq_id"]).unique(),
-            on=["demand_group_id", "activity_seq_id", "time_seq_id"],
+            one_step_keys.select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"]).unique(),
+            on=DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"],
             how="inner",
         )
-        .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+        .sort(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "seq_step_index"])
     )
 
 
@@ -120,8 +125,8 @@ def log_step_dropout_diagnostics(
     chain_key_cols: list[str],
     transport_zones: Any | None,
 ) -> None:
-    """Log spatialization dropouts only when debug logging is enabled."""
-    if not logging.root.isEnabledFor(logging.DEBUG):
+    """Log spatialization dropouts only when trace logging is enabled."""
+    if not is_trace_enabled():
         return
 
     # Start from the non-anchor rows that must survive this step.

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
@@ -3,6 +3,10 @@ from typing import Any
 
 import polars as pl
 
+from mobility.runtime.logging_levels import TRACE_LEVEL, is_trace_enabled
+
+from ..demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+
 
 def log_location_chain_diagnostics(
     *,
@@ -11,13 +15,16 @@ def log_location_chain_diagnostics(
     trip_chains: pl.DataFrame,
     unique_destination_chains: pl.DataFrame,
 ) -> None:
-    """Log mode-search chain diagnostics only when debug logging is enabled."""
-    if not logging.root.isEnabledFor(logging.DEBUG):
+    """Log mode-search chain diagnostics only when trace logging is enabled."""
+    if not is_trace_enabled():
         return
 
+    destination_steps = with_demand_subgroup_id(destination_steps)
+    trip_chains = with_demand_subgroup_id(trip_chains)
     trip_chain_lengths = _trip_chain_lengths(trip_chains)
     unique_chain_lengths = _unique_chain_lengths(unique_destination_chains)
-    logging.debug(
+    logging.log(
+        TRACE_LEVEL,
         "Mode search chain lengths at iteration %s | grouped=%s | unique_dest_seq=%s",
         iteration,
         _chain_length_distribution(trip_chain_lengths),
@@ -84,7 +91,7 @@ def _grouped_invalid_chains(
     return (
         trip_chain_lengths
         .join(invalid_unique_chains.select("dest_seq_id"), on="dest_seq_id", how="inner")
-        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id"])
+        .sort(["dest_seq_id"] + DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"])
     )
 
 
@@ -94,15 +101,13 @@ def _invalid_destination_steps(
     grouped_invalid_chains: pl.DataFrame,
 ) -> pl.DataFrame:
     """Return the raw destination rows behind invalid location chains."""
-    invalid_chain_keys = grouped_invalid_chains.select(
-        ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"]
-    )
+    invalid_chain_keys = grouped_invalid_chains.select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
     return (
         destination_steps
         .join(
             invalid_chain_keys,
-            on=["demand_group_id", "activity_seq_id", "time_seq_id", "dest_seq_id"],
+            on=DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"],
             how="inner",
         )
-        .sort(["dest_seq_id", "demand_group_id", "activity_seq_id", "time_seq_id", "seq_step_index"])
+        .sort(["dest_seq_id"] + DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "seq_step_index"])
     )

--- a/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
+++ b/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pandas as pd
 import polars as pl
 
+from mobility.runtime.logging_levels import TRACE_LEVEL
 from mobility.trips.group_day_trips.plans.debug_logs import (
     log_destination_sequence_diagnostics,
     log_step_dropout_diagnostics,
@@ -13,8 +14,8 @@ from mobility.trips.group_day_trips.plans.mode_sequence_search.debug_logs import
 )
 
 
-def test_debug_diagnostics_do_not_collect_inputs_when_debug_is_disabled(caplog):
-    with caplog.at_level(logging.INFO):
+def test_trace_diagnostics_do_not_collect_inputs_when_trace_is_disabled(caplog):
+    with caplog.at_level(logging.DEBUG):
         log_destination_sequence_diagnostics(
             iteration=1,
             source_activity_sequences=pl.DataFrame(),
@@ -61,7 +62,7 @@ def test_log_destination_sequence_diagnostics_reports_one_step_chains(caplog):
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_destination_sequence_diagnostics(
             iteration=7,
             source_activity_sequences=source_activity_sequences,
@@ -88,7 +89,7 @@ def test_log_destination_sequence_diagnostics_skips_warning_for_complete_chains(
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_destination_sequence_diagnostics(
             iteration=7,
             source_activity_sequences=pl.DataFrame(),
@@ -149,7 +150,7 @@ def test_log_step_dropout_diagnostics_reports_each_dropout_stage(caplog):
         )
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=2,
             chains_step=chains_step,
@@ -202,7 +203,7 @@ def test_log_step_dropout_diagnostics_skips_when_no_non_anchor_or_dropout(caplog
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=1,
             chains_step=anchor_only,
@@ -259,7 +260,7 @@ def test_log_step_dropout_diagnostics_can_trace_costs_without_transport_zones(ca
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=1,
             chains_step=chains_step,
@@ -304,7 +305,7 @@ def test_log_location_chain_diagnostics_reports_invalid_unique_chains(caplog):
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_location_chain_diagnostics(
             iteration=5,
             destination_steps=destination_steps,
@@ -335,7 +336,7 @@ def test_log_location_chain_diagnostics_skips_warning_for_valid_chains(caplog):
         }
     )
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(TRACE_LEVEL):
         log_location_chain_diagnostics(
             iteration=5,
             destination_steps=pl.DataFrame(),

--- a/tests/back/unit/domain/set_params/test_029_set_params_injects_truststore.py
+++ b/tests/back/unit/domain/set_params/test_029_set_params_injects_truststore.py
@@ -116,6 +116,18 @@ def test_set_params_maps_old_debug_logging_level_to_feedback_debug(tmp_path):
     assert os.environ["MOBILITY_DEBUG"] == "1"
 
 
+def test_set_params_maps_trace_logging_level_to_feedback_debug(tmp_path):
+    set_params(
+        package_data_folder_path=str(tmp_path / "pkg"),
+        project_data_folder_path=str(tmp_path / "project"),
+        r_packages=False,
+        logging_level="TRACE",
+    )
+
+    assert os.environ["MOBILITY_FEEDBACK"] == "debug"
+    assert os.environ["MOBILITY_DEBUG"] == "1"
+
+
 def test_set_params_rejects_unknown_feedback_mode(tmp_path):
     with pytest.raises(ValueError, match="Unknown feedback setting"):
         set_params(


### PR DESCRIPTION
### Motivation

Some GroupDayTrips diagnostics build detailed tables. They are useful for investigating a specific problem, but too heavy for normal debug logs.

### Changes

Adds a `TRACE` logging level below `DEBUG`.

Moves detailed destination-chain and mode-search-chain diagnostics from `DEBUG` to `TRACE`. Normal `DEBUG` logs no longer prepare these detailed tables.

Keeps these diagnostics compatible with `demand_subgroup_id`. Rows without this column are treated as subgroup 0.

Accepts `set_params(logging_level="TRACE")` and keeps the usual debug feedback mode enabled.

### Example

```python
mobility.set_params(logging_level="TRACE")
```

### AI-assisted contribution

- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: TRACE logging and focused tests.
- What you reviewed or changed: logging setup, set_params handling, and detailed diagnostics.
- How you validated it (tests, checks, manual verification): ran the targeted unit tests for the stacked changes.

### Checklist

- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior