### PR TITLE
Use demand subgroups as plan keys

### DIFF
--- a/mobility/runtime/assets/cache_schema.py
+++ b/mobility/runtime/assets/cache_schema.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pathlib
+
+import polars as pl
+
+
+Schema = dict[str, pl.DataType]
+
+
+def read_cached_parquet(
+    cache_path: pathlib.Path,
+    *,
+    table_name: str,
+    required_schema: Schema,
+) -> pl.DataFrame:
+    """Read one cached parquet table and check its current table contract."""
+    table = pl.read_parquet(cache_path)
+    validate_cached_table(
+        table,
+        table_name=table_name,
+        required_schema=required_schema,
+        cache_path=cache_path,
+    )
+    return table
+
+
+def scan_cached_parquet(
+    cache_path: pathlib.Path,
+    *,
+    table_name: str,
+    required_schema: Schema,
+) -> pl.LazyFrame:
+    """Scan one cached parquet table lazily and check its current table contract."""
+    table = pl.scan_parquet(cache_path)
+    validate_cached_table(
+        table,
+        table_name=table_name,
+        required_schema=required_schema,
+        cache_path=cache_path,
+    )
+    return table
+
+
+def validate_cached_table(
+    table: pl.DataFrame | pl.LazyFrame,
+    *,
+    table_name: str,
+    required_schema: Schema,
+    cache_path: pathlib.Path | None = None,
+) -> None:
+    """Fail when a cached table is missing required columns or key dtypes."""
+    actual_schema = table.schema if isinstance(table, pl.DataFrame) else table.collect_schema()
+    missing_columns = [
+        column
+        for column in required_schema
+        if column not in actual_schema
+    ]
+    wrong_types = [
+        (column, expected_dtype, actual_schema[column])
+        for column, expected_dtype in required_schema.items()
+        if column in actual_schema and actual_schema[column] != expected_dtype
+    ]
+
+    if not missing_columns and not wrong_types:
+        return
+
+    raise RuntimeError(
+        _format_cached_schema_error(
+            table_name=table_name,
+            cache_path=cache_path,
+            missing_columns=missing_columns,
+            wrong_types=wrong_types,
+        )
+    )
+
+
+def _format_cached_schema_error(
+    *,
+    table_name: str,
+    cache_path: pathlib.Path | None,
+    missing_columns: list[str],
+    wrong_types: list[tuple[str, pl.DataType, pl.DataType]],
+) -> str:
+    """Build a clear error message for stale cached parquet tables."""
+    lines = [
+        f"Cached table `{table_name}` does not match the current schema.",
+    ]
+    if cache_path is not None:
+        lines.extend(["", f"Cache path: {cache_path}"])
+    if missing_columns:
+        lines.append("")
+        lines.append("Missing columns:")
+        lines.extend(f"- {column}" for column in missing_columns)
+    if wrong_types:
+        lines.append("")
+        lines.append("Wrong column types:")
+        lines.extend(
+            f"- {column}: expected {expected_dtype}, found {actual_dtype}"
+            for column, expected_dtype, actual_dtype in wrong_types
+        )
+    lines.extend(
+        [
+            "",
+            "This cache was created with an older layout.",
+            "Please clear the matching cached files and rerun the model.",
+        ]
+    )
+    return "\n".join(lines)

--- a/mobility/trips/group_day_trips/core/run.py
+++ b/mobility/trips/group_day_trips/core/run.py
@@ -7,6 +7,7 @@ from typing import List
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet, scan_cached_parquet
 from ..iterations import (
     InitialIterationStateAsset,
     IterationSeedsAsset,
@@ -14,6 +15,7 @@ from ..iterations import (
     IterationTransportCostsAsset,
     IterationStateAsset,
 )
+from ..iterations.iteration_assets import CURRENT_PLAN_STEPS_SCHEMA
 from ..evaluation.population_weighted_plan_steps import PopulationWeightedPlanSteps
 from ..evaluation.calibration_plan_steps import (
     ObservedCalibrationPlanSteps,
@@ -384,7 +386,7 @@ class Run(FileAsset):
         return IterationMetricsBuilder(
             model_loss=ModelLoss(expected_plan_steps=expected_inputs.calibration_plan_steps),
             model_trip_count_loss=ModelTripCountLoss(
-                expected_plan_steps=expected_inputs.population_weighted_plan_steps,
+                expected_plan_steps=expected_inputs.population_weighted_plan_steps.get(),
                 surveys=self.surveys,
                 is_weekday=self.is_weekday,
             ),
@@ -487,7 +489,15 @@ class Run(FileAsset):
                 "Call `remove()` to clear cached artifacts and rerun from scratch."
             )
 
-        return pl.concat([pl.read_parquet(path) for path in transition_paths], how="vertical")
+        transitions = [
+            read_cached_parquet(
+                path,
+                table_name="transition_events",
+                required_schema=TRANSITION_EVENT_SCHEMA,
+            )
+            for path in transition_paths
+        ]
+        return pl.concat(transitions, how="vertical")
 
 
     def _write_outputs(
@@ -555,7 +565,11 @@ class Run(FileAsset):
         state_asset = self.iteration_state_assets[iteration - 1]
         current_plan_steps_path = state_asset.cache_path["current_plan_steps"]
         if current_plan_steps_path.exists():
-            return pl.scan_parquet(current_plan_steps_path)
+            return scan_cached_parquet(
+                current_plan_steps_path,
+                table_name="current_plan_steps",
+                required_schema=CURRENT_PLAN_STEPS_SCHEMA,
+            )
 
         state = state_asset.get()
         if state.current_plan_steps is None:

--- a/mobility/trips/group_day_trips/evaluation/calibration_plan_steps.py
+++ b/mobility/trips/group_day_trips/evaluation/calibration_plan_steps.py
@@ -12,13 +12,6 @@ TIME_BIN_BREAKS_MINUTES = [0.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 1e9]
 CALIBRATION_PLAN_STEP_COLUMNS = ["activity", "distance_bin", "time_bin", "mode", "distance", "time", "n_persons"]
 
 
-def _as_lazyframe(plan_steps: pl.LazyFrame | pl.DataFrame) -> pl.LazyFrame:
-    """Return a lazy frame regardless of the input plan-step container."""
-    if isinstance(plan_steps, pl.DataFrame):
-        return plan_steps.lazy()
-    return plan_steps
-
-
 def distance_bin_expr(column: str = "distance") -> pl.Expr:
     """Return the canonical distance-bin expression shared by calibration diagnostics."""
     return pl.col(column).cast(pl.Float64).cut(DISTANCE_BIN_BREAKS, left_closed=True).cast(pl.String)
@@ -30,10 +23,9 @@ def time_bin_expr(column: str = "time") -> pl.Expr:
 
 
 def to_calibration_plan_steps(
-    plan_steps: pl.LazyFrame | pl.DataFrame,
+    plan_steps: pl.LazyFrame,
 ) -> pl.LazyFrame:
     """Convert raw plan steps to the canonical calibration-step schema."""
-    plan_steps = _as_lazyframe(plan_steps)
     is_stay_home = pl.col("mode").cast(pl.String) == "stay_home"
     return (
         plan_steps

--- a/mobility/trips/group_day_trips/evaluation/iteration_metrics.py
+++ b/mobility/trips/group_day_trips/evaluation/iteration_metrics.py
@@ -99,15 +99,15 @@ class IterationMetricsBuilder:
         """Compute one persisted diagnostics row for a single model iteration."""
         loss_row = self.model_loss.history_row(
             iteration=iteration,
-            plan_steps=to_calibration_plan_steps(current_plan_steps),
+            plan_steps=to_calibration_plan_steps(current_plan_steps.lazy()),
         )
         trip_count_loss_row = self.model_trip_count_loss.history_row(
             iteration=iteration,
-            plan_steps=current_plan_steps,
+            plan_steps=current_plan_steps.lazy(),
         )
         entropy_row = self.model_entropy.history_row(
             iteration=iteration,
-            plan_steps=current_plan_steps,
+            plan_steps=current_plan_steps.lazy(),
         )
         total_loss = float(loss_row["total_loss"]) + float(trip_count_loss_row["trip_count_loss"])
         return {

--- a/mobility/trips/group_day_trips/evaluation/model_loss.py
+++ b/mobility/trips/group_day_trips/evaluation/model_loss.py
@@ -158,10 +158,8 @@ class ModelLoss:
             .agg(value=pl.col("value").sum())
         )
 
-    def _aggregate(self, plan_steps: pl.LazyFrame | pl.DataFrame) -> pl.DataFrame:
+    def _aggregate(self, plan_steps: pl.LazyFrame) -> pl.DataFrame:
         """Aggregate canonical calibration plan steps into loss marginals."""
-        if isinstance(plan_steps, pl.DataFrame):
-            plan_steps = plan_steps.lazy()
         available_columns = set(plan_steps.collect_schema().names())
         missing_columns = [col for col in CALIBRATION_PLAN_STEP_COLUMNS if col not in available_columns]
         if missing_columns:

--- a/mobility/trips/group_day_trips/evaluation/model_trip_count_loss.py
+++ b/mobility/trips/group_day_trips/evaluation/model_trip_count_loss.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import polars as pl
 
-from .calibration_plan_steps import _as_lazyframe
 from .trip_pattern_distribution import get_survey_immobility_probabilities
 
 TRIP_COUNT_BINS = ["0", "1", "2", "3", "4", "5+"]
 
 
 def build_trip_count_distribution(
-    plan_steps: pl.LazyFrame | pl.DataFrame,
+    plan_steps: pl.LazyFrame,
     *,
     immobility_probabilities: pl.DataFrame | None = None,
     epsilon: float = 1e-12,
@@ -20,7 +19,6 @@ def build_trip_count_distribution(
     cleaned mobile survey plans. Mobile weights are scaled by the mobile share,
     and a zero-trip mass is added by country and socio-professional group.
     """
-    plan_steps = _as_lazyframe(plan_steps)
     available_columns = set(plan_steps.collect_schema().names())
     required_columns = {"activity_seq_id", "n_persons"}
     if not required_columns.issubset(available_columns):
@@ -136,14 +134,18 @@ class ModelTripCountLoss:
     def __init__(
         self,
         *,
-        expected_plan_steps,
+        expected_plan_steps: pl.LazyFrame,
         surveys=None,
         is_weekday: bool = True,
-        observed_plan_steps=None,
+        observed_plan_steps: pl.LazyFrame | None = None,
         history=None,
         epsilon: float = 1e-9,
     ) -> None:
         """Attach expected data, optional observed data, and optional history storage."""
+        if not isinstance(expected_plan_steps, pl.LazyFrame):
+            raise TypeError("ModelTripCountLoss expects lazy expected plan steps.")
+        if observed_plan_steps is not None and not isinstance(observed_plan_steps, pl.LazyFrame):
+            raise TypeError("ModelTripCountLoss expects lazy observed plan steps.")
         self.expected_plan_steps = expected_plan_steps
         self.surveys = surveys
         self.is_weekday = is_weekday
@@ -161,7 +163,7 @@ class ModelTripCountLoss:
                 else None
             )
             self._expected_distribution = build_trip_count_distribution(
-                _get_plan_steps(self.expected_plan_steps),
+                self.expected_plan_steps,
                 immobility_probabilities=immobility,
             )
         return self._expected_distribution
@@ -170,7 +172,7 @@ class ModelTripCountLoss:
         """Return the observed trip-count distribution for the attached run."""
         if self.observed_plan_steps is None:
             raise ValueError("No observed plan steps are attached to this ModelTripCountLoss instance.")
-        return build_trip_count_distribution(_get_plan_steps(self.observed_plan_steps))
+        return build_trip_count_distribution(self.observed_plan_steps)
 
     def comparison(self, plan_steps=None) -> pl.DataFrame:
         """Return observed-versus-expected trip-count distribution comparisons."""
@@ -255,8 +257,3 @@ def _trip_count_bin_expr(column: str) -> pl.Expr:
 def _all_trip_count_bins() -> pl.DataFrame:
     """Return all trip-count bins so missing classes get explicit zero mass."""
     return pl.DataFrame({"trip_count_bin": TRIP_COUNT_BINS})
-
-
-def _get_plan_steps(plan_steps):
-    """Return a plan-step frame from either a frame or a small asset wrapper."""
-    return plan_steps.get() if hasattr(plan_steps, "get") else plan_steps

--- a/mobility/trips/group_day_trips/evaluation/trip_pattern_distribution.py
+++ b/mobility/trips/group_day_trips/evaluation/trip_pattern_distribution.py
@@ -7,7 +7,7 @@ import polars as pl
 
 from mobility.runtime.assets.file_asset import FileAsset
 
-from .calibration_plan_steps import _as_lazyframe, distance_bin_expr
+from .calibration_plan_steps import distance_bin_expr
 
 
 def get_survey_immobility_probabilities(surveys, *, is_weekday: bool) -> pl.DataFrame:
@@ -32,13 +32,12 @@ def get_survey_immobility_probabilities(surveys, *, is_weekday: bool) -> pl.Data
 
 
 def build_trip_pattern_distribution(
-    plan_steps: pl.LazyFrame | pl.DataFrame,
+    plan_steps: pl.LazyFrame,
     *,
     epsilon: float = 1e-12,
     immobility_probabilities: pl.DataFrame | None = None,
 ) -> pl.DataFrame:
     """Build a weighted trip-pattern distribution from raw ordered plan steps."""
-    plan_steps = _as_lazyframe(plan_steps)
     available_columns = set(plan_steps.collect_schema().names())
     candidate_columns = [
         "country",

--- a/mobility/trips/group_day_trips/iterations/iteration_assets.py
+++ b/mobility/trips/group_day_trips/iterations/iteration_assets.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet, validate_cached_table
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities.activity import (
     resolve_activity_arrival_time_rigidity,
@@ -27,6 +28,8 @@ from mobility.transport.costs.od_flows_asset import VehicleODFlowsAsset
 from mobility.transport.modes.core.mode_values import get_mode_values
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
 from ..plans.candidate_plan_steps import CandidatePlanStepsAsset
+from ..plans.demand_subgroups import DEMAND_UNIT_SCHEMA
+from ..plans.plan_ids import PLAN_KEY_SCHEMA, PLAN_STEP_KEY_SCHEMA
 
 
 STATE_TABLE_NAMES = [
@@ -44,6 +47,32 @@ STATE_TABLE_NAMES = [
     "destination_saturation",
     "costs",
 ]
+
+
+DEMAND_GROUPS_SCHEMA = {
+    **DEMAND_UNIT_SCHEMA,
+    "n_persons": pl.Float64,
+}
+CURRENT_PLANS_SCHEMA = {
+    **PLAN_KEY_SCHEMA,
+    "plan_id": pl.UInt32,
+    "n_persons": pl.Float64,
+}
+CURRENT_PLAN_STEPS_SCHEMA = {
+    **PLAN_STEP_KEY_SCHEMA,
+}
+PLAN_ID_INDEX_SCHEMA = {
+    **PLAN_KEY_SCHEMA,
+    "plan_id": pl.UInt32,
+}
+RUN_STATE_TABLE_SCHEMAS = {
+    "demand_groups": DEMAND_GROUPS_SCHEMA,
+    "stay_home_plan": CURRENT_PLAN_STEPS_SCHEMA,
+    "current_plans": CURRENT_PLANS_SCHEMA,
+    "current_plan_steps": CURRENT_PLAN_STEPS_SCHEMA,
+    "candidate_plan_steps": CandidatePlanStepsAsset.REQUIRED_SCHEMA,
+    "plan_id_index": PLAN_ID_INDEX_SCHEMA,
+}
 
 
 def _state_cache_paths(base_folder: pathlib.Path, iteration: int) -> dict[str, pathlib.Path]:
@@ -90,6 +119,17 @@ def _read_run_state(cache_path: dict[str, pathlib.Path], *, start_iteration: int
         tables["current_plan_steps"] = None
     if metadata.get("candidate_plan_steps_is_none", False):
         tables["candidate_plan_steps"] = None
+
+    for table_name, required_schema in RUN_STATE_TABLE_SCHEMAS.items():
+        table = tables[table_name]
+        if table is None:
+            continue
+        validate_cached_table(
+            table,
+            table_name=table_name,
+            required_schema=required_schema,
+            cache_path=cache_path[table_name],
+        )
 
     return RunState(
         survey_plans=tables["survey_plans"],
@@ -772,6 +812,8 @@ class IterationStateAsset(FileAsset):
 class CurrentPlansAsset(FileAsset):
     """Persisted current plan distribution after one completed iteration."""
 
+    REQUIRED_SCHEMA = CURRENT_PLANS_SCHEMA
+
     def __init__(
         self,
         *,
@@ -792,7 +834,11 @@ class CurrentPlansAsset(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pl.DataFrame:
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="current_plans",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pl.DataFrame:
         if self.current_plans is None:
@@ -804,6 +850,8 @@ class CurrentPlansAsset(FileAsset):
 
 class CurrentPlanStepsAsset(FileAsset):
     """Persisted step-level details for the current plans after one completed iteration."""
+
+    REQUIRED_SCHEMA = CURRENT_PLAN_STEPS_SCHEMA
 
     def __init__(
         self,
@@ -825,7 +873,11 @@ class CurrentPlanStepsAsset(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pl.DataFrame:
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="current_plan_steps",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pl.DataFrame:
         if self.current_plan_steps is None:
@@ -842,6 +894,8 @@ class PlanIdIndexAsset(FileAsset):
     supports the older `Iterations.load_state()` and `Iterations.save_state()`
     table API, where each saved state table has its own small FileAsset wrapper.
     """
+
+    REQUIRED_SCHEMA = PLAN_ID_INDEX_SCHEMA
 
     def __init__(
         self,
@@ -863,7 +917,11 @@ class PlanIdIndexAsset(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pl.DataFrame:
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="plan_id_index",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pl.DataFrame:
         if self.plan_id_index is None:

--- a/mobility/trips/group_day_trips/plans/activity_sequences.py
+++ b/mobility/trips/group_day_trips/plans/activity_sequences.py
@@ -3,14 +3,22 @@ from typing import Any
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
 from mobility.trips.group_day_trips.core.parameters import BehaviorChangeScope
-from .demand_subgroups import DEMAND_UNIT_COLS, demand_unit_hash, with_demand_subgroup_id
+from .demand_subgroups import DEMAND_UNIT_COLS, DEMAND_UNIT_SCHEMA, demand_unit_hash
 
 
 class ActivitySequences(FileAsset):
     """Persist admitted timed activity-sequence seeds for one iteration."""
+
+    REQUIRED_SCHEMA = {
+        **DEMAND_UNIT_SCHEMA,
+        "activity_seq_id": pl.UInt32,
+        "time_seq_id": pl.UInt32,
+        "seq_step_index": pl.UInt8,
+    }
 
     OUTPUT_COLUMNS = [
         "demand_group_id",
@@ -70,7 +78,11 @@ class ActivitySequences(FileAsset):
 
     def get_cached_asset(self) -> pl.DataFrame:
         """Return cached admitted activity-sequence rows for one iteration."""
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="activity_sequences",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pl.DataFrame:
         """Compute and persist admitted activity-sequence rows for one iteration."""
@@ -104,13 +116,13 @@ class ActivitySequences(FileAsset):
 
         state = self.previous_state.get()
         if self.current_plans is None:
-            self.current_plans = with_demand_subgroup_id(state.current_plans)
+            self.current_plans = state.current_plans
         if self.survey_plans is None:
             self.survey_plans = state.survey_plans
         if self.survey_plan_steps is None:
             self.survey_plan_steps = state.survey_plan_steps
         if self.demand_groups is None:
-            self.demand_groups = with_demand_subgroup_id(state.demand_groups)
+            self.demand_groups = state.demand_groups
 
     def _build_activity_sequences_for_scope(self) -> pl.DataFrame:
         """Return admitted timed activity-sequence rows for this iteration."""
@@ -131,7 +143,7 @@ class ActivitySequences(FileAsset):
     def _sample_all_activity_sequences(self) -> pl.DataFrame:
         """Sample timed survey activity-sequence seeds from raw survey plans."""
         weighted_survey_plans = (
-            with_demand_subgroup_id(self.demand_groups)
+            self.demand_groups
             .join(self.survey_plans, on=["country", "city_category", "csp", "n_cars"], how="inner")
             .filter(pl.col("time_seq_id") != 0)
         )
@@ -176,7 +188,7 @@ class ActivitySequences(FileAsset):
     def _select_active_activity_sequences(self) -> pl.DataFrame:
         """Return the currently occupied non-stay-home activity sequences."""
         active_activity_sequences = (
-            with_demand_subgroup_id(self.current_plans)
+            self.current_plans
             .filter(pl.col("time_seq_id") != 0)
             .select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"])
             .unique()

--- a/mobility/trips/group_day_trips/plans/candidate_plan_steps.py
+++ b/mobility/trips/group_day_trips/plans/candidate_plan_steps.py
@@ -2,12 +2,20 @@ import pathlib
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet
 from mobility.runtime.assets.file_asset import FileAsset
-from .demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from .demand_subgroups import DEMAND_UNIT_COLS
+from .plan_ids import PLAN_STEP_KEY_SCHEMA
 
 
 class CandidatePlanStepsAsset(FileAsset):
     """Persisted candidate plan-step memory after one completed iteration."""
+
+    REQUIRED_SCHEMA = {
+        **PLAN_STEP_KEY_SCHEMA,
+        "first_seen_iteration": pl.UInt16,
+        "last_seen_iteration": pl.UInt16,
+    }
 
     STRUCTURAL_COLUMNS = [
         "demand_group_id",
@@ -66,7 +74,11 @@ class CandidatePlanStepsAsset(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pl.DataFrame:
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="candidate_plan_steps",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pl.DataFrame:
         if self.candidate_plan_steps is None:
@@ -102,32 +114,18 @@ class CandidatePlanStepsAsset(FileAsset):
             )
         )
         return (
-            with_demand_subgroup_id(mode_sequences.get_cached_asset()).lazy()
+            mode_sequences.get_cached_asset().lazy()
             .join(
-                with_demand_subgroup_id(destination_sequences.get_cached_asset()).lazy(),
+                destination_sequences.get_cached_asset().lazy(),
                 on=DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "seq_step_index"],
             )
             .join(survey_plan_steps.lazy(), on=["activity_seq_id", "time_seq_id", "seq_step_index"])
             .join(
-                with_demand_subgroup_id(demand_groups)
-                .select(DEMAND_UNIT_COLS + ["country", "csp"])
-                .lazy(),
+                demand_groups.select(DEMAND_UNIT_COLS + ["country", "csp"]).lazy(),
                 on=DEMAND_UNIT_COLS,
             )
             .select(cls.STRUCTURAL_COLUMNS)
         )
-
-    @classmethod
-    def _with_retention_columns(cls, frame: pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
-        """Add missing candidate-memory columns for older cached files."""
-        candidate_rows = frame.lazy() if isinstance(frame, pl.DataFrame) else frame
-        schema = frame.schema if isinstance(frame, pl.DataFrame) else frame.collect_schema()
-        if "last_seen_iteration" not in schema:
-            candidate_rows = candidate_rows.with_columns(
-                last_seen_iteration=pl.col("first_seen_iteration")
-            )
-        candidate_rows = with_demand_subgroup_id(candidate_rows)
-        return candidate_rows
 
     @classmethod
     def build_candidate_memory(
@@ -144,12 +142,9 @@ class CandidatePlanStepsAsset(FileAsset):
         max_inactive_age: int,
     ) -> pl.LazyFrame:
         """Merge new iteration candidates into the cumulative structural candidate memory."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        demand_groups = with_demand_subgroup_id(demand_groups)
-
         candidate_sets = []
         if previous_candidate_plan_steps is not None:
-            previous_candidates = cls._with_retention_columns(previous_candidate_plan_steps)
+            previous_candidates = previous_candidate_plan_steps.lazy()
             candidate_sets.append(
                 previous_candidates
                 .filter(pl.col("mode_seq_id") != 0)
@@ -160,7 +155,7 @@ class CandidatePlanStepsAsset(FileAsset):
                 previous_candidates
                 .filter(pl.col("mode_seq_id") != 0)
                 .join(
-                    with_demand_subgroup_id(current_plans)
+                    current_plans
                     .select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id"])
                     .lazy(),
                     on=DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id"],

--- a/mobility/trips/group_day_trips/plans/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/debug_logs.py
@@ -5,7 +5,84 @@ import polars as pl
 
 from mobility.runtime.logging_levels import TRACE_LEVEL, is_trace_enabled
 
-from .demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from .demand_subgroups import DEMAND_UNIT_COLS
+
+
+def log_destination_spatialization_step(
+    *,
+    seq_step_index: int,
+    sequence_step: pl.DataFrame,
+    non_anchor_count: int,
+    anchor_count: int,
+) -> None:
+    """Log the size of one destination spatialization step."""
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        return
+
+    unique_draws = sequence_step.select(
+        pl.struct(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]).n_unique()
+    ).item()
+    logging.debug(
+        "Destination spatialization step %s input rows=%s non_anchor=%s anchor=%s unique_draws=%s",
+        seq_step_index,
+        sequence_step.height,
+        non_anchor_count,
+        anchor_count,
+        unique_draws,
+    )
+
+
+def log_missing_anchor_destination_samples(
+    *,
+    sequence_key_cols: list[str],
+    expected_anchor_steps: pl.DataFrame,
+    sampled_anchor_steps: pl.DataFrame,
+) -> None:
+    """Warn when an anchor activity has no reachable destination candidate."""
+    if sampled_anchor_steps.height >= expected_anchor_steps.height:
+        return
+
+    missing_anchors = (
+        expected_anchor_steps
+        .join(
+            sampled_anchor_steps.select(sequence_key_cols + ["seq_step_index"]),
+            on=sequence_key_cols + ["seq_step_index"],
+            how="anti",
+        )
+        .select(sequence_key_cols + ["activity", "seq_step_index", "from"])
+    )
+    logging.warning(
+        "Dropping %s anchor destination steps because no reachable anchor candidate could be sampled. "
+        "Sample steps: %s",
+        missing_anchors.height,
+        missing_anchors.head(20).to_dicts(),
+    )
+
+
+def log_incomplete_destination_draws(
+    *,
+    iteration: int,
+    activity_sequences_with_counts: pl.DataFrame,
+    sequence_key_cols: list[str],
+) -> None:
+    """Warn when a destination draw lost one or more steps."""
+    incomplete_draws = (
+        activity_sequences_with_counts
+        .filter(pl.col("step_count_after_spatialization") != pl.col("step_count"))
+        .select(sequence_key_cols + ["step_count", "step_count_after_spatialization"])
+        .unique()
+        .sort(sequence_key_cols)
+    )
+    if incomplete_draws.height == 0:
+        return
+
+    logging.warning(
+        "Dropping %s incomplete destination draws at iteration %s because one or more steps disappeared during spatialization. "
+        "Sample draws: %s",
+        incomplete_draws.height,
+        iteration,
+        incomplete_draws.head(20).to_dicts(),
+    )
 
 
 def log_destination_sequence_diagnostics(
@@ -14,48 +91,46 @@ def log_destination_sequence_diagnostics(
     source_activity_sequences: pl.DataFrame,
     destination_sequences: pl.DataFrame,
 ) -> None:
-    """Log destination-chain diagnostics only when trace logging is enabled."""
+    """Log destination-sequence diagnostics only when trace logging is enabled."""
     if not is_trace_enabled():
         return
 
-    source_activity_sequences = with_demand_subgroup_id(source_activity_sequences)
-    destination_sequences = with_demand_subgroup_id(destination_sequences)
-    chain_lengths = _destination_chain_lengths(destination_sequences)
+    sequence_lengths = _destination_sequence_lengths(destination_sequences)
     logging.log(
         TRACE_LEVEL,
         "Destination sequence step counts at iteration %s | grouped=%s",
         iteration,
-        _distribution_by_count(chain_lengths, "step_count"),
+        sequence_lengths.group_by("step_count").len().sort("step_count").to_dicts(),
     )
 
-    one_step_chains = chain_lengths.filter(pl.col("step_count") == 1)
-    if one_step_chains.height == 0:
+    one_step_sequences = sequence_lengths.filter(pl.col("step_count") == 1)
+    if one_step_sequences.height == 0:
         return
 
-    one_step_keys = one_step_chains.select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
+    one_step_keys = one_step_sequences.select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
     logging.warning(
-        "Destination sequences contain %s one-step chains at iteration %s. "
-        "Sample grouped chains: %s | Sample raw rows: %s",
-        one_step_chains.height,
+        "Destination sequences contain %s one-step sequences at iteration %s. "
+        "Sample grouped sequences: %s | Sample raw rows: %s",
+        one_step_sequences.height,
         iteration,
-        one_step_chains.head(10).to_dicts(),
-        _one_step_chain_rows(
+        one_step_sequences.head(10).to_dicts(),
+        _one_step_sequence_rows(
             destination_sequences=destination_sequences,
             one_step_keys=one_step_keys,
         ).head(20).to_dicts(),
     )
     logging.warning(
-        "Activity-sequence source rows behind one-step destination chains at iteration %s: %s",
+        "Activity-sequence source rows behind one-step destination sequences at iteration %s: %s",
         iteration,
-        _source_rows_for_chain_keys(
+        _source_rows_for_sequence_keys(
             source_activity_sequences=source_activity_sequences,
             one_step_keys=one_step_keys,
         ).head(20).to_dicts(),
     )
 
 
-def _destination_chain_lengths(destination_sequences: pl.DataFrame) -> pl.DataFrame:
-    """Build one row per destination chain with ordered locations."""
+def _destination_sequence_lengths(destination_sequences: pl.DataFrame) -> pl.DataFrame:
+    """Build one row per destination sequence with ordered locations."""
     return (
         destination_sequences
         .group_by(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id"])
@@ -68,23 +143,12 @@ def _destination_chain_lengths(destination_sequences: pl.DataFrame) -> pl.DataFr
     )
 
 
-def _distribution_by_count(frame: pl.DataFrame, count_col: str) -> list[dict[str, Any]]:
-    """Return a compact count distribution for debug logging."""
-    return (
-        frame
-        .group_by(count_col)
-        .len()
-        .sort(count_col)
-        .to_dicts()
-    )
-
-
-def _one_step_chain_rows(
+def _one_step_sequence_rows(
     *,
     destination_sequences: pl.DataFrame,
     one_step_keys: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Return the raw step rows behind one-step destination chains."""
+    """Return the raw step rows behind one-step destination sequences."""
     return (
         destination_sequences
         .join(
@@ -96,12 +160,12 @@ def _one_step_chain_rows(
     )
 
 
-def _source_rows_for_chain_keys(
+def _source_rows_for_sequence_keys(
     *,
     source_activity_sequences: pl.DataFrame,
     one_step_keys: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Return the source activity rows behind the problematic destination chains."""
+    """Return the source activity rows behind the problematic destination sequences."""
     return (
         source_activity_sequences
         .join(
@@ -116,13 +180,13 @@ def _source_rows_for_chain_keys(
 def log_step_dropout_diagnostics(
     *,
     seq_step_index: int,
-    chains_step: pl.DataFrame,
+    sequence_step: pl.DataFrame,
     costs: pl.DataFrame,
     non_anchor_candidates: pl.LazyFrame,
     candidates_with_origin_costs: pl.LazyFrame,
     candidates_with_costs: pl.LazyFrame,
     sampled_non_anchor_steps: pl.LazyFrame,
-    chain_key_cols: list[str],
+    sequence_key_cols: list[str],
     transport_zones: Any | None,
 ) -> None:
     """Log spatialization dropouts only when trace logging is enabled."""
@@ -131,45 +195,50 @@ def log_step_dropout_diagnostics(
 
     # Start from the non-anchor rows that must survive this step.
     non_anchor_input = (
-        chains_step
+        sequence_step
         .filter(pl.col("is_anchor").not_())
-        .select(chain_key_cols + ["activity", "seq_step_index", "from", "anchor_to"])
+        .select(sequence_key_cols + ["activity", "seq_step_index", "from", "anchor_to"])
         .unique()
     )
     if non_anchor_input.height == 0:
         return
 
-    candidate_keys = _collect_unique_keys(non_anchor_candidates, chain_key_cols)
-    origin_cost_keys = _collect_unique_keys(candidates_with_origin_costs, chain_key_cols)
-    costed_keys = _collect_unique_keys(candidates_with_costs, chain_key_cols)
-    sampled_keys = _collect_unique_keys(sampled_non_anchor_steps, chain_key_cols)
+    candidate_keys = _collect_unique_keys(non_anchor_candidates, sequence_key_cols)
+    origin_cost_keys = _collect_unique_keys(candidates_with_origin_costs, sequence_key_cols)
+    costed_keys = _collect_unique_keys(candidates_with_costs, sequence_key_cols)
+    sampled_keys = _collect_unique_keys(sampled_non_anchor_steps, sequence_key_cols)
 
-    # Compute the first stage where each chain disappears.
-    missing_after_probability = non_anchor_input.join(candidate_keys, on=chain_key_cols, how="anti")
-    missing_after_origin_costs = (
-        non_anchor_input
-        .join(candidate_keys, on=chain_key_cols, how="inner")
-        .join(origin_cost_keys, on=chain_key_cols, how="anti")
-    )
-    missing_after_anchor_costs = (
-        non_anchor_input
-        .join(origin_cost_keys, on=chain_key_cols, how="inner")
-        .join(costed_keys, on=chain_key_cols, how="anti")
-    )
-    missing_after_sampling = (
-        non_anchor_input
-        .join(costed_keys, on=chain_key_cols, how="inner")
-        .join(sampled_keys, on=chain_key_cols, how="anti")
-    )
+    # Compute the first stage where each sequence disappears.
+    missing_by_stage = {
+        "probability": non_anchor_input.join(candidate_keys, on=sequence_key_cols, how="anti"),
+        "origin_cost": (
+            non_anchor_input
+            .join(candidate_keys, on=sequence_key_cols, how="inner")
+            .join(origin_cost_keys, on=sequence_key_cols, how="anti")
+        ),
+        "anchor_cost": (
+            non_anchor_input
+            .join(origin_cost_keys, on=sequence_key_cols, how="inner")
+            .join(costed_keys, on=sequence_key_cols, how="anti")
+        ),
+        "sampling": (
+            non_anchor_input
+            .join(costed_keys, on=sequence_key_cols, how="inner")
+            .join(sampled_keys, on=sequence_key_cols, how="anti")
+        ),
+    }
 
-    if (
-        missing_after_probability.height == 0
-        and missing_after_origin_costs.height == 0
-        and missing_after_anchor_costs.height == 0
-        and missing_after_sampling.height == 0
-    ):
+    if all(dropouts.height == 0 for dropouts in missing_by_stage.values()):
         return
 
+    candidate_samples = {
+        stage: _candidate_samples_for_dropouts(
+            dropouts=dropouts,
+            non_anchor_candidates=non_anchor_candidates,
+            sequence_key_cols=sequence_key_cols,
+        )
+        for stage, dropouts in missing_by_stage.items()
+    }
     logging.warning(
         "Destination spatialization dropouts at step %s | input_non_anchor=%s | after_probability_missing=%s | after_origin_cost_missing=%s | "
         "after_anchor_cost_missing=%s | after_sampling_missing=%s | probability_samples=%s | origin_cost_samples=%s | "
@@ -177,56 +246,40 @@ def log_step_dropout_diagnostics(
         "anchor_cost_candidates=%s | sampling_candidates=%s | origin_cost_traces=%s | anchor_cost_traces=%s",
         seq_step_index,
         non_anchor_input.height,
-        missing_after_probability.height,
-        missing_after_origin_costs.height,
-        missing_after_anchor_costs.height,
-        missing_after_sampling.height,
-        missing_after_probability.head(10).to_dicts(),
-        missing_after_origin_costs.head(10).to_dicts(),
-        missing_after_anchor_costs.head(10).to_dicts(),
-        missing_after_sampling.head(10).to_dicts(),
-        _candidate_samples_for_dropouts(
-            dropouts=missing_after_probability,
-            non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
-        ),
-        _candidate_samples_for_dropouts(
-            dropouts=missing_after_origin_costs,
-            non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
-        ),
-        _candidate_samples_for_dropouts(
-            dropouts=missing_after_anchor_costs,
-            non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
-        ),
-        _candidate_samples_for_dropouts(
-            dropouts=missing_after_sampling,
-            non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
-        ),
+        missing_by_stage["probability"].height,
+        missing_by_stage["origin_cost"].height,
+        missing_by_stage["anchor_cost"].height,
+        missing_by_stage["sampling"].height,
+        missing_by_stage["probability"].head(10).to_dicts(),
+        missing_by_stage["origin_cost"].head(10).to_dicts(),
+        missing_by_stage["anchor_cost"].head(10).to_dicts(),
+        missing_by_stage["sampling"].head(10).to_dicts(),
+        candidate_samples["probability"],
+        candidate_samples["origin_cost"],
+        candidate_samples["anchor_cost"],
+        candidate_samples["sampling"],
         _cost_trace_for_dropouts(
-            dropouts=missing_after_origin_costs,
+            dropouts=missing_by_stage["origin_cost"],
             non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             costs=costs,
             transport_zones=transport_zones,
         ),
         _cost_trace_for_dropouts(
-            dropouts=missing_after_anchor_costs,
+            dropouts=missing_by_stage["anchor_cost"],
             non_anchor_candidates=non_anchor_candidates,
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             costs=costs,
             transport_zones=transport_zones,
         ),
     )
 
 
-def _collect_unique_keys(frame: pl.LazyFrame, chain_key_cols: list[str]) -> pl.DataFrame:
-    """Collect one unique key row per surviving chain."""
+def _collect_unique_keys(frame: pl.LazyFrame, sequence_key_cols: list[str]) -> pl.DataFrame:
+    """Collect one unique key row per surviving sequence."""
     return (
         frame
-        .select(chain_key_cols)
+        .select(sequence_key_cols)
         .unique()
         .collect(engine="streaming")
     )
@@ -236,16 +289,16 @@ def _candidate_samples_for_dropouts(
     *,
     dropouts: pl.DataFrame,
     non_anchor_candidates: pl.LazyFrame,
-    chain_key_cols: list[str],
+    sequence_key_cols: list[str],
 ) -> list[dict[str, Any]]:
-    """Return a small sample of destination candidates for dropped chains."""
+    """Return a small sample of destination candidates for dropped sequences."""
     if dropouts.height == 0:
         return []
     return (
         non_anchor_candidates
-        .join(dropouts.lazy().select(chain_key_cols), on=chain_key_cols, how="inner")
-        .select(chain_key_cols + ["activity", "seq_step_index", "from", "to", "anchor_to", "p_ij"])
-        .sort(chain_key_cols + ["to"])
+        .join(dropouts.lazy().select(sequence_key_cols), on=sequence_key_cols, how="inner")
+        .select(sequence_key_cols + ["activity", "seq_step_index", "from", "to", "anchor_to", "p_ij"])
+        .sort(sequence_key_cols + ["to"])
         .limit(20)
         .collect(engine="streaming")
         .to_dicts()
@@ -256,19 +309,19 @@ def _cost_trace_for_dropouts(
     *,
     dropouts: pl.DataFrame,
     non_anchor_candidates: pl.LazyFrame,
-    chain_key_cols: list[str],
+    sequence_key_cols: list[str],
     costs: pl.DataFrame,
     transport_zones: Any | None,
 ) -> list[dict[str, Any]]:
-    """Trace OD cost availability for a few dropped chains."""
+    """Trace OD cost availability for a few dropped sequences."""
     if dropouts.height == 0:
         return []
 
     candidate_rows = (
         non_anchor_candidates
-        .join(dropouts.lazy().select(chain_key_cols), on=chain_key_cols, how="inner")
-        .select(chain_key_cols + ["from", "to", "anchor_to"])
-        .sort(chain_key_cols + ["to"])
+        .join(dropouts.lazy().select(sequence_key_cols), on=sequence_key_cols, how="inner")
+        .select(sequence_key_cols + ["from", "to", "anchor_to"])
+        .sort(sequence_key_cols + ["to"])
         .limit(10)
         .collect(engine="streaming")
     )

--- a/mobility/trips/group_day_trips/plans/demand_subgroups.py
+++ b/mobility/trips/group_day_trips/plans/demand_subgroups.py
@@ -4,16 +4,10 @@ import polars as pl
 
 
 DEMAND_UNIT_COLS = ["demand_group_id", "demand_subgroup_id"]
-
-
-def with_demand_subgroup_id(frame: pl.DataFrame | pl.LazyFrame | None) -> pl.DataFrame | pl.LazyFrame | None:
-    """Return a frame with the default demand subgroup column."""
-    if frame is None:
-        return None
-    schema = frame.schema if isinstance(frame, pl.DataFrame) else frame.collect_schema()
-    if "demand_subgroup_id" in schema:
-        return frame
-    return frame.with_columns(pl.lit(0, dtype=pl.UInt32).alias("demand_subgroup_id"))
+DEMAND_UNIT_SCHEMA = {
+    "demand_group_id": pl.UInt32,
+    "demand_subgroup_id": pl.UInt32,
+}
 
 
 def demand_unit_hash(other_columns: list[str], *, seed: int) -> pl.Expr:
@@ -33,7 +27,15 @@ def split_large_demand_groups(
     max_persons_per_demand_subgroup: int | None,
 ) -> pl.DataFrame:
     """Split high-weight demand groups into deterministic stochastic subgroups."""
-    demand_groups = with_demand_subgroup_id(demand_groups)
+    if "demand_subgroup_id" in demand_groups.columns:
+        raise ValueError(
+            "`split_large_demand_groups()` expects raw demand groups without "
+            "`demand_subgroup_id` because it owns subgroup creation."
+        )
+
+    demand_groups = demand_groups.with_columns(
+        demand_subgroup_id=pl.lit(0, dtype=pl.UInt32)
+    )
     if max_persons_per_demand_subgroup is None:
         return demand_groups
 

--- a/mobility/trips/group_day_trips/plans/destination_sequences.py
+++ b/mobility/trips/group_day_trips/plans/destination_sequences.py
@@ -5,9 +5,13 @@ from typing import Any
 import polars as pl
 from scipy.stats import norm
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet
 from mobility.trips.group_day_trips.core.parameters import BehaviorChangeScope
 from .debug_logs import (
     log_destination_sequence_diagnostics,
+    log_destination_spatialization_step,
+    log_incomplete_destination_draws,
+    log_missing_anchor_destination_samples,
     log_step_dropout_diagnostics,
 )
 from .stable_key_index import StableKeyIndex
@@ -15,60 +19,35 @@ from mobility.runtime.assets.file_asset import FileAsset
 from mobility.activities.activity import resolve_activity_parameters
 from mobility.runtime.parameter_values import SensitivityCase
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
-from .demand_subgroups import DEMAND_UNIT_COLS, demand_unit_hash, with_demand_subgroup_id
-
-
-def _spatialization_cost_views(costs: pl.DataFrame) -> dict[str, pl.LazyFrame]:
-    """Build the cost projections reused by each destination spatialization step."""
-    costs_lf = costs.lazy()
-    return {
-        "to_candidate": costs_lf.select(
-            [
-                pl.col("from").alias("candidate_from"),
-                pl.col("to").alias("candidate_to"),
-                pl.col("cost").alias("cost_to_candidate"),
-            ]
-        ),
-        "to_anchor": costs_lf.select(
-            [
-                pl.col("from").alias("anchor_from"),
-                pl.col("to").alias("anchor_to_cost"),
-                pl.col("cost").alias("cost_to_anchor"),
-            ]
-        ),
-        "to_home": costs_lf.select(
-            [
-                pl.col("from").alias("home_return_from"),
-                pl.col("to").alias("home_return_to"),
-                pl.col("cost").alias("cost_to_home"),
-            ]
-        ),
-        "anchor_leg_pairs": costs_lf.select(
-            [
-                pl.col("from").alias("anchor_leg_from"),
-                pl.col("to").alias("anchor_leg_to"),
-            ]
-        ).unique(),
-    }
+from .demand_subgroups import DEMAND_UNIT_COLS, DEMAND_UNIT_SCHEMA, demand_unit_hash
 
 
 class DestinationSequences(FileAsset):
     """Persist destination sequences produced for one PopulationGroupDayTrips iteration."""
 
-    OUTPUT_COLUMNS = [
-        "demand_group_id",
-        "demand_subgroup_id",
-        "activity_seq_id",
-        "time_seq_id",
-        "dest_seq_id",
-        "seq_step_index",
-        "from",
-        "to",
-        "departure_time",
-        "arrival_time",
-        "next_departure_time",
-        "iteration",
-    ]
+    OUTPUT_SCHEMA = {
+        "demand_group_id": pl.UInt32,
+        "demand_subgroup_id": pl.UInt32,
+        "activity_seq_id": pl.UInt32,
+        "time_seq_id": pl.UInt32,
+        "dest_seq_id": pl.UInt32,
+        "seq_step_index": pl.UInt8,
+        "from": pl.UInt16,
+        "to": pl.UInt16,
+        "departure_time": pl.Float32,
+        "arrival_time": pl.Float32,
+        "next_departure_time": pl.Float32,
+        "iteration": pl.UInt16,
+    }
+    REQUIRED_SCHEMA = {
+        **DEMAND_UNIT_SCHEMA,
+        "activity_seq_id": pl.UInt32,
+        "time_seq_id": pl.UInt32,
+        "dest_seq_id": pl.UInt32,
+        "seq_step_index": pl.UInt8,
+    }
+
+    OUTPUT_COLUMNS = list(OUTPUT_SCHEMA)
 
     def __init__(
         self,
@@ -117,10 +96,10 @@ class DestinationSequences(FileAsset):
         self.sensitivity_case = sensitivity_case
         self.transport_zones = transport_zones
         self.transport_costs = transport_costs
-        self.current_plans = with_demand_subgroup_id(current_plans) if current_plans is not None else None
-        self.current_plan_steps = with_demand_subgroup_id(current_plan_steps) if current_plan_steps is not None else None
+        self.current_plans = current_plans
+        self.current_plan_steps = current_plan_steps
         self.destination_saturation = destination_saturation
-        self.demand_groups = with_demand_subgroup_id(demand_groups) if demand_groups is not None else None
+        self.demand_groups = demand_groups
         self.costs = costs
         self.parameters = parameters
         self.seed = seed
@@ -162,11 +141,15 @@ class DestinationSequences(FileAsset):
 
     def get_cached_asset(self) -> pl.DataFrame:
         """Return cached destination sequences for one iteration."""
-        return pl.read_parquet(self.cache_path["sequences"])
+        return read_cached_parquet(
+            self.cache_path["sequences"],
+            table_name="destination_sequences",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
 
     def get_index(self) -> pl.DataFrame:
-        """Return the destination-chain index cached with this iteration."""
+        """Return the destination-sequence index cached with this iteration."""
         return pl.read_parquet(self.cache_path["index"])
 
 
@@ -177,26 +160,8 @@ class DestinationSequences(FileAsset):
         if self.seed is None and self.seed_asset is not None:
             self.seed = self.seed_asset.get()["destination_sequences"]
 
-        if self.activities is None:
-            raise ValueError("Cannot build destination sequences without activities.")
-        if self.transport_zones is None:
-            raise ValueError("Cannot build destination sequences without transport zones.")
-        if self.destination_saturation is None:
-            raise ValueError("Cannot build destination sequences without destination saturation.")
-        if self.demand_groups is None:
-            raise ValueError("Cannot build destination sequences without demand groups.")
-        if self.costs is None:
-            raise ValueError("Cannot build destination sequences without costs.")
-        if self.parameters is None:
-            raise ValueError("Cannot build destination sequences without parameters.")
-        if self.seed is None:
-            raise ValueError("Cannot build destination sequences without a seed.")
-        if self.resolved_activity_parameters is None:
-            raise ValueError("Cannot build destination sequences without resolved activity parameters.")
-        if self.current_plans is None:
-            raise ValueError("Cannot build destination sequences without current plans.")
-
-        destination_sequences = self._build_destination_sequences_for_scope()
+        scope = self.parameters.behavior_change.scope_at(self.iteration)
+        destination_sequences = self._build_destination_sequences_for_scope(scope)
 
         self.cache_path["sequences"].parent.mkdir(parents=True, exist_ok=True)
         destination_sequences.write_parquet(self.cache_path["sequences"])
@@ -209,29 +174,27 @@ class DestinationSequences(FileAsset):
 
         state = self.previous_state.get()
         if self.current_plans is None:
-            self.current_plans = with_demand_subgroup_id(state.current_plans)
+            self.current_plans = state.current_plans
         if self.current_plan_steps is None:
-            self.current_plan_steps = with_demand_subgroup_id(state.current_plan_steps)
+            self.current_plan_steps = state.current_plan_steps
         if self.destination_saturation is None:
             self.destination_saturation = state.destination_saturation
         if self.demand_groups is None:
-            self.demand_groups = with_demand_subgroup_id(state.demand_groups)
+            self.demand_groups = state.demand_groups
         if self.costs is None and self.transport_costs is not None:
             self.costs = self.transport_costs.get_costs_by_od(["cost", "distance"])
         elif self.costs is None:
             self.costs = state.costs
 
-    def _build_destination_sequences_for_scope(self) -> pl.DataFrame:
+    def _build_destination_sequences_for_scope(self, scope: BehaviorChangeScope) -> pl.DataFrame:
         """Return the destination sequences to use for this iteration."""
-        scope = self.parameters.behavior_change.scope_at(self.iteration)
-
         if scope == BehaviorChangeScope.FULL_REPLANNING:
             sampled_sequences = self._sample_all_destination_sequences()
-            return self._with_refreshed_active_destination_sequences(sampled_sequences)
+            return self._with_current_active_destination_sequences(sampled_sequences)
 
         if scope == BehaviorChangeScope.DESTINATION_REPLANNING:
             sampled_sequences = self._sample_active_destination_sequences()
-            return self._with_refreshed_active_destination_sequences(sampled_sequences)
+            return self._with_current_active_destination_sequences(sampled_sequences)
 
         if scope in (BehaviorChangeScope.MODE_REPLANNING, BehaviorChangeScope.NO_TRANSITIONS):
             reused_sequences = self._reuse_current_destination_sequences()
@@ -241,9 +204,7 @@ class DestinationSequences(FileAsset):
         raise ValueError(f"Unsupported behavior change scope: {scope}")
 
     def _sample_all_destination_sequences(self) -> pl.DataFrame:
-        """Sample destination sequences from all non-stay-home activity chains."""
-        if self.activity_sequences is None:
-            raise ValueError("Cannot build destination sequences without activity sequences.")
+        """Sample destination sequences from all non-stay-home activity sequences."""
         return self.run(
             self.activities,
             self.transport_zones,
@@ -257,10 +218,8 @@ class DestinationSequences(FileAsset):
 
     def _sample_active_destination_sequences(self) -> pl.DataFrame:
         """Sample destination sequences for currently active activity sequences only."""
-        if self.activity_sequences is None:
-            raise ValueError("Cannot build destination sequences without activity sequences.")
-        filtered_chains = self.activity_sequences.get_cached_asset()
-        if filtered_chains.height == 0:
+        filtered_sequences = self.activity_sequences.get_cached_asset()
+        if filtered_sequences.height == 0:
             self._cache_empty_destination_sequence_index()
             return self._empty_destination_sequences()
 
@@ -268,7 +227,7 @@ class DestinationSequences(FileAsset):
             self.activities,
             self.transport_zones,
             self.destination_saturation,
-            filtered_chains,
+            filtered_sequences,
             self.demand_groups,
             self.costs,
             self.parameters,
@@ -283,12 +242,6 @@ class DestinationSequences(FileAsset):
 
         if active_dest_sequences.height == 0:
             return self._empty_destination_sequences()
-
-        if self.current_plan_steps is None:
-            raise ValueError(
-                "No current plan steps available for active non-stay-home "
-                f"plans at iteration={self.iteration}."
-            )
 
         reused = (
             self.current_plan_steps.lazy()
@@ -329,12 +282,11 @@ class DestinationSequences(FileAsset):
 
         return reused
 
-    def _with_refreshed_active_destination_sequences(self, sampled_sequences: pl.DataFrame) -> pl.DataFrame:
-        """Append active destination chains when active-mode refresh is enabled."""
+    def _with_current_active_destination_sequences(self, sampled_sequences: pl.DataFrame) -> pl.DataFrame:
+        """Append current active destination sequences when the option is enabled."""
         if not self.parameters.destination_sequences.refresh_active_mode_alternatives:
             return sampled_sequences
 
-        sampled_sequences = with_demand_subgroup_id(sampled_sequences)
         active_sequences = self._reuse_current_destination_sequences()
         if active_sequences.height == 0:
             return sampled_sequences.select(self.OUTPUT_COLUMNS)
@@ -367,25 +319,10 @@ class DestinationSequences(FileAsset):
 
     def _empty_destination_sequences(self) -> pl.DataFrame:
         """Return an empty destination-sequences dataframe with the expected schema."""
-        return pl.DataFrame(
-            schema={
-                "demand_group_id": pl.UInt32,
-                "demand_subgroup_id": pl.UInt32,
-                "activity_seq_id": pl.UInt32,
-                "time_seq_id": pl.UInt32,
-                "dest_seq_id": pl.UInt32,
-                "seq_step_index": pl.UInt8,
-                "from": pl.UInt16,
-                "to": pl.UInt16,
-                "departure_time": pl.Float32,
-                "arrival_time": pl.Float32,
-                "next_departure_time": pl.Float32,
-                "iteration": pl.UInt16,
-            }
-        )
+        return pl.DataFrame(schema=self.OUTPUT_SCHEMA)
 
     def _cache_empty_destination_sequence_index(self) -> None:
-        """Write a carried-forward destination index when no new chain is sampled."""
+        """Write a carried-forward destination index when no new sequence is sampled."""
         empty_keys = pl.DataFrame(schema={"destination_sequence_key": pl.String})
         StableKeyIndex(
             key_cols=["destination_sequence_key"],
@@ -420,12 +357,12 @@ class DestinationSequences(FileAsset):
             self.resolved_activity_parameters,
             parameters.destination_sequences.dest_prob_cutoff,
         )
-        cost_views = _spatialization_cost_views(costs)
+        cost_views = self._spatialization_cost_views(costs)
         activity_sequences = (
             activity_sequences
             .filter(pl.col("activity_seq_id") != 0)
             .join(
-                with_demand_subgroup_id(demand_groups).select(DEMAND_UNIT_COLS + ["home_zone_id"]),
+                demand_groups.select(DEMAND_UNIT_COLS + ["home_zone_id"]),
                 on=DEMAND_UNIT_COLS,
             )
             .select(
@@ -449,7 +386,6 @@ class DestinationSequences(FileAsset):
         anchor_spatialized_sequences = self._spatialize_anchor_activities(
             source_activity_sequences,
             destination_probability,
-            costs,
             parameters.destination_sequences.alpha,
             seed,
             cost_views,
@@ -594,8 +530,6 @@ class DestinationSequences(FileAsset):
         )
         costs_by_bin = destination_probability_inputs[0]
         cost_bin_to_destination = destination_probability_inputs[1]
-        if resolved_activity_parameters is None:
-            raise ValueError("Cannot compute destination probabilities without resolved activity parameters.")
         activities_lambda = {
             activity.name: resolved_activity_parameters[activity.name].radiation_lambda
             for activity in activities
@@ -642,38 +576,140 @@ class DestinationSequences(FileAsset):
         )
 
 
-    def _spatialize_anchor_activities(
-        self,
-        chains: pl.DataFrame,
-        destination_probability: pl.DataFrame,
-        costs: pl.DataFrame,
+    @staticmethod
+    def _spatialization_cost_views(costs: pl.DataFrame) -> dict[str, pl.LazyFrame]:
+        """Build the cost projections reused by each destination spatialization step."""
+        costs_lf = costs.lazy()
+        return {
+            "to_candidate": costs_lf.select(
+                [
+                    pl.col("from").alias("candidate_from"),
+                    pl.col("to").alias("candidate_to"),
+                    pl.col("cost").alias("cost_to_candidate"),
+                ]
+            ),
+            "to_anchor": costs_lf.select(
+                [
+                    pl.col("from").alias("anchor_from"),
+                    pl.col("to").alias("anchor_to_cost"),
+                    pl.col("cost").alias("cost_to_anchor"),
+                ]
+            ),
+            "to_home": costs_lf.select(
+                [
+                    pl.col("from").alias("home_return_from"),
+                    pl.col("to").alias("home_return_to"),
+                    pl.col("cost").alias("cost_to_home"),
+                ]
+            ),
+            "anchor_leg_pairs": costs_lf.select(
+                [
+                    pl.col("from").alias("anchor_leg_from"),
+                    pl.col("to").alias("anchor_leg_to"),
+                ]
+            ).unique(),
+        }
+
+
+    @staticmethod
+    def _sample_sequence_aware_destinations(
+        *,
+        steps_lf: pl.LazyFrame,
+        destination_probability_lf: pl.LazyFrame,
+        origin_cost_lf: pl.LazyFrame,
+        onward_cost_lf: pl.LazyFrame,
+        onward_left_on: list[str],
+        onward_right_on: list[str],
+        onward_cost_col: str,
         alpha: float,
         seed: int,
-        cost_views: dict[str, pl.LazyFrame] | None = None,
+        output_cols: list[str],
+    ) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
+        """Sample destinations while checking both legs around the candidate zone."""
+        active_probability = destination_probability_lf.join(
+            steps_lf.select(["from", "activity"]).unique(),
+            on=["from", "activity"],
+            how="semi",
+        )
+        candidates = steps_lf.join(active_probability, on=["from", "activity"])
+        candidates_with_origin_costs = candidates.join(
+            origin_cost_lf,
+            left_on=["from", "to"],
+            right_on=["candidate_from", "candidate_to"],
+        )
+        candidates_with_costs = candidates_with_origin_costs.join(
+            onward_cost_lf,
+            left_on=onward_left_on,
+            right_on=onward_right_on,
+        )
+        sampled = (
+            candidates_with_costs
+            .with_columns(
+                sequence_cost_via_candidate=pl.col("cost_to_candidate") + pl.col(onward_cost_col),
+            )
+            .with_columns(
+                p_ij=(
+                    (
+                        pl.col("p_ij").clip(1e-18).log()
+                        - alpha * pl.col("sequence_cost_via_candidate")
+                    ).exp()
+                ),
+            )
+            .with_columns(
+                noise=(
+                    demand_unit_hash(
+                        ["activity_seq_id", "time_seq_id", "dest_draw_id", "to"],
+                        seed=seed,
+                    )
+                    .cast(pl.Float64)
+                    .truediv(pl.lit(18446744073709551616.0))
+                    .log()
+                    .neg()
+                ),
+            )
+            .with_columns(
+                sample_score=pl.col("noise") / pl.col("p_ij").clip(1e-18)
+                + pl.col("to").cast(pl.Float64) * 1e-18
+            )
+            .with_columns(
+                min_score=pl.col("sample_score").min().over(
+                    DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
+                )
+            )
+            .filter(pl.col("sample_score") == pl.col("min_score"))
+            .select(output_cols)
+        )
+        return candidates, candidates_with_origin_costs, candidates_with_costs, sampled
+
+
+    def _spatialize_anchor_activities(
+        self,
+        sequences: pl.DataFrame,
+        destination_probability: pl.DataFrame,
+        alpha: float,
+        seed: int,
+        cost_views: dict[str, pl.LazyFrame],
     ) -> pl.DataFrame:
-        """Sample anchor destinations with a forward tour-aware pass.
+        """Choose the anchor destinations of each daily tour.
 
-        Anchor activities are fixed points in the daily schedule, for example
-        `studies`, `work`, and `home`. We sample them before the more flexible
-        non-anchor activities, because later non-anchor steps need to know the
-        next anchor location they are travelling toward.
+        Anchor activities structure the day, such as home, work, and studies.
+        They are sampled before non-anchor activities because a later shopping
+        or leisure stop needs to know the next anchor destination the person is
+        travelling toward.
 
-        The important rule is that anchors are sampled in travel order. A work
-        anchor after a study anchor is sampled from the sampled study location,
-        not independently from home. We also use the same simple two-leg penalty
-        as non-anchor activities:
+        Anchors are sampled in travel order. For example, if a person goes from
+        home to studies and then to work, the work destination is sampled from
+        the sampled studies zone, not independently from home. We also use a
+        simple two-leg penalty:
 
         `current location -> candidate anchor -> home`
 
-        This keeps sampled anchor chains reachable and avoids impossible legs
+        This keeps sampled anchor sequences reachable and avoids impossible legs
         such as sampling a work zone that cannot be reached from the previous
         anchor zone.
         """
         logging.debug("Spatializing anchor activities...")
-        chains = with_demand_subgroup_id(chains)
-        if cost_views is None:
-            cost_views = _spatialization_cost_views(costs)
-        chain_key_cols = [
+        sequence_key_cols = [
             "demand_group_id",
             "demand_subgroup_id",
             "home_zone_id",
@@ -681,305 +717,216 @@ class DestinationSequences(FileAsset):
             "time_seq_id",
             "dest_draw_id",
         ]
+        anchor_output_cols = sequence_key_cols + [
+            "activity",
+            "is_anchor",
+            "seq_step_index",
+            "step_count",
+            "from",
+            "to",
+            "departure_time",
+            "arrival_time",
+            "next_departure_time",
+        ]
         destination_probability_lf = destination_probability.lazy()
         destination_draw_ids = pl.DataFrame(
-            {"dest_draw_id": list(range(1, int(self.parameters.destination_sequences.k_destination_sequences) + 1))},
+            {"dest_draw_id": list(range(int(self.parameters.destination_sequences.k_destination_sequences)))},
             schema={"dest_draw_id": pl.UInt32},
         )
+        sequences = (
+            sequences
+            .sort(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "seq_step_index"])
+            .with_columns(
+                next_anchor_seq_step_index=(
+                    pl.when(pl.col("is_anchor"))
+                    .then(pl.col("seq_step_index"))
+                    .otherwise(pl.lit(None, dtype=pl.UInt8))
+                    .backward_fill()
+                    .over(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id"])
+                )
+            )
+        )
 
-        expanded_chains = (
-            chains
+        expanded_anchor_steps = (
+            sequences
+            .filter(pl.col("is_anchor"))
             .join(destination_draw_ids, how="cross")
             .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "seq_step_index"])
         )
+        expanded_non_anchor_steps = (
+            sequences
+            .filter(pl.col("is_anchor").not_())
+            .join(destination_draw_ids, how="cross")
+            .with_columns(
+                pl.lit(None, dtype=pl.UInt16).alias("from"),
+                pl.lit(None, dtype=pl.UInt16).alias("to"),
+            )
+            .select(anchor_output_cols + ["next_anchor_seq_step_index"])
+        )
 
-        # `current_locations` is the last sampled anchor location for each draw.
-        # It starts at home and is updated only when an anchor or home step is
-        # spatialized. Non-anchor steps are sampled later and do not move this
-        # anchor-to-anchor reference point.
+        # Track the previous anchor destination for each draw. Non-anchor
+        # activities are sampled later, so they do not move this location.
         current_locations = (
-            expanded_chains
-            .select(chain_key_cols)
+            expanded_anchor_steps
+            .select(sequence_key_cols)
             .unique()
             .with_columns(pl.col("home_zone_id").alias("from"))
         )
 
-        spatialized_steps: list[pl.DataFrame] = []
-        missing_anchor_samples: list[pl.DataFrame] = []
-        seq_step_index = 1
-        while True:
-            chains_step = (
-                expanded_chains
-                .filter(pl.col("seq_step_index") == seq_step_index)
-                .join(current_locations, on=chain_key_cols)
-            )
-            if chains_step.height == 0:
-                break
+        sampled_anchor_steps_by_position: list[pl.DataFrame] = []
 
-            chains_step_lf = chains_step.lazy()
-            home_steps = (
-                chains_step_lf
+        anchor_step_indexes = expanded_anchor_steps["seq_step_index"].unique().sort().to_list()
+        for seq_step_index in anchor_step_indexes:
+            anchor_steps_at_position = (
+                expanded_anchor_steps
+                .filter(pl.col("seq_step_index") == seq_step_index)
+                .join(current_locations, on=sequence_key_cols)
+            )
+            if anchor_steps_at_position.height == 0:
+                continue
+
+            anchor_steps_at_position_lf = anchor_steps_at_position.lazy()
+
+            # Home is an anchor, but it is not sampled: its destination is
+            # always the household home zone.
+            home_anchor_steps = (
+                anchor_steps_at_position_lf
                 .filter(pl.col("activity") == "home")
                 .with_columns(to=pl.col("home_zone_id"))
-                .select(
-                    [
-                        "demand_group_id",
-                        "demand_subgroup_id",
-                        "home_zone_id",
-                        "activity_seq_id",
-                        "time_seq_id",
-                        "dest_draw_id",
-                        "activity",
-                        "is_anchor",
-                        "seq_step_index",
-                        "step_count",
-                        "from",
-                        "to",
-                        "departure_time",
-                        "arrival_time",
-                        "next_departure_time",
-                    ]
-                )
+                .select(anchor_output_cols)
                 .collect(engine="streaming")
             )
 
-            active_anchor_probability_keys = (
-                chains_step_lf
-                .filter((pl.col("is_anchor")) & (pl.col("activity") != "home"))
-                .select(["from", "activity"])
-                .unique()
-            )
-            active_anchor_probability = destination_probability_lf.join(
-                active_anchor_probability_keys,
-                on=["from", "activity"],
-                how="semi",
-            )
-            anchor_candidates = (
-                chains_step_lf
-                .filter((pl.col("is_anchor")) & (pl.col("activity") != "home"))
-                .join(active_anchor_probability, on=["from", "activity"])
-            )
-            anchors_with_origin_costs = (
-                anchor_candidates
-                .join(
-                    cost_views["to_candidate"],
-                    left_on=["from", "to"],
-                    right_on=["candidate_from", "candidate_to"],
+            non_home_anchor_steps = anchor_steps_at_position.filter(pl.col("activity") != "home")
+            if non_home_anchor_steps.height == 0:
+                sampled_anchor_steps = home_anchor_steps.head(0)
+            else:
+                non_home_anchor_steps_lf = non_home_anchor_steps.lazy()
+
+                # Keep anchor candidates that can be reached from the previous
+                # anchor and can then return home: previous anchor -> candidate
+                # anchor -> home.
+                _, _, _, sampled_anchor_steps_lf = self._sample_sequence_aware_destinations(
+                    steps_lf=non_home_anchor_steps_lf,
+                    destination_probability_lf=destination_probability_lf,
+                    origin_cost_lf=cost_views["to_candidate"],
+                    onward_cost_lf=cost_views["to_home"],
+                    onward_left_on=["to", "home_zone_id"],
+                    onward_right_on=["home_return_from", "home_return_to"],
+                    onward_cost_col="cost_to_home",
+                    alpha=alpha,
+                    seed=seed,
+                    output_cols=anchor_output_cols,
                 )
-            )
-            anchors_with_costs = (
-                anchors_with_origin_costs
-                .join(
-                    cost_views["to_home"],
-                    left_on=["to", "home_zone_id"],
-                    right_on=["home_return_from", "home_return_to"],
-                )
-            )
-            weighted_anchors = (
-                anchors_with_costs
-                .with_columns(
-                    chain_cost_via_candidate=pl.col("cost_to_candidate") + pl.col("cost_to_home"),
-                )
-                .with_columns(
-                    p_ij=(
-                        (
-                            pl.col("p_ij").clip(1e-18).log()
-                            - alpha * pl.col("chain_cost_via_candidate")
-                        ).exp()
-                    ),
-                )
-            )
-            sampled_anchor_steps = (
-                weighted_anchors
-                .with_columns(
-                    noise=(
-                        demand_unit_hash(
-                            ["activity_seq_id", "time_seq_id", "dest_draw_id", "to"],
-                            seed=seed,
-                        )
-                        .cast(pl.Float64)
-                        .truediv(pl.lit(18446744073709551616.0))
-                        .log()
-                        .neg()
-                    ),
-                )
-                .with_columns(
-                    sample_score=pl.col("noise") / pl.col("p_ij").clip(1e-18)
-                    + pl.col("to").cast(pl.Float64) * 1e-18
-                )
-                .with_columns(
-                    min_score=pl.col("sample_score").min().over(
-                        DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
-                    )
-                )
-                .filter(pl.col("sample_score") == pl.col("min_score"))
-                .select(
-                    [
-                        "demand_group_id",
-                        "demand_subgroup_id",
-                        "home_zone_id",
-                        "activity_seq_id",
-                        "time_seq_id",
-                        "dest_draw_id",
-                        "activity",
-                        "is_anchor",
-                        "seq_step_index",
-                        "step_count",
-                        "from",
-                        "to",
-                        "departure_time",
-                        "arrival_time",
-                        "next_departure_time",
-                    ]
-                )
-                .collect(engine="streaming")
+                sampled_anchor_steps = sampled_anchor_steps_lf.collect(engine="streaming")
+
+            log_missing_anchor_destination_samples(
+                sequence_key_cols=sequence_key_cols,
+                expected_anchor_steps=non_home_anchor_steps,
+                sampled_anchor_steps=sampled_anchor_steps,
             )
 
-            non_anchor_steps = (
-                chains_step_lf
-                .filter(pl.col("is_anchor").not_())
-                .with_columns(to=pl.lit(None).cast(pl.UInt16))
-                .select(
-                    [
-                        "demand_group_id",
-                        "demand_subgroup_id",
-                        "home_zone_id",
-                        "activity_seq_id",
-                        "time_seq_id",
-                        "dest_draw_id",
-                        "activity",
-                        "is_anchor",
-                        "seq_step_index",
-                        "step_count",
-                        "from",
-                        "to",
-                        "departure_time",
-                        "arrival_time",
-                        "next_departure_time",
-                    ]
-                )
-                .collect(engine="streaming")
-            )
+            sampled_anchor_steps_by_position.extend([home_anchor_steps, sampled_anchor_steps])
 
-            anchor_inputs = chains_step.filter((pl.col("is_anchor")) & (pl.col("activity") != "home"))
-            if sampled_anchor_steps.height < anchor_inputs.height:
-                missing_anchor_samples.append(
-                    anchor_inputs
-                    .join(
-                        sampled_anchor_steps.select(chain_key_cols + ["seq_step_index"]),
-                        on=chain_key_cols + ["seq_step_index"],
-                        how="anti",
-                    )
-                    .select(chain_key_cols + ["activity", "seq_step_index", "from"])
-                )
-
-            spatialized_steps.extend([home_steps, sampled_anchor_steps, non_anchor_steps])
-
-            sampled_updates = (
-                pl.concat([home_steps, sampled_anchor_steps], how="vertical_relaxed")
-                .select(chain_key_cols + ["to"])
+            next_anchor_locations = (
+                pl.concat([home_anchor_steps, sampled_anchor_steps], how="vertical_relaxed")
+                .select(sequence_key_cols + ["to"])
                 .rename({"to": "next_from"})
             )
-            if sampled_updates.height > 0:
+            if next_anchor_locations.height > 0:
                 current_locations = (
                     current_locations
-                    .join(sampled_updates, on=chain_key_cols, how="left")
+                    .join(next_anchor_locations, on=sequence_key_cols, how="left")
                     .with_columns(
                         pl.coalesce(pl.col("next_from"), pl.col("from")).cast(pl.UInt16).alias("from")
                     )
                     .drop("next_from")
                 )
-
-            seq_step_index += 1
-
-        if missing_anchor_samples:
-            missing_anchors = pl.concat(missing_anchor_samples, how="vertical_relaxed")
-            logging.warning(
-                "Dropping %s anchor destination steps because no reachable anchor candidate could be sampled. "
-                "Sample steps: %s",
-                missing_anchors.height,
-                missing_anchors.head(20).to_dicts(),
+        sampled_anchor_steps = (
+            pl.concat(sampled_anchor_steps_by_position, how="vertical_relaxed")
+            if sampled_anchor_steps_by_position
+            else expanded_non_anchor_steps.head(0)
+        )
+        sampled_anchor_locations = (
+            sampled_anchor_steps
+            .select(
+                sequence_key_cols
+                + [
+                    pl.col("seq_step_index").alias("next_anchor_seq_step_index"),
+                    pl.col("to").alias("anchor_to"),
+                ]
             )
-
-        return (
-            pl.concat(spatialized_steps, how="vertical_relaxed")
-            .with_columns(
-                anchor_to=pl.when(pl.col("is_anchor"))
-                .then(pl.col("to"))
-                .otherwise(pl.lit(None, dtype=pl.UInt16))
-            )
-            .sort(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "seq_step_index"])
-            .with_columns(
-                anchor_to=pl.col("anchor_to").backward_fill().over(
-                    DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
-                )
-            )
-            # The next pass builds the actual step `from` and `to` columns.
-            # Keep only `anchor_to` here, otherwise stale/null step columns can
-            # interfere with the later Polars joins used to sample non-anchor
-            # destinations.
+        )
+        spatialized_anchor_steps = (
+            sampled_anchor_steps
+            .with_columns(anchor_to=pl.col("to"))
             .drop(["from", "to"])
+        )
+        spatialized_non_anchor_steps = (
+            expanded_non_anchor_steps
+            .join(
+                sampled_anchor_locations,
+                on=sequence_key_cols + ["next_anchor_seq_step_index"],
+                how="left",
+            )
+            .drop(["from", "to", "next_anchor_seq_step_index"])
+        )
+        return pl.concat(
+            [spatialized_anchor_steps, spatialized_non_anchor_steps],
+            how="vertical_relaxed",
         )
 
 
     def _spatialize_other_activities(
         self,
-        chains: pl.DataFrame,
+        sequences: pl.DataFrame,
         destination_probability: pl.DataFrame,
         costs: pl.DataFrame,
         alpha: float,
         seed: int,
-        cost_views: dict[str, pl.LazyFrame] | None = None,
+        cost_views: dict[str, pl.LazyFrame],
     ) -> pl.DataFrame:
         """Sample destinations for non-anchor activities step by step."""
         logging.debug("Spatializing other activities...")
-        chains = with_demand_subgroup_id(chains)
-        if cost_views is None:
-            cost_views = _spatialization_cost_views(costs)
-        chains_step = (
-            chains
+        sequence_step = (
+            sequences
             .filter(pl.col("seq_step_index") == 1)
             .with_columns(pl.col("home_zone_id").alias("from"))
         )
         seq_step_index = 1
-        spatialized_chains: list[pl.DataFrame] = []
-        while chains_step.height > 0:
-            step_stats = chains_step.select(
-                input_rows=pl.len(),
+        spatialized_sequences: list[pl.DataFrame] = []
+        while sequence_step.height > 0:
+            step_counts = sequence_step.select(
                 non_anchor=pl.col("is_anchor").not_().sum(),
                 anchor=pl.col("is_anchor").sum(),
-                unique_draws=pl.struct(
-                    DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
-                ).n_unique(),
             ).row(0, named=True)
-            if logging.root.isEnabledFor(logging.DEBUG):
-                logging.debug(
-                    "Destination spatialization step %s input rows=%s non_anchor=%s anchor=%s unique_draws=%s",
-                    seq_step_index,
-                    step_stats["input_rows"],
-                    step_stats["non_anchor"],
-                    step_stats["anchor"],
-                    step_stats["unique_draws"],
-                )
+            non_anchor_count = int(step_counts["non_anchor"])
+            anchor_count = int(step_counts["anchor"])
+            log_destination_spatialization_step(
+                seq_step_index=seq_step_index,
+                sequence_step=sequence_step,
+                non_anchor_count=non_anchor_count,
+                anchor_count=anchor_count,
+            )
             logging.debug("Spatializing step %s...", str(seq_step_index))
             spatialized_step = (
-                self._spatialize_trip_chain_step(
+                self._spatialize_sequence_step(
                     seq_step_index,
-                    chains_step,
+                    sequence_step,
                     destination_probability,
                     costs,
                     alpha,
                     seed,
                     cost_views,
-                    int(step_stats["non_anchor"]),
-                    int(step_stats["anchor"]),
+                    non_anchor_count,
+                    anchor_count,
                 )
                 .with_columns(seq_step_index=pl.lit(seq_step_index).cast(pl.UInt8))
             )
-            spatialized_chains.append(spatialized_step)
+            spatialized_sequences.append(spatialized_step)
             seq_step_index += 1
-            chains_step = (
-                chains.lazy()
+            sequence_step = (
+                sequences.lazy()
                 .filter(pl.col("seq_step_index") == seq_step_index)
                 .join(
                     spatialized_step.lazy()
@@ -989,35 +936,25 @@ class DestinationSequences(FileAsset):
                 )
                 .collect(engine="streaming")
             )
-        return pl.concat(spatialized_chains)
+        return pl.concat(spatialized_sequences)
 
 
-    def _spatialize_trip_chain_step(
+    def _spatialize_sequence_step(
         self,
         seq_step_index: int,
-        chains_step: pl.DataFrame,
+        sequence_step: pl.DataFrame,
         destination_probability: pl.DataFrame,
         costs: pl.DataFrame,
         alpha: float,
         seed: int,
-        cost_views: dict[str, pl.LazyFrame] | None = None,
-        non_anchor_count: int | None = None,
-        anchor_count: int | None = None,
+        cost_views: dict[str, pl.LazyFrame],
+        non_anchor_count: int,
+        anchor_count: int,
     ) -> pl.DataFrame:
         """Sample destinations for one step between anchors."""
-        chains_step = with_demand_subgroup_id(chains_step)
-        if cost_views is None:
-            cost_views = _spatialization_cost_views(costs)
-        if non_anchor_count is None or anchor_count is None:
-            step_counts = chains_step.select(
-                non_anchor=pl.col("is_anchor").not_().sum(),
-                anchor=pl.col("is_anchor").sum(),
-            ).row(0, named=True)
-            non_anchor_count = int(step_counts["non_anchor"])
-            anchor_count = int(step_counts["anchor"])
-        chains_step_lf = chains_step.lazy()
+        sequence_step_lf = sequence_step.lazy()
         destination_probability_lf = destination_probability.lazy()
-        chain_key_cols = [
+        sequence_key_cols = [
             "demand_group_id",
             "demand_subgroup_id",
             "home_zone_id",
@@ -1044,98 +981,43 @@ class DestinationSequences(FileAsset):
         step_frames: list[pl.LazyFrame] = []
 
         if non_anchor_count > 0:
-            non_anchor_steps = chains_step_lf.filter(pl.col("is_anchor").not_())
-            active_probability_keys = non_anchor_steps.select(["from", "activity"]).unique()
-            active_destination_probability = destination_probability_lf.join(
-                active_probability_keys,
-                on=["from", "activity"],
-                how="semi",
-            )
+            non_anchor_steps = sequence_step_lf.filter(pl.col("is_anchor").not_())
 
-            # Start from the base destination probabilities for non-anchor
-            # activities. These probabilities come from the radiation model and
-            # only depend on the current origin, the activity, and destination
-            # opportunities.
-            non_anchor_candidates = non_anchor_steps.join(
-                active_destination_probability,
-                on=["from", "activity"],
-            )
-
-            # Attach the two legs that define the chain cost of visiting a
-            # candidate destination before continuing to the next anchor.
-            candidates_with_origin_costs = non_anchor_candidates.join(
-                cost_views["to_candidate"],
-                left_on=["from", "to"],
-                right_on=["candidate_from", "candidate_to"],
-            )
-            candidates_with_costs = candidates_with_origin_costs.join(
-                cost_views["to_anchor"],
-                left_on=["to", "anchor_to"],
-                right_on=["anchor_from", "anchor_to_cost"],
-            )
-
-            # Apply an additional chain-aware correction on top of the base
-            # radiation probability. This reduces unrealistic intermediate stops
-            # that would create costly onward travel to the next anchor.
-            weighted_candidates = (
-                candidates_with_costs
-                .with_columns(
-                    chain_cost_via_candidate=pl.col("cost_to_candidate") + pl.col("cost_to_anchor"),
-                )
-                .with_columns(
-                    p_ij=(
-                        (
-                            pl.col("p_ij").clip(1e-18).log()
-                            - alpha * pl.col("chain_cost_via_candidate")
-                        ).exp()
-                    ),
-                )
-            )
-
-            # Draw one destination per sequence and destination draw using the
-            # seeded exponential race sampling already used elsewhere.
-            sampled_non_anchor_steps = (
-                weighted_candidates
-                .with_columns(
-                    noise=(
-                        demand_unit_hash(
-                            ["activity_seq_id", "time_seq_id", "dest_draw_id", "to"],
-                            seed=seed,
-                        )
-                        .cast(pl.Float64)
-                        .truediv(pl.lit(18446744073709551616.0))
-                        .log()
-                        .neg()
-                    ),
-                )
-                .with_columns(
-                    sample_score=pl.col("noise") / pl.col("p_ij").clip(1e-18)
-                    + pl.col("to").cast(pl.Float64) * 1e-18
-                )
-                .with_columns(
-                    min_score=pl.col("sample_score").min().over(
-                        DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
-                    )
-                )
-                .filter(pl.col("sample_score") == pl.col("min_score"))
-                .select(output_cols)
+            # Keep non-anchor candidates that fit between the current location
+            # and the next anchor: current location -> candidate -> next anchor.
+            (
+                non_anchor_candidates,
+                candidates_with_origin_costs,
+                candidates_with_costs,
+                sampled_non_anchor_steps,
+            ) = self._sample_sequence_aware_destinations(
+                steps_lf=non_anchor_steps,
+                destination_probability_lf=destination_probability_lf,
+                origin_cost_lf=cost_views["to_candidate"],
+                onward_cost_lf=cost_views["to_anchor"],
+                onward_left_on=["to", "anchor_to"],
+                onward_right_on=["anchor_from", "anchor_to_cost"],
+                onward_cost_col="cost_to_anchor",
+                alpha=alpha,
+                seed=seed,
+                output_cols=output_cols,
             )
             step_frames.append(sampled_non_anchor_steps)
             log_step_dropout_diagnostics(
                 seq_step_index=seq_step_index,
-                chains_step=chains_step,
+                sequence_step=sequence_step,
                 costs=costs,
                 non_anchor_candidates=non_anchor_candidates,
                 candidates_with_origin_costs=candidates_with_origin_costs,
                 candidates_with_costs=candidates_with_costs,
                 sampled_non_anchor_steps=sampled_non_anchor_steps,
-                chain_key_cols=chain_key_cols,
+                sequence_key_cols=sequence_key_cols,
                 transport_zones=self.transport_zones,
             )
 
         if anchor_count > 0:
             steps_anchor = (
-                chains_step_lf
+                sequence_step_lf
                 .filter(pl.col("is_anchor"))
                 .with_columns(to=pl.col("anchor_to"))
                 # Anchor destinations were sampled earlier, but we still check
@@ -1150,15 +1032,6 @@ class DestinationSequences(FileAsset):
             )
             step_frames.append(steps_anchor)
 
-        if len(step_frames) == 0:
-            return (
-                chains_step_lf
-                .with_columns(to=pl.lit(None, dtype=pl.UInt16))
-                .select(output_cols)
-                .head(0)
-                .collect(engine="streaming")
-            )
-
         return pl.concat(step_frames).collect(engine="streaming")
 
     @staticmethod
@@ -1171,35 +1044,24 @@ class DestinationSequences(FileAsset):
 
         A non-anchor step can disappear when there is no valid travel-cost path from
         the sampled destination to the next anchor destination. If we keep the
-        remaining earlier steps, we create a truncated destination chain that later
+        remaining earlier steps, we create a truncated destination sequence that later
         becomes invalid input for mode-sequence search.
         """
-        activity_sequences = with_demand_subgroup_id(activity_sequences)
-        chain_key_cols = DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
+        sequence_key_cols = DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_draw_id"]
         activity_sequences_with_counts = (
             activity_sequences
             .with_columns(
-                step_count_after_spatialization=pl.len().over(chain_key_cols).cast(pl.UInt8),
+                step_count_after_spatialization=pl.len().over(sequence_key_cols).cast(pl.UInt8),
             )
         )
-        incomplete_draws = (
-            activity_sequences_with_counts
-            .filter(pl.col("step_count_after_spatialization") != pl.col("step_count"))
-            .select(chain_key_cols + ["step_count", "step_count_after_spatialization"])
-            .unique()
-            .sort(chain_key_cols)
+        log_incomplete_destination_draws(
+            iteration=iteration,
+            activity_sequences_with_counts=activity_sequences_with_counts,
+            sequence_key_cols=sequence_key_cols,
         )
-        if incomplete_draws.height > 0:
-            logging.warning(
-                "Dropping %s incomplete destination draws at iteration %s because one or more steps disappeared during spatialization. "
-                "Sample draws: %s",
-                incomplete_draws.height,
-                iteration,
-                incomplete_draws.head(20).to_dicts(),
-            )
         return (
             activity_sequences_with_counts
             .filter(pl.col("step_count_after_spatialization") == pl.col("step_count"))
             .drop(["step_count", "step_count_after_spatialization"])
-            .sort(chain_key_cols + ["seq_step_index"])
+            .sort(sequence_key_cols + ["seq_step_index"])
         )

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/debug_logs.py
@@ -5,7 +5,7 @@ import polars as pl
 
 from mobility.runtime.logging_levels import TRACE_LEVEL, is_trace_enabled
 
-from ..demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from ..demand_subgroups import DEMAND_UNIT_COLS
 
 
 def log_location_chain_diagnostics(
@@ -19,8 +19,6 @@ def log_location_chain_diagnostics(
     if not is_trace_enabled():
         return
 
-    destination_steps = with_demand_subgroup_id(destination_steps)
-    trip_chains = with_demand_subgroup_id(trip_chains)
     trip_chain_lengths = _trip_chain_lengths(trip_chains)
     unique_chain_lengths = _unique_chain_lengths(unique_destination_chains)
     logging.log(

--- a/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
+++ b/mobility/trips/group_day_trips/plans/mode_sequence_search/mode_sequences.py
@@ -3,9 +3,11 @@ from typing import Any
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet
 from mobility.runtime.assets.file_asset import FileAsset
 from mobility.trips.group_day_trips.core.memory_logging import log_memory_checkpoint
 from mobility.trips.group_day_trips.core.progress import get_group_day_trips_progress
+from mobility.trips.group_day_trips.plans.plan_ids import PLAN_STEP_KEY_SCHEMA
 
 from ..stable_key_index import StableKeyIndex
 from .assemble import (
@@ -49,6 +51,10 @@ class ModeSequences(FileAsset):
        `mode_seq_id` values and the expected storage schema.
     """
 
+    REQUIRED_SCHEMA = {
+        **PLAN_STEP_KEY_SCHEMA,
+    }
+
     def __init__(
         self,
         *,
@@ -85,7 +91,11 @@ class ModeSequences(FileAsset):
 
     def get_cached_asset(self) -> pl.DataFrame:
         """Return cached mode sequences for one iteration."""
-        return pl.read_parquet(self.cache_path["sequences"])
+        return read_cached_parquet(
+            self.cache_path["sequences"],
+            table_name="mode_sequences",
+            required_schema=self.REQUIRED_SCHEMA,
+        )
 
     def get_index(self) -> pl.DataFrame:
         """Return the mode-sequence index cached with this iteration."""

--- a/mobility/trips/group_day_trips/plans/plan_ids.py
+++ b/mobility/trips/group_day_trips/plans/plan_ids.py
@@ -3,10 +3,21 @@ from __future__ import annotations
 import polars as pl
 
 from .stable_key_index import StableKeyIndex
-from .demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from .demand_subgroups import DEMAND_UNIT_COLS, DEMAND_UNIT_SCHEMA
 
 
 PLAN_KEY_COLS = DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id"]
+PLAN_KEY_SCHEMA = {
+    **DEMAND_UNIT_SCHEMA,
+    "activity_seq_id": pl.UInt32,
+    "time_seq_id": pl.UInt32,
+    "dest_seq_id": pl.UInt32,
+    "mode_seq_id": pl.UInt32,
+}
+PLAN_STEP_KEY_SCHEMA = {
+    **PLAN_KEY_SCHEMA,
+    "seq_step_index": pl.UInt8,
+}
 
 
 def add_plan_id(
@@ -20,7 +31,6 @@ def add_plan_id(
     normal FileAsset DAG instead of mutating one shared index file as a hidden
     side effect.
     """
-    frame = with_demand_subgroup_id(frame)
     return StableKeyIndex(
         key_cols=PLAN_KEY_COLS,
         index_col="plan_id",

--- a/mobility/trips/group_day_trips/plans/plan_updater.py
+++ b/mobility/trips/group_day_trips/plans/plan_updater.py
@@ -12,7 +12,7 @@ from ..transitions.transition_events import (
     build_transition_events_lazy,
 )
 from .candidate_plan_steps import CandidatePlanStepsAsset
-from .demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from .demand_subgroups import DEMAND_UNIT_COLS
 from .plan_distance import PlanDistance
 from .plan_ids import PLAN_KEY_COLS, add_plan_id
 from .plan_schedule_updater import PlanScheduleUpdater
@@ -48,14 +48,6 @@ class PlanUpdater:
         parameters: Any,
     ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.LazyFrame | None, pl.DataFrame]:
         """Advance one iteration of plan updates."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        if current_plan_steps is not None:
-            current_plan_steps = with_demand_subgroup_id(current_plan_steps)
-        if candidate_plan_steps is not None:
-            candidate_plan_steps = with_demand_subgroup_id(candidate_plan_steps)
-        demand_groups = with_demand_subgroup_id(demand_groups)
-        stay_home_plan = with_demand_subgroup_id(stay_home_plan)
-
         possible_plan_steps = self.get_possible_plan_steps(
             current_plans,
             current_plan_steps,
@@ -272,7 +264,6 @@ class PlanUpdater:
     ) -> pl.LazyFrame:
         """Score plan-step candidates under current costs and destination saturation."""
 
-        candidates = CandidatePlanStepsAsset._with_retention_columns(candidates)
         cost_by_od_and_modes = transport_costs.get_costs_by_od_and_mode(
             ["cost", "distance", "time"],
             detail_distances=False,
@@ -577,9 +568,6 @@ class PlanUpdater:
         min_transition_utility_gain: float = 0.0,
     ) -> pl.LazyFrame:
         """Build allowed from-to plan pairs under the active behavior scope."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        possible_plan_utility = with_demand_subgroup_id(possible_plan_utility)
-
         logging.debug(
             "Building PopulationGroupDayTrips allowed plan transitions: scope=%s",
             str(behavior_change_scope),
@@ -714,8 +702,6 @@ class PlanUpdater:
         transition_distance_friction: float = 0.0,
     ) -> pl.DataFrame:
         """Compute one-step transition probabilities with distance-threshold filtering and revision."""
-        allowed_transitions = with_demand_subgroup_id(allowed_transitions)
-
         logging.debug("Collecting PopulationGroupDayTrips transition probabilities")
 
         plan_cols = PLAN_KEY_COLS
@@ -806,9 +792,6 @@ class PlanUpdater:
         plan_probability_pruning_min_iteration: int = 2,
     ) -> tuple[pl.DataFrame, pl.LazyFrame]:
         """Apply transition probabilities and emit transition events."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        transition_probabilities = with_demand_subgroup_id(transition_probabilities)
-
         plan_cols = PLAN_KEY_COLS
 
         transitions = (
@@ -929,7 +912,6 @@ class PlanUpdater:
         retained_share: float,
     ) -> pl.DataFrame | None:
         """Build a raw-target to retained-target map from transition mass."""
-        transitions = with_demand_subgroup_id(transitions)
         target_cols = [
             "plan_id_trans",
             "demand_group_id",
@@ -1053,8 +1035,6 @@ class PlanUpdater:
         transitions: pl.LazyFrame,
     ) -> pl.LazyFrame:
         """Attach previous utility for the final transition target state."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        transitions = with_demand_subgroup_id(transitions)
         prev_to_lookup = (
             current_plans.lazy()
             .select(DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id", "utility"])
@@ -1084,9 +1064,6 @@ class PlanUpdater:
 
     def get_current_plan_steps(self, current_plans, possible_plan_steps):
         """Expand aggregate plans to per-step rows."""
-        current_plans = with_demand_subgroup_id(current_plans)
-        possible_plan_steps = with_demand_subgroup_id(possible_plan_steps)
-
         current_plan_steps = (
             current_plans.select(
                 [

--- a/mobility/trips/group_day_trips/transitions/transition_events.py
+++ b/mobility/trips/group_day_trips/transitions/transition_events.py
@@ -2,15 +2,15 @@ import pathlib
 
 import polars as pl
 
+from mobility.runtime.assets.cache_schema import read_cached_parquet
 from mobility.runtime.assets.file_asset import FileAsset
-from mobility.trips.group_day_trips.plans.demand_subgroups import DEMAND_UNIT_COLS, with_demand_subgroup_id
+from mobility.trips.group_day_trips.plans.demand_subgroups import DEMAND_UNIT_COLS
 
-from .transition_schema import TRANSITION_EVENT_COLUMNS
+from .transition_schema import TRANSITION_EVENT_COLUMNS, TRANSITION_EVENT_SCHEMA
 
 
 def build_transition_events_lazy(transitions: pl.LazyFrame, *, iteration: int) -> pl.LazyFrame:
     """Build the core transition-event table from raw plan-to-plan transitions."""
-    transitions = with_demand_subgroup_id(transitions)
     return transitions.with_columns(
         iteration=pl.lit(iteration).cast(pl.UInt32),
         utility_from=pl.col("utility_from_updated"),
@@ -52,8 +52,6 @@ def add_transition_plan_details(
     possible_plan_steps: pl.LazyFrame,
 ) -> pl.LazyFrame:
     """Attach full from/to plan details to transition events."""
-    transition_events = with_demand_subgroup_id(transition_events)
-    possible_plan_steps = with_demand_subgroup_id(possible_plan_steps)
     plan_keys = DEMAND_UNIT_COLS + ["activity_seq_id", "time_seq_id", "dest_seq_id", "mode_seq_id"]
 
     plan_details = (
@@ -172,7 +170,11 @@ class TransitionEventsAsset(FileAsset):
         super().__init__(inputs, cache_path)
 
     def get_cached_asset(self) -> pl.DataFrame:
-        return pl.read_parquet(self.cache_path)
+        return read_cached_parquet(
+            self.cache_path,
+            table_name="transition_events",
+            required_schema=TRANSITION_EVENT_SCHEMA,
+        )
 
     def create_and_get_asset(self) -> pathlib.Path:
         if self.transition_events is None:

--- a/mobility/trips/group_day_trips/transitions/transition_events.py
+++ b/mobility/trips/group_day_trips/transitions/transition_events.py
@@ -69,9 +69,9 @@ def add_transition_plan_details(
         .group_by(plan_keys)
         .agg(
             trip_count=pl.len().cast(pl.Float64),
-            activity_time=pl.col("duration_per_pers").fill_null(0.0).sum(),
-            travel_time=pl.col("time").fill_null(0.0).sum(),
-            distance=pl.col("distance").fill_null(0.0).sum(),
+            activity_time=pl.col("duration_per_pers").fill_null(0.0).sum().cast(pl.Float64),
+            travel_time=pl.col("time").fill_null(0.0).sum().cast(pl.Float64),
+            distance=pl.col("distance").fill_null(0.0).sum().cast(pl.Float64),
             steps=pl.col("step_desc").sort_by("seq_step_index").str.join("<br>"),
         )
     )

--- a/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
+++ b/tests/back/unit/domain/group_day_trips/test_003_behavior_change_scopes.py
@@ -15,6 +15,7 @@ from mobility.trips.group_day_trips.plans.plan_updater import PlanUpdater
 
 def _make_possible_plan_steps(rows: dict[str, list]) -> pl.DataFrame:
     rows = {
+        "demand_subgroup_id": rows.get("demand_subgroup_id", [0] * len(rows["demand_group_id"])),
         "country": rows.get("country", ["fr"] * len(rows["demand_group_id"])),
         "time_seq_id": rows.get("time_seq_id", [0] * len(rows["demand_group_id"])),
         "first_seen_iteration": rows.get("first_seen_iteration", [None] * len(rows["demand_group_id"])),
@@ -26,6 +27,7 @@ def _make_possible_plan_steps(rows: dict[str, list]) -> pl.DataFrame:
         rows,
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "country": pl.Utf8,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -59,6 +61,7 @@ def _make_possible_plan_steps(rows: dict[str, list]) -> pl.DataFrame:
 
 def _make_current_plans(rows: dict[str, list]) -> pl.DataFrame:
     rows = {
+        "demand_subgroup_id": rows.get("demand_subgroup_id", [0] * len(rows["demand_group_id"])),
         "time_seq_id": rows.get("time_seq_id", [0] * len(rows["demand_group_id"])),
         **rows,
     }
@@ -66,6 +69,7 @@ def _make_current_plans(rows: dict[str, list]) -> pl.DataFrame:
         rows,
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -78,6 +82,7 @@ def _make_current_plans(rows: dict[str, list]) -> pl.DataFrame:
 
 def _make_possible_plan_utility(rows: dict[str, list]) -> pl.LazyFrame:
     rows = {
+        "demand_subgroup_id": rows.get("demand_subgroup_id", [0] * len(rows["demand_group_id"])),
         "time_seq_id": rows.get("time_seq_id", [0] * len(rows["demand_group_id"])),
         **rows,
     }
@@ -85,6 +90,7 @@ def _make_possible_plan_utility(rows: dict[str, list]) -> pl.LazyFrame:
         rows,
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -120,6 +126,7 @@ def test_get_transition_probabilities_blocks_stay_home_in_mode_replanning(tmp_pa
     current_plans = _make_current_plans(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [0, 10],
             "dest_seq_id": [0, 100],
             "mode_seq_id": [0, 1000],
@@ -193,6 +200,7 @@ def test_get_transition_probabilities_no_transitions_keeps_current_plan(tmp_path
     current_plans = _make_current_plans(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [0, 10],
             "time_seq_id": [0, 20],
             "dest_seq_id": [0, 100],
@@ -290,6 +298,7 @@ def test_add_plan_id_keeps_stay_home_and_non_stay_home_states_distinct():
     plans = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [0, 10],
             "time_seq_id": [0, 0],
             "dest_seq_id": [0, 100],
@@ -297,6 +306,7 @@ def test_add_plan_id_keeps_stay_home_and_non_stay_home_states_distinct():
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -363,6 +373,7 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [0],
                 "dest_seq_id": [100],
@@ -376,6 +387,7 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -393,6 +405,7 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [0],
                 "dest_seq_id": [100],
@@ -403,6 +416,7 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -438,11 +452,13 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
     demand_groups = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "country": ["fr"],
             "csp": ["x"],
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "country": pl.Utf8,
             "csp": pl.Utf8,
         },
@@ -456,6 +472,7 @@ def test_candidate_memory_ignores_persisted_stay_home_rows():
         current_plans=pl.DataFrame(
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -513,6 +530,7 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
         pl.DataFrame(
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -530,6 +548,7 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
         pl.DataFrame(
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -555,11 +574,13 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
     demand_groups = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "country": ["fr"],
             "csp": ["x"],
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "country": pl.Utf8,
             "csp": pl.Utf8,
         },
@@ -573,6 +594,7 @@ def test_candidate_memory_prunes_old_inactive_plans_after_warmup():
         current_plans=pl.DataFrame(
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -631,6 +653,7 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [11],
                 "time_seq_id": [0],
                 "dest_seq_id": [101],
@@ -644,6 +667,7 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -661,6 +685,7 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [11],
                 "time_seq_id": [0],
                 "dest_seq_id": [101],
@@ -671,6 +696,7 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -704,8 +730,13 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
         },
     )
     demand_groups = pl.DataFrame(
-        {"demand_group_id": [1], "country": ["fr"], "csp": ["x"]},
-        schema={"demand_group_id": pl.UInt32, "country": pl.Utf8, "csp": pl.Utf8},
+        {"demand_group_id": [1], "demand_subgroup_id": [0], "country": ["fr"], "csp": ["x"]},
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "country": pl.Utf8,
+            "csp": pl.Utf8,
+        },
     )
 
     result = CandidatePlanStepsAsset.build_candidate_memory(
@@ -716,6 +747,7 @@ def test_candidate_memory_keeps_regenerated_inactive_plans_after_warmup():
         current_plans=pl.DataFrame(
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -1223,6 +1255,7 @@ def test_apply_transitions_prunes_low_probability_targets_consistently(tmp_path)
     plan_keys = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 1, 1],
+            "demand_subgroup_id": [0, 0, 0, 0],
             "activity_seq_id": [10, 11, 12, 13],
             "time_seq_id": [100, 101, 102, 103],
             "dest_seq_id": [1000, 1001, 1002, 1003],
@@ -1230,6 +1263,7 @@ def test_apply_transitions_prunes_low_probability_targets_consistently(tmp_path)
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -1254,6 +1288,7 @@ def test_apply_transitions_prunes_low_probability_targets_consistently(tmp_path)
         [
             pl.col("plan_id").alias("plan_id_trans"),
             pl.lit(from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(from_state["demand_subgroup_id"], dtype=pl.UInt32).alias("demand_subgroup_id"),
             pl.lit(from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
             pl.lit(from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
             pl.lit(from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),
@@ -1301,6 +1336,7 @@ def test_apply_transitions_probability_pruning_does_not_merge_mobile_targets_int
     plan_keys = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 1, 1],
+            "demand_subgroup_id": [0, 0, 0, 0],
             "activity_seq_id": [0, 10, 11, 12],
             "time_seq_id": [0, 100, 101, 102],
             "dest_seq_id": [0, 1000, 1001, 1002],
@@ -1308,6 +1344,7 @@ def test_apply_transitions_probability_pruning_does_not_merge_mobile_targets_int
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -1332,6 +1369,7 @@ def test_apply_transitions_probability_pruning_does_not_merge_mobile_targets_int
         [
             pl.col("plan_id").alias("plan_id_trans"),
             pl.lit(mobile_from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(mobile_from_state["demand_subgroup_id"], dtype=pl.UInt32).alias("demand_subgroup_id"),
             pl.lit(mobile_from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
             pl.lit(mobile_from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
             pl.lit(mobile_from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),
@@ -1374,6 +1412,7 @@ def test_apply_transitions_probability_pruning_keeps_default_behavior(tmp_path):
     plan_keys = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [10, 11],
             "time_seq_id": [100, 101],
             "dest_seq_id": [1000, 1001],
@@ -1381,6 +1420,7 @@ def test_apply_transitions_probability_pruning_keeps_default_behavior(tmp_path):
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -1401,6 +1441,7 @@ def test_apply_transitions_probability_pruning_keeps_default_behavior(tmp_path):
         [
             pl.col("plan_id").alias("plan_id_trans"),
             pl.lit(from_state["demand_group_id"], dtype=pl.UInt32).alias("demand_group_id"),
+            pl.lit(from_state["demand_subgroup_id"], dtype=pl.UInt32).alias("demand_subgroup_id"),
             pl.lit(from_state["activity_seq_id"], dtype=pl.UInt32).alias("activity_seq_id"),
             pl.lit(from_state["time_seq_id"], dtype=pl.UInt32).alias("time_seq_id"),
             pl.lit(from_state["dest_seq_id"], dtype=pl.UInt32).alias("dest_seq_id"),

--- a/tests/back/unit/domain/group_day_trips/test_007_plan_schedule_updater.py
+++ b/tests/back/unit/domain/group_day_trips/test_007_plan_schedule_updater.py
@@ -9,10 +9,18 @@ from mobility.trips.group_day_trips.plans.plan_schedule_updater import PlanSched
 
 
 def _make_plan_steps(rows: dict[str, list]) -> pl.LazyFrame:
+    rows = {
+        **rows,
+        "demand_subgroup_id": rows.get(
+            "demand_subgroup_id",
+            [0] * len(rows["demand_group_id"]),
+        ),
+    }
     return pl.DataFrame(
         rows,
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,

--- a/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
+++ b/tests/back/unit/domain/group_day_trips/test_009_diagnostics_and_metrics.py
@@ -2951,7 +2951,7 @@ def test_calibration_plan_steps_keep_stay_home_as_a_distribution_state():
         mode=pl.col("mode").cast(pl.Enum(["car", "stay_home"])),
     )
 
-    calibration_steps = to_calibration_plan_steps(raw_plan_steps).collect()
+    calibration_steps = to_calibration_plan_steps(raw_plan_steps.lazy()).collect()
 
     assert calibration_steps.sort("mode").to_dict(as_series=False) == {
         "activity": ["work", "stay_home"],
@@ -3006,14 +3006,14 @@ def test_model_loss_summary_history_and_validation():
         ).lazy()
     )
     loss = ModelLoss(
-        expected_plan_steps=_FrameAsset(expected, lazy=False),
+        expected_plan_steps=_FrameAsset(expected),
         observed_plan_steps=_FrameAsset(observed),
         history=history_store,
     )
 
     summary = loss.summary()
     history = loss.history()
-    history_row = loss.history_row(iteration=2, plan_steps=observed)
+    history_row = loss.history_row(iteration=2, plan_steps=observed.lazy())
 
     assert summary.height == 1
     assert summary["total_loss"].unique().item() > 0.0
@@ -3041,7 +3041,7 @@ def test_model_loss_summary_history_and_validation():
                     "time": [2.0],
                     "n_persons": [1.0],
                 }
-            )
+            ).lazy()
         )
 
 
@@ -3072,11 +3072,11 @@ def test_model_loss_is_based_on_distribution_shares_not_global_scale():
     scaled_expected = expected.with_columns(n_persons=pl.col("n_persons") * 10.0)
     scaled_observed = observed.with_columns(n_persons=pl.col("n_persons") * 10.0)
 
-    loss = ModelLoss(expected_plan_steps=_FrameAsset(expected, lazy=False))
-    scaled_loss = ModelLoss(expected_plan_steps=_FrameAsset(scaled_expected, lazy=False))
+    loss = ModelLoss(expected_plan_steps=_FrameAsset(expected))
+    scaled_loss = ModelLoss(expected_plan_steps=_FrameAsset(scaled_expected))
 
-    assert loss.total_loss(plan_steps=observed) == pytest.approx(
-        scaled_loss.total_loss(plan_steps=scaled_observed)
+    assert loss.total_loss(plan_steps=observed.lazy()) == pytest.approx(
+        scaled_loss.total_loss(plan_steps=scaled_observed.lazy())
     )
 
 
@@ -3105,7 +3105,7 @@ def test_model_loss_ignores_stay_home_when_comparing_trip_distributions():
         }
     )
 
-    comparison = ModelLoss(expected_plan_steps=_FrameAsset(expected, lazy=False)).comparison(plan_steps=observed)
+    comparison = ModelLoss(expected_plan_steps=_FrameAsset(expected)).comparison(plan_steps=observed.lazy())
 
     assert comparison["activity"].to_list() == ["work"]
     assert comparison["observed_total"].to_list() == pytest.approx([2.0])
@@ -3149,14 +3149,14 @@ def test_model_trip_count_loss_uses_cleaned_survey_steps_and_immobility():
     )
 
     distribution = build_trip_count_distribution(
-        expected_mobile_steps,
+        expected_mobile_steps.lazy(),
         immobility_probabilities=pl.DataFrame({"country": ["fr"], "csp": ["A"], "p_immobility": [0.2]}),
     )
     loss = ModelTripCountLoss(
-        expected_plan_steps=_FrameAsset(expected_mobile_steps),
+        expected_plan_steps=expected_mobile_steps.lazy(),
         surveys=[survey],
         is_weekday=True,
-        observed_plan_steps=_FrameAsset(observed_steps),
+        observed_plan_steps=observed_steps.lazy(),
     )
 
     expected_by_bin = dict(zip(distribution["trip_count_bin"], distribution["n_persons"]))
@@ -3183,7 +3183,7 @@ def test_model_entropy_and_trip_pattern_distribution_cover_mobile_and_stay_home_
             "n_persons": [2.0, 2.0, 1.0],
         }
     )
-    distribution = build_trip_pattern_distribution(raw_plan_steps)
+    distribution = build_trip_pattern_distribution(raw_plan_steps.lazy())
     expected_distribution = pl.DataFrame(
         {
             "trip_pattern": distribution["trip_pattern"].to_list(),
@@ -3223,9 +3223,9 @@ def test_model_entropy_and_trip_pattern_distribution_cover_mobile_and_stay_home_
     )
 
     comparison = entropy.comparison()
-    summary = entropy.summary(plan_steps=raw_plan_steps)
+    summary = entropy.summary(plan_steps=raw_plan_steps.lazy())
     history = entropy.history()
-    history_row = entropy.history_row(iteration=2, plan_steps=raw_plan_steps)
+    history_row = entropy.history_row(iteration=2, plan_steps=raw_plan_steps.lazy())
 
     assert set(distribution["trip_pattern"].to_list()) == {"stay_home", distribution["trip_pattern"][0]}
     assert distribution["probability"].sum() == pytest.approx(1.0)
@@ -3313,10 +3313,16 @@ def test_iteration_metrics_builder_rebuilds_history_and_run_diagnostics_exposes_
             observed_calibration_plan_steps=object(),
             expected_entropy_plan_steps=object(),
             observed_entropy_plan_steps=object(),
-            population_weighted_plan_steps=object(),
+            population_weighted_plan_steps=pl.DataFrame(
+                {"activity_seq_id": [0], "n_persons": [1.0]},
+                schema={"activity_seq_id": pl.UInt32, "n_persons": pl.Float64},
+            ).lazy(),
             surveys=[],
             is_weekday=True,
-            plan_steps=object(),
+            plan_steps=pl.DataFrame(
+                {"activity_seq_id": [0], "n_persons": [1.0]},
+                schema={"activity_seq_id": pl.UInt32, "n_persons": pl.Float64},
+            ).lazy(),
             iteration_metrics_store=history_store,
         )
     )

--- a/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
+++ b/tests/back/unit/domain/group_day_trips/test_010_group_day_trips_results_api.py
@@ -958,7 +958,28 @@ def test_scoped_run_table_does_not_depend_on_full_run_asset(tmp_path):
 def test_run_iteration_table_scans_cached_plan_steps_without_state_load(tmp_path):
     """Check all-iteration results do not load the full saved iteration state."""
     plan_steps_path = tmp_path / "current_plan_steps.parquet"
-    pl.DataFrame({"activity_seq_id": [1], "n_persons": [2.0]}).write_parquet(plan_steps_path)
+    pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "activity_seq_id": [1],
+            "time_seq_id": [1],
+            "dest_seq_id": [1],
+            "mode_seq_id": [1],
+            "seq_step_index": [1],
+            "n_persons": [2.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt8,
+            "n_persons": pl.Float64,
+        },
+    ).write_parquet(plan_steps_path)
 
     class CachedStateAsset:
         cache_path = {"current_plan_steps": plan_steps_path}

--- a/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
+++ b/tests/back/unit/domain/group_day_trips/test_011_plan_updater_country_value_coefficients.py
@@ -14,6 +14,7 @@ def test_plan_updater_prepares_destination_country_value_coefficient():
     candidates = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "country": ["fr", "fr"],
             "activity_seq_id": [10, 10],
             "time_seq_id": [1, 1],
@@ -104,6 +105,7 @@ def test_plan_updater_integrates_shadow_price_in_activity_value_when_enabled():
     candidates = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "country": ["fr"],
             "activity_seq_id": [10],
             "time_seq_id": [1],
@@ -240,6 +242,7 @@ def test_possible_plan_utility_subtracts_travel_time_from_home_night(tmp_path):
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "country": ["fr"],
                 "activity_seq_id": [10],
                 "time_seq_id": [100],
@@ -264,6 +267,7 @@ def test_possible_plan_utility_subtracts_travel_time_from_home_night(tmp_path):
     stay_home_plan = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "activity_seq_id": [0],
             "time_seq_id": [0],
             "mode_seq_id": [0],
@@ -293,6 +297,7 @@ def test_add_stay_home_plan_steps_preserves_candidate_retention_columns(tmp_path
         pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "country": ["fr"],
                 "csp": ["worker"],
                 "activity_seq_id": [10],
@@ -328,6 +333,7 @@ def test_add_stay_home_plan_steps_preserves_candidate_retention_columns(tmp_path
     stay_home_plan = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "country": ["fr"],
             "csp": ["worker"],
             "mean_home_night_per_pers": [10.0],

--- a/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
+++ b/tests/back/unit/domain/group_day_trips/test_012_destination_sequences.py
@@ -9,6 +9,7 @@ from mobility.trips.group_day_trips import (
     GroupDayTripsPlanUpdateParameters,
 )
 from mobility.trips.group_day_trips.plans.destination_sequences import DestinationSequences
+from mobility.trips.group_day_trips.plans.demand_subgroups import demand_unit_hash
 
 
 def _make_local_tmp_path(tmp_path: Path, name: str) -> Path:
@@ -32,6 +33,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
         current_plans=pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [1],
                 "dest_seq_id": [100],
@@ -39,6 +41,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -49,6 +52,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
             pl.DataFrame(
                 {
                     "demand_group_id": [1],
+                    "demand_subgroup_id": [0],
                     "activity_seq_id": [10],
                     "time_seq_id": [0],
                     "seq_step_index": [0],
@@ -56,6 +60,7 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
                 },
                 schema={
                     "demand_group_id": pl.UInt32,
+                    "demand_subgroup_id": pl.UInt32,
                     "activity_seq_id": pl.UInt32,
                     "time_seq_id": pl.UInt32,
                     "seq_step_index": pl.UInt32,
@@ -78,17 +83,18 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
         activities,
         transport_zones,
         destination_saturation,
-        chains,
+        activity_sequences,
         demand_groups,
         costs,
         parameters,
         seed,
     ):
-        seen["chains"] = chains
+        seen["activity_sequences"] = activity_sequences
         return pl.DataFrame(
-            {
-                "demand_group_id": [1],
-                "activity_seq_id": [10],
+                {
+                    "demand_group_id": [1],
+                    "demand_subgroup_id": [0],
+                    "activity_seq_id": [10],
                 "time_seq_id": [0],
                 "dest_seq_id": [100],
                 "seq_step_index": [0],
@@ -99,9 +105,10 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
                 "next_departure_time": [17.0],
                 "iteration": [3],
             },
-            schema={
-                "demand_group_id": pl.UInt32,
-                "activity_seq_id": pl.UInt32,
+                schema={
+                    "demand_group_id": pl.UInt32,
+                    "demand_subgroup_id": pl.UInt32,
+                    "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
                 "seq_step_index": pl.UInt32,
@@ -117,10 +124,10 @@ def test_sample_active_destination_sequences_keeps_only_active_activity_sequence
     destination_sequences.run = fake_run
     destination_sequences._sample_active_destination_sequences()
 
-    assert seen["chains"].select("activity_seq_id").to_series().to_list() == [10]
+    assert seen["activity_sequences"].select("activity_seq_id").to_series().to_list() == [10]
 
 
-def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_path):
+def test_refresh_active_mode_alternatives_appends_active_destination_sequences(tmp_path):
     destination_sequences = DestinationSequences(
         is_weekday=True,
         iteration=5,
@@ -128,6 +135,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
         current_plans=pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [20],
                 "dest_seq_id": [30],
@@ -135,6 +143,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -144,6 +153,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
         current_plan_steps=pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [20],
                 "dest_seq_id": [30],
@@ -156,6 +166,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -183,6 +194,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
     sampled = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "activity_seq_id": [11],
             "time_seq_id": [21],
             "dest_seq_id": [31],
@@ -197,6 +209,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
             "dest_seq_id": pl.UInt32,
@@ -211,7 +224,7 @@ def test_refresh_active_mode_alternatives_appends_active_destination_chains(tmp_
         },
     )
 
-    result = destination_sequences._with_refreshed_active_destination_sequences(sampled)
+    result = destination_sequences._with_current_active_destination_sequences(sampled)
 
     assert result.select("dest_seq_id").sort("dest_seq_id").to_series().to_list() == [30, 31]
     assert result.filter(pl.col("dest_seq_id") == 30).select("iteration").item() == 5
@@ -282,9 +295,9 @@ def test_refresh_active_mode_alternatives_keeps_distinct_subgroup_steps(tmp_path
         seed=123,
         resolved_activity_parameters={},
     )
-    sampled = pl.DataFrame(schema={column: dtype for column, dtype in destination_sequences._empty_destination_sequences().schema.items()})
+    sampled = pl.DataFrame(schema=DestinationSequences.OUTPUT_SCHEMA)
 
-    result = destination_sequences._with_refreshed_active_destination_sequences(sampled)
+    result = destination_sequences._with_current_active_destination_sequences(sampled)
 
     assert (
         result
@@ -331,7 +344,7 @@ def test_refresh_active_mode_alternatives_default_keeps_sampled_destinations_onl
         }
     )
 
-    result = destination_sequences._with_refreshed_active_destination_sequences(sampled)
+    result = destination_sequences._with_current_active_destination_sequences(sampled)
 
     assert result is sampled
 
@@ -437,11 +450,11 @@ def test_destination_probability_inputs_use_shadow_attraction_when_enabled(tmp_p
     assert probabilities["p_to"].to_list() == [2.0 / 3.0, 1.0 / 3.0]
 
 
-def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candidates(tmp_path):
+def test_spatialize_sequence_step_uses_sequence_cost_to_reweight_non_anchor_candidates(tmp_path):
     destination_sequences = DestinationSequences(
         is_weekday=True,
         iteration=1,
-        base_folder=_make_local_tmp_path(tmp_path, "non_anchor_chain_cost_weighting"),
+        base_folder=_make_local_tmp_path(tmp_path, "non_anchor_sequence_cost_weighting"),
         activities=[],
         transport_zones=None,
         destination_saturation=pl.DataFrame(),
@@ -460,15 +473,17 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
 
     candidate_noise = (
         pl.DataFrame(
-            {
-                "demand_group_id": [1] * len(candidate_destinations),
-                "activity_seq_id": [10] * len(candidate_destinations),
+                {
+                    "demand_group_id": [1] * len(candidate_destinations),
+                    "demand_subgroup_id": [0] * len(candidate_destinations),
+                    "activity_seq_id": [10] * len(candidate_destinations),
                 "time_seq_id": [1] * len(candidate_destinations),
-                "dest_draw_id": [1] * len(candidate_destinations),
+                    "dest_draw_id": [1] * len(candidate_destinations),
                 "to": candidate_destinations,
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_draw_id": pl.UInt32,
@@ -477,9 +492,8 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
         )
         .with_columns(
             noise=(
-                pl.struct(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "to"])
-                .hash(seed=seed)
-                .cast(pl.Float64)
+                    demand_unit_hash(["activity_seq_id", "time_seq_id", "dest_draw_id", "to"], seed=seed)
+                    .cast(pl.Float64)
                 .truediv(pl.lit(18446744073709551616.0))
                 .log()
                 .neg()
@@ -490,9 +504,10 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
     lowest_noise_candidate = int(candidate_noise["to"][0])
     highest_noise_candidate = int(candidate_noise["to"][-1])
 
-    chains_step = pl.DataFrame(
+    sequence_step = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "home_zone_id": [1],
             "activity_seq_id": [10],
             "time_seq_id": [1],
@@ -509,6 +524,7 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "home_zone_id": pl.UInt16,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -554,26 +570,32 @@ def test_spatialize_trip_chain_step_uses_chain_cost_to_reweight_non_anchor_candi
         },
     )
 
-    result_without_chain_penalty = destination_sequences._spatialize_trip_chain_step(
+    result_without_sequence_penalty = destination_sequences._spatialize_sequence_step(
         seq_step_index=1,
-        chains_step=chains_step,
+        sequence_step=sequence_step,
         destination_probability=destination_probability,
         costs=costs,
         alpha=0.0,
         seed=seed,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
+        non_anchor_count=1,
+        anchor_count=0,
     )
-    result_with_chain_penalty = destination_sequences._spatialize_trip_chain_step(
+    result_with_sequence_penalty = destination_sequences._spatialize_sequence_step(
         seq_step_index=1,
-        chains_step=chains_step,
+        sequence_step=sequence_step,
         destination_probability=destination_probability,
         costs=costs,
         alpha=1.0,
         seed=seed,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
+        non_anchor_count=1,
+        anchor_count=0,
     )
 
-    assert result_without_chain_penalty["to"].to_list() == [lowest_noise_candidate]
-    assert result_with_chain_penalty["to"].to_list() == [highest_noise_candidate]
-    assert result_with_chain_penalty["to"].to_list() != result_without_chain_penalty["to"].to_list()
+    assert result_without_sequence_penalty["to"].to_list() == [lowest_noise_candidate]
+    assert result_with_sequence_penalty["to"].to_list() == [highest_noise_candidate]
+    assert result_with_sequence_penalty["to"].to_list() != result_without_sequence_penalty["to"].to_list()
 
 
 def test_spatialize_anchor_activities_samples_from_current_anchor_location(tmp_path):
@@ -594,9 +616,10 @@ def test_spatialize_anchor_activities_samples_from_current_anchor_location(tmp_p
         current_plans=pl.DataFrame(),
     )
 
-    chains = pl.DataFrame(
+    sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 1],
+            "demand_subgroup_id": [0, 0, 0],
             "home_zone_id": [10, 10, 10],
             "activity_seq_id": [20, 20, 20],
             "time_seq_id": [1, 1, 1],
@@ -610,6 +633,7 @@ def test_spatialize_anchor_activities_samples_from_current_anchor_location(tmp_p
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "home_zone_id": pl.UInt16,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -650,11 +674,11 @@ def test_spatialize_anchor_activities_samples_from_current_anchor_location(tmp_p
     )
 
     result = destination_sequences._spatialize_anchor_activities(
-        chains,
+        sequences,
         destination_probability,
-        costs,
         alpha=0.0,
         seed=123,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
     )
 
     sampled_anchors = (
@@ -671,11 +695,11 @@ def test_spatialize_anchor_activities_samples_from_current_anchor_location(tmp_p
     ]
 
 
-def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp_path):
+def test_spatialize_anchor_activities_uses_sequence_cost_to_reweight_candidates(tmp_path):
     destination_sequences = DestinationSequences(
         is_weekday=True,
         iteration=1,
-        base_folder=_make_local_tmp_path(tmp_path, "anchor_chain_cost_weighting"),
+        base_folder=_make_local_tmp_path(tmp_path, "anchor_sequence_cost_weighting"),
         activities=[],
         transport_zones=None,
         destination_saturation=pl.DataFrame(),
@@ -695,15 +719,17 @@ def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp
     base_probability = 1.0 / len(candidate_destinations)
     candidate_noise = (
         pl.DataFrame(
-            {
-                "demand_group_id": [1] * len(candidate_destinations),
-                "activity_seq_id": [10] * len(candidate_destinations),
+                {
+                    "demand_group_id": [1] * len(candidate_destinations),
+                    "demand_subgroup_id": [0] * len(candidate_destinations),
+                    "activity_seq_id": [10] * len(candidate_destinations),
                 "time_seq_id": [1] * len(candidate_destinations),
-                "dest_draw_id": [1] * len(candidate_destinations),
+                "dest_draw_id": [0] * len(candidate_destinations),
                 "to": candidate_destinations,
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_draw_id": pl.UInt32,
@@ -712,9 +738,8 @@ def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp
         )
         .with_columns(
             noise=(
-                pl.struct(["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id", "to"])
-                .hash(seed=seed)
-                .cast(pl.Float64)
+                    demand_unit_hash(["activity_seq_id", "time_seq_id", "dest_draw_id", "to"], seed=seed)
+                    .cast(pl.Float64)
                 .truediv(pl.lit(18446744073709551616.0))
                 .log()
                 .neg()
@@ -725,9 +750,10 @@ def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp
     lowest_noise_candidate = int(candidate_noise["to"][0])
     highest_noise_candidate = int(candidate_noise["to"][-1])
 
-    chains = pl.DataFrame(
+    sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "home_zone_id": [home_zone, home_zone],
             "activity_seq_id": [10, 10],
             "time_seq_id": [1, 1],
@@ -741,6 +767,7 @@ def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "home_zone_id": pl.UInt16,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -783,30 +810,30 @@ def test_spatialize_anchor_activities_uses_chain_cost_to_reweight_candidates(tmp
         },
     )
 
-    result_without_chain_penalty = destination_sequences._spatialize_anchor_activities(
-        chains,
+    result_without_sequence_penalty = destination_sequences._spatialize_anchor_activities(
+        sequences,
         destination_probability,
-        costs,
         alpha=0.0,
         seed=seed,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
     )
-    result_with_chain_penalty = destination_sequences._spatialize_anchor_activities(
-        chains,
+    result_with_sequence_penalty = destination_sequences._spatialize_anchor_activities(
+        sequences,
         destination_probability,
-        costs,
         alpha=1.0,
         seed=seed,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
     )
 
-    assert result_without_chain_penalty.filter(pl.col("activity") == "work")["anchor_to"].to_list() == [
+    assert result_without_sequence_penalty.filter(pl.col("activity") == "work")["anchor_to"].to_list() == [
         lowest_noise_candidate
     ]
-    assert result_with_chain_penalty.filter(pl.col("activity") == "work")["anchor_to"].to_list() == [
+    assert result_with_sequence_penalty.filter(pl.col("activity") == "work")["anchor_to"].to_list() == [
         highest_noise_candidate
     ]
 
 
-def test_spatialize_trip_chain_step_drops_anchor_without_leg_cost(tmp_path):
+def test_spatialize_sequence_step_drops_anchor_without_leg_cost(tmp_path):
     destination_sequences = DestinationSequences(
         is_weekday=True,
         iteration=1,
@@ -822,9 +849,10 @@ def test_spatialize_trip_chain_step_drops_anchor_without_leg_cost(tmp_path):
         current_plans=pl.DataFrame(),
     )
 
-    chains_step = pl.DataFrame(
+    sequence_step = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "home_zone_id": [1],
             "activity_seq_id": [10],
             "time_seq_id": [1],
@@ -841,6 +869,7 @@ def test_spatialize_trip_chain_step_drops_anchor_without_leg_cost(tmp_path):
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "home_zone_id": pl.UInt16,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -877,13 +906,16 @@ def test_spatialize_trip_chain_step_drops_anchor_without_leg_cost(tmp_path):
         },
     )
 
-    result = destination_sequences._spatialize_trip_chain_step(
+    result = destination_sequences._spatialize_sequence_step(
         seq_step_index=1,
-        chains_step=chains_step,
+        sequence_step=sequence_step,
         destination_probability=destination_probability,
         costs=costs,
         alpha=0.0,
         seed=123,
+        cost_views=DestinationSequences._spatialization_cost_views(costs),
+        non_anchor_count=0,
+        anchor_count=1,
     )
 
     assert result.is_empty()
@@ -893,6 +925,7 @@ def test_drop_incomplete_destination_draws_removes_partial_draws():
     activity_sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 2, 2],
+            "demand_subgroup_id": [0, 0, 0, 0],
             "home_zone_id": [100, 100, 200, 200],
             "activity_seq_id": [10, 10, 20, 20],
             "time_seq_id": [1, 1, 2, 2],
@@ -909,6 +942,7 @@ def test_drop_incomplete_destination_draws_removes_partial_draws():
         },
         schema={
             "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
             "home_zone_id": pl.UInt16,
             "activity_seq_id": pl.UInt32,
             "time_seq_id": pl.UInt32,
@@ -949,6 +983,7 @@ def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path)
         current_plans=pl.DataFrame(
             {
                 "demand_group_id": [1],
+                "demand_subgroup_id": [0],
                 "activity_seq_id": [10],
                 "time_seq_id": [1],
                 "dest_seq_id": [100],
@@ -956,6 +991,7 @@ def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path)
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,
@@ -965,6 +1001,7 @@ def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path)
         current_plan_steps=pl.DataFrame(
             {
                 "demand_group_id": [1, 1],
+                "demand_subgroup_id": [0, 0],
                 "activity_seq_id": [10, 10],
                 "time_seq_id": [1, 1],
                 "dest_seq_id": [100, 100],
@@ -978,6 +1015,7 @@ def test_reuse_current_destination_sequences_reuses_current_plan_steps(tmp_path)
             },
             schema={
                 "demand_group_id": pl.UInt32,
+                "demand_subgroup_id": pl.UInt32,
                 "activity_seq_id": pl.UInt32,
                 "time_seq_id": pl.UInt32,
                 "dest_seq_id": pl.UInt32,

--- a/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
+++ b/tests/back/unit/domain/group_day_trips/test_013_debug_logs.py
@@ -23,13 +23,13 @@ def test_trace_diagnostics_do_not_collect_inputs_when_trace_is_disabled(caplog):
         )
         log_step_dropout_diagnostics(
             seq_step_index=1,
-            chains_step=pl.DataFrame(),
+            sequence_step=pl.DataFrame(),
             costs=pl.DataFrame(),
             non_anchor_candidates=pl.DataFrame().lazy(),
             candidates_with_origin_costs=pl.DataFrame().lazy(),
             candidates_with_costs=pl.DataFrame().lazy(),
             sampled_non_anchor_steps=pl.DataFrame().lazy(),
-            chain_key_cols=[],
+            sequence_key_cols=[],
             transport_zones=None,
         )
         log_location_chain_diagnostics(
@@ -40,10 +40,11 @@ def test_trace_diagnostics_do_not_collect_inputs_when_trace_is_disabled(caplog):
         )
 
 
-def test_log_destination_sequence_diagnostics_reports_one_step_chains(caplog):
+def test_log_destination_sequence_diagnostics_reports_one_step_sequences(caplog):
     source_activity_sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 2],
+            "demand_subgroup_id": [0, 0, 0],
             "activity_seq_id": [10, 10, 20],
             "time_seq_id": [100, 100, 200],
             "seq_step_index": [0, 1, 0],
@@ -53,6 +54,7 @@ def test_log_destination_sequence_diagnostics_reports_one_step_chains(caplog):
     destination_sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 2],
+            "demand_subgroup_id": [0, 0, 0],
             "activity_seq_id": [10, 10, 20],
             "time_seq_id": [100, 100, 200],
             "dest_seq_id": [1000, 1000, 2000],
@@ -70,16 +72,17 @@ def test_log_destination_sequence_diagnostics_reports_one_step_chains(caplog):
         )
 
     assert "Destination sequence step counts at iteration 7" in caplog.text
-    assert "Destination sequences contain 1 one-step chains at iteration 7" in caplog.text
-    assert "Activity-sequence source rows behind one-step destination chains at iteration 7" in caplog.text
+    assert "Destination sequences contain 1 one-step sequences at iteration 7" in caplog.text
+    assert "Activity-sequence source rows behind one-step destination sequences at iteration 7" in caplog.text
     assert "'dest_seq_id': 2000" in caplog.text
     assert "'activity': 'home'" in caplog.text
 
 
-def test_log_destination_sequence_diagnostics_skips_warning_for_complete_chains(caplog):
+def test_log_destination_sequence_diagnostics_skips_warning_for_complete_sequences(caplog):
     destination_sequences = pl.DataFrame(
         {
             "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [10, 10],
             "time_seq_id": [100, 100],
             "dest_seq_id": [1000, 1000],
@@ -101,8 +104,8 @@ def test_log_destination_sequence_diagnostics_skips_warning_for_complete_chains(
 
 
 def test_log_step_dropout_diagnostics_reports_each_dropout_stage(caplog):
-    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
-    chains_step = pl.DataFrame(
+    sequence_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    sequence_step = pl.DataFrame(
         {
             "demand_group_id": [1, 2, 3, 4, 5],
             "activity_seq_id": [10, 20, 30, 40, 50],
@@ -153,13 +156,13 @@ def test_log_step_dropout_diagnostics_reports_each_dropout_stage(caplog):
     with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=2,
-            chains_step=chains_step,
+            sequence_step=sequence_step,
             costs=costs,
             non_anchor_candidates=non_anchor_candidates.lazy(),
             candidates_with_origin_costs=candidates_with_origin_costs.lazy(),
             candidates_with_costs=candidates_with_costs.lazy(),
             sampled_non_anchor_steps=sampled_non_anchor_steps.lazy(),
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             transport_zones=transport_zones,
         )
 
@@ -173,7 +176,7 @@ def test_log_step_dropout_diagnostics_reports_each_dropout_stage(caplog):
 
 
 def test_log_step_dropout_diagnostics_skips_when_no_non_anchor_or_dropout(caplog):
-    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    sequence_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
     anchor_only = pl.DataFrame(
         {
             "demand_group_id": [1],
@@ -206,24 +209,24 @@ def test_log_step_dropout_diagnostics_skips_when_no_non_anchor_or_dropout(caplog
     with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=1,
-            chains_step=anchor_only,
+            sequence_step=anchor_only,
             costs=pl.DataFrame(),
             non_anchor_candidates=pl.DataFrame().lazy(),
             candidates_with_origin_costs=pl.DataFrame().lazy(),
             candidates_with_costs=pl.DataFrame().lazy(),
             sampled_non_anchor_steps=pl.DataFrame().lazy(),
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             transport_zones=None,
         )
         log_step_dropout_diagnostics(
             seq_step_index=1,
-            chains_step=surviving_candidate,
+            sequence_step=surviving_candidate,
             costs=pl.DataFrame(),
             non_anchor_candidates=surviving_candidate.lazy(),
             candidates_with_origin_costs=surviving_candidate.lazy(),
             candidates_with_costs=surviving_candidate.lazy(),
             sampled_non_anchor_steps=surviving_candidate.lazy(),
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             transport_zones=None,
         )
 
@@ -231,8 +234,8 @@ def test_log_step_dropout_diagnostics_skips_when_no_non_anchor_or_dropout(caplog
 
 
 def test_log_step_dropout_diagnostics_can_trace_costs_without_transport_zones(caplog):
-    chain_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
-    chains_step = pl.DataFrame(
+    sequence_key_cols = ["demand_group_id", "activity_seq_id", "time_seq_id", "dest_draw_id"]
+    sequence_step = pl.DataFrame(
         {
             "demand_group_id": [1],
             "activity_seq_id": [10],
@@ -263,13 +266,13 @@ def test_log_step_dropout_diagnostics_can_trace_costs_without_transport_zones(ca
     with caplog.at_level(TRACE_LEVEL):
         log_step_dropout_diagnostics(
             seq_step_index=1,
-            chains_step=chains_step,
+            sequence_step=sequence_step,
             costs=pl.DataFrame({"from": [10], "to": [20], "cost": [1.0]}),
             non_anchor_candidates=non_anchor_candidates.lazy(),
             candidates_with_origin_costs=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
             candidates_with_costs=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
             sampled_non_anchor_steps=pl.DataFrame(schema=non_anchor_candidates.schema).lazy(),
-            chain_key_cols=chain_key_cols,
+            sequence_key_cols=sequence_key_cols,
             transport_zones=None,
         )
 
@@ -281,6 +284,7 @@ def test_log_location_chain_diagnostics_reports_invalid_unique_chains(caplog):
     destination_steps = pl.DataFrame(
         {
             "demand_group_id": [1, 1, 2],
+            "demand_subgroup_id": [0, 0, 0],
             "activity_seq_id": [10, 10, 20],
             "time_seq_id": [100, 100, 200],
             "dest_seq_id": [1000, 1000, 2000],
@@ -292,6 +296,7 @@ def test_log_location_chain_diagnostics_reports_invalid_unique_chains(caplog):
     trip_chains = pl.DataFrame(
         {
             "demand_group_id": [1, 2],
+            "demand_subgroup_id": [0, 0],
             "activity_seq_id": [10, 20],
             "time_seq_id": [100, 200],
             "dest_seq_id": [1000, 2000],
@@ -323,6 +328,7 @@ def test_log_location_chain_diagnostics_skips_warning_for_valid_chains(caplog):
     trip_chains = pl.DataFrame(
         {
             "demand_group_id": [1],
+            "demand_subgroup_id": [0],
             "activity_seq_id": [10],
             "time_seq_id": [100],
             "dest_seq_id": [1000],

--- a/tests/back/unit/domain/group_day_trips/test_017_demand_subgroups.py
+++ b/tests/back/unit/domain/group_day_trips/test_017_demand_subgroups.py
@@ -1,5 +1,15 @@
 import polars as pl
+import pytest
 
+from mobility.runtime.assets.cache_schema import validate_cached_table
+from mobility.trips.group_day_trips.core.run_state import RunState
+from mobility.trips.group_day_trips.iterations.iteration_assets import (
+    DEMAND_GROUPS_SCHEMA,
+    _read_run_state,
+    _state_cache_paths,
+    _write_run_state,
+)
+from mobility.trips.group_day_trips.plans.candidate_plan_steps import CandidatePlanStepsAsset
 from mobility.trips.group_day_trips.plans.demand_subgroups import (
     demand_unit_hash,
     split_large_demand_groups,
@@ -76,3 +86,213 @@ def test_demand_unit_hash_keeps_old_hash_for_default_subgroup():
 
     assert result["unit_hash"][0] == result["old_hash"][0]
     assert result["unit_hash"][1] != result["old_hash"][1]
+
+
+def test_split_large_demand_groups_owns_subgroup_creation():
+    demand_groups = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "n_persons": [20.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "n_persons": pl.Float64,
+        },
+    )
+
+    with pytest.raises(ValueError, match="owns subgroup creation"):
+        split_large_demand_groups(
+            demand_groups,
+            max_persons_per_demand_subgroup=None,
+        )
+
+
+def test_validate_cached_table_reports_schema_diff(tmp_path):
+    table = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "n_persons": [20.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "n_persons": pl.Float64,
+        },
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        validate_cached_table(
+            table,
+            table_name="demand_groups",
+            required_schema=DEMAND_GROUPS_SCHEMA,
+            cache_path=tmp_path / "demand_groups.parquet",
+        )
+
+    message = str(error.value)
+    assert "Cached table `demand_groups` does not match the current schema." in message
+    assert "Missing columns:" in message
+    assert "- demand_subgroup_id" in message
+    assert "Please clear the matching cached files and rerun the model." in message
+
+
+def test_validate_cached_table_reports_wrong_dtype(tmp_path):
+    table = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "n_persons": [20.0],
+        },
+        schema={
+            "demand_group_id": pl.Int64,
+            "demand_subgroup_id": pl.UInt32,
+            "n_persons": pl.Float64,
+        },
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        validate_cached_table(
+            table,
+            table_name="demand_groups",
+            required_schema=DEMAND_GROUPS_SCHEMA,
+            cache_path=tmp_path / "demand_groups.parquet",
+        )
+
+    message = str(error.value)
+    assert "Wrong column types:" in message
+    assert "- demand_group_id: expected UInt32, found Int64" in message
+
+
+def test_read_run_state_rejects_old_cached_schema(tmp_path):
+    cache_path = _state_cache_paths(tmp_path, 0)
+    state = _minimal_run_state()
+    _write_run_state(cache_path, state, rng_state=("rng",))
+    state.demand_groups.drop("demand_subgroup_id").write_parquet(cache_path["demand_groups"])
+
+    with pytest.raises(RuntimeError, match="demand_subgroup_id"):
+        _read_run_state(cache_path, start_iteration=1)
+
+
+def test_candidate_plan_steps_asset_rejects_old_cached_schema(tmp_path):
+    asset = CandidatePlanStepsAsset(
+        run_key="run",
+        is_weekday=True,
+        iteration=1,
+        base_folder=tmp_path,
+    )
+    old_candidates = _candidate_plan_steps().drop("demand_subgroup_id")
+    old_candidates.write_parquet(asset.cache_path)
+
+    with pytest.raises(RuntimeError, match="candidate_plan_steps"):
+        asset.get_cached_asset()
+
+
+def _minimal_run_state() -> RunState:
+    demand_groups = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "n_persons": [20.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "n_persons": pl.Float64,
+        },
+    )
+    current_plans = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "activity_seq_id": [0],
+            "time_seq_id": [0],
+            "dest_seq_id": [0],
+            "mode_seq_id": [0],
+            "plan_id": [0],
+            "n_persons": [20.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "plan_id": pl.UInt32,
+            "n_persons": pl.Float64,
+        },
+    )
+    current_plan_steps = pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "activity_seq_id": [0],
+            "time_seq_id": [0],
+            "dest_seq_id": [0],
+            "mode_seq_id": [0],
+            "seq_step_index": [0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt8,
+        },
+    )
+    plan_id_index = current_plans.select(
+        [
+            "demand_group_id",
+            "demand_subgroup_id",
+            "activity_seq_id",
+            "time_seq_id",
+            "dest_seq_id",
+            "mode_seq_id",
+            "plan_id",
+        ]
+    )
+    return RunState(
+        survey_plans=pl.DataFrame(),
+        survey_plan_steps=pl.DataFrame(),
+        demand_groups=demand_groups,
+        activity_dur=pl.DataFrame(),
+        home_night_dur=pl.DataFrame(),
+        stay_home_plan=current_plan_steps,
+        opportunities=pl.DataFrame(),
+        current_plans=current_plans,
+        candidate_plan_steps=_candidate_plan_steps(),
+        plan_id_index=plan_id_index,
+        destination_saturation=pl.DataFrame(),
+        costs=pl.DataFrame(),
+        start_iteration=1,
+        current_plan_steps=current_plan_steps,
+    )
+
+
+def _candidate_plan_steps() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "activity_seq_id": [0],
+            "time_seq_id": [0],
+            "dest_seq_id": [0],
+            "mode_seq_id": [0],
+            "seq_step_index": [0],
+            "first_seen_iteration": [1],
+            "last_seen_iteration": [1],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt8,
+            "first_seen_iteration": pl.UInt16,
+            "last_seen_iteration": pl.UInt16,
+        },
+    ).select(CandidatePlanStepsAsset.REQUIRED_SCHEMA.keys())

--- a/tests/back/unit/domain/group_day_trips/test_018_transition_events.py
+++ b/tests/back/unit/domain/group_day_trips/test_018_transition_events.py
@@ -1,0 +1,93 @@
+import polars as pl
+
+from mobility.trips.group_day_trips.transitions.transition_events import (
+    add_transition_plan_details,
+)
+from mobility.trips.group_day_trips.transitions.transition_schema import (
+    TRANSITION_EVENT_SCHEMA,
+)
+
+
+def test_transition_plan_details_match_cache_schema_with_float32_activity_times():
+    transition_events = pl.DataFrame(
+        {
+            "iteration": [1],
+            "demand_group_id": [1],
+            "demand_subgroup_id": [0],
+            "activity_seq_id": [10],
+            "time_seq_id": [100],
+            "dest_seq_id": [1000],
+            "mode_seq_id": [10000],
+            "activity_seq_id_trans": [11],
+            "time_seq_id_trans": [101],
+            "dest_seq_id_trans": [1001],
+            "mode_seq_id_trans": [10001],
+            "n_persons_moved": [3.0],
+            "utility_prev_from": [1.0],
+            "utility_prev_to": [1.5],
+            "utility_from": [2.0],
+            "utility_to": [2.5],
+            "tau_transition": [0.1],
+            "q_transition": [0.2],
+            "adjustment_factor": [1.0],
+            "is_self_transition": [False],
+        },
+        schema={
+            "iteration": pl.UInt32,
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "activity_seq_id_trans": pl.UInt32,
+            "time_seq_id_trans": pl.UInt32,
+            "dest_seq_id_trans": pl.UInt32,
+            "mode_seq_id_trans": pl.UInt32,
+            "n_persons_moved": pl.Float64,
+            "utility_prev_from": pl.Float64,
+            "utility_prev_to": pl.Float64,
+            "utility_from": pl.Float64,
+            "utility_to": pl.Float64,
+            "tau_transition": pl.Float64,
+            "q_transition": pl.Float64,
+            "adjustment_factor": pl.Float64,
+            "is_self_transition": pl.Boolean,
+        },
+    ).lazy()
+    possible_plan_steps = pl.DataFrame(
+        {
+            "demand_group_id": [1, 1],
+            "demand_subgroup_id": [0, 0],
+            "activity_seq_id": [10, 11],
+            "time_seq_id": [100, 101],
+            "dest_seq_id": [1000, 1001],
+            "mode_seq_id": [10000, 10001],
+            "seq_step_index": [0, 0],
+            "to": [100, 101],
+            "activity": ["work", "shop"],
+            "mode": ["car", "walk"],
+            "duration_per_pers": [8.0, 2.5],
+            "time": [0.5, 0.25],
+            "distance": [12.0, 1.0],
+        },
+        schema={
+            "demand_group_id": pl.UInt32,
+            "demand_subgroup_id": pl.UInt32,
+            "activity_seq_id": pl.UInt32,
+            "time_seq_id": pl.UInt32,
+            "dest_seq_id": pl.UInt32,
+            "mode_seq_id": pl.UInt32,
+            "seq_step_index": pl.UInt32,
+            "to": pl.Int32,
+            "activity": pl.Utf8,
+            "mode": pl.Utf8,
+            "duration_per_pers": pl.Float32,
+            "time": pl.Float64,
+            "distance": pl.Float64,
+        },
+    ).lazy()
+
+    with_details = add_transition_plan_details(transition_events, possible_plan_steps)
+
+    assert dict(with_details.collect_schema()) == TRANSITION_EVENT_SCHEMA


### PR DESCRIPTION
### Motivation
Some demand groups can now be split into smaller subgroups. These subgroups must stay separate through the whole daily mobility model, otherwise two different groups of people can accidentally share the same sampled activities, destinations, modes, or transition history.

This PR makes that subgroup key a normal part of the group day trips workflow. It also simplifies destination sampling code so the main ideas are clearer: first choose the fixed points of the day, such as home, work, or studies, then choose the other stops around them.

### Changes
- Keep `demand_subgroup_id` in the main keys used for plans, plan steps, destination sequences, mode sequences, candidate plans, and transitions.
- Stop silently adding missing subgroup ids inside low-level methods. These tables are internal model tables, so they should already have the right columns.
- Add clearer cache errors when an old saved run table is missing the new subgroup column or has old column types.
- Rewrite destination sequence sampling around simpler transport concepts:
  - anchor activities are fixed points of the day, such as home, work, and studies;
  - other activities are sampled after anchors, using the next anchor as the direction of travel.
- Reduce unnecessary row expansion when sampling anchor destinations.
- Move debug-only preparation into debug logging helpers, so normal model runs do less diagnostic work.
- Make diagnostic helpers expect lazy plan-step tables directly and fail early if they receive the wrong kind of input.
- Update unit tests for demand subgroups, cache validation, destination sampling, diagnostics, and plan updates.

### Example (if relevant)
Not applicable. This is an internal model and cache change.

### AI-assisted contribution
- [ ] No AI assistance
- [ ] AI used for minor help only (e.g. autocomplete, small refactors)
- [x] AI used for substantial parts of this PR

If substantial, briefly describe:
- Scope of AI-assisted content: subgroup-key propagation, destination sampling refactor, cache schema checks, debug log cleanup, and related tests.
- What you reviewed or changed: reviewed the planning, diagnostics, cache-read, and test paths; fixed stale call sites and test fixtures found during review.
- How you validated it (tests, checks, manual verification): ran `mamba run -n mobility python -m pytest --local --use-truststore tests/back/unit/domain/group_day_trips` and `git diff --check`.

### Checklist
- [x] I have reviewed all code in this PR
- [x] I understand the code and can maintain it
- [x] I added or ran appropriate tests/checks for the changed behavior
